### PR TITLE
Use a standard C++ mutex.  This should be semantically equivalent to …

### DIFF
--- a/Code/wwlib/mutex.cpp
+++ b/Code/wwlib/mutex.cpp
@@ -18,116 +18,27 @@
 
 #include "mutex.h"
 #include "wwdebug.h"
-#include <windows.h>
-
 
 // ----------------------------------------------------------------------------
 
-MutexClass::MutexClass(const char* name) : handle(NULL), locked(false)
+CriticalSectionClass::CriticalSectionClass() : mtx()
 {
-	#ifdef _UNIX
-		//assert(0);
-	#else
-		handle=CreateMutex(NULL,false,name);
-		WWASSERT(handle);
-	#endif
-}
 
-MutexClass::~MutexClass()
-{
-	#ifdef _UNIX
-		//assert(0);
-	#else
-		WWASSERT(!locked); // Can't delete locked mutex!
-		CloseHandle(handle);
-	#endif
-}
-
-bool MutexClass::Lock(int time)
-{
-	#ifdef _UNIX
-		//assert(0);
-		return true;
-	#else
-		int res = WaitForSingleObject(handle,time==WAIT_INFINITE ? INFINITE : time);
-		if (res!=WAIT_OBJECT_0) return false;
-		locked++;
-		return true;
-	#endif
-}
-
-void MutexClass::Unlock()
-{
-	#ifdef _UNIX
-		//assert(0);
-	#else
-		WWASSERT(locked);
-		locked--;
-		int res=ReleaseMutex(handle);
-		WWASSERT(res);
-	#endif
-}
-
-// ----------------------------------------------------------------------------
-
-MutexClass::LockClass::LockClass(MutexClass& mutex_,int time) : mutex(mutex_)
-{
-	failed=!mutex.Lock(time);
-}
-
-MutexClass::LockClass::~LockClass()
-{
-	if (!failed) mutex.Unlock();
-}
-
-
-
-
-
-
-
-// ----------------------------------------------------------------------------
-
-CriticalSectionClass::CriticalSectionClass() : handle(NULL), locked(false)
-{
-	#ifdef _UNIX
-		//assert(0);
-	#else
-		handle=new char[sizeof(CRITICAL_SECTION)];
-		InitializeCriticalSection((CRITICAL_SECTION*)handle);
-	#endif
 }
 
 CriticalSectionClass::~CriticalSectionClass()
 {
-	#ifdef _UNIX
-		//assert(0);
-	#else
-		WWASSERT(!locked); // Can't delete locked mutex!
-		DeleteCriticalSection((CRITICAL_SECTION*)handle);
-		delete[] handle;
-	#endif
+
 }
 
 void CriticalSectionClass::Lock()
 {
-	#ifdef _UNIX
-		//assert(0);
-	#else
-		EnterCriticalSection((CRITICAL_SECTION*)handle);
-		locked++;
-	#endif
+    this->mtx.lock();
 }
 
 void CriticalSectionClass::Unlock()
 {
-	#ifdef _UNIX
-		//assert(0);
-	#else
-		WWASSERT(locked);
-		locked--;
-		LeaveCriticalSection((CRITICAL_SECTION*)handle);
-	#endif
+    this->mtx.unlock();
 }
 
 // ----------------------------------------------------------------------------

--- a/Code/wwlib/mutex.h
+++ b/Code/wwlib/mutex.h
@@ -26,53 +26,9 @@
 #include "always.h"
 #include "thread.h"
 
+#include <mutex>
+#include <atomic>
 
-// Always use mutex or critical section when accessing the same data from multiple threads!
-
-// ----------------------------------------------------------------------------
-//
-// Mutex class is an expensive way of synchronization! Use critical sections
-// (below) for all synchronization. Use mutexes for inter-process locking.
-//
-// ----------------------------------------------------------------------------
-
-class MutexClass
-{
-	void* handle;
-	unsigned locked;
-
-	// Lock and unlock are private so that you can't use them directly. Use LockClass as a sentry instead!
-	// Lock returns true if lock was succesful, false otherwise
-	bool Lock(int time);
-	void Unlock();
-
-public:
-	// Name can (and usually should) be NULL. Use name only if you wish to create a globally unique mutex
-	MutexClass(const char* name = NULL);
-	~MutexClass();
-
-	enum {
-		WAIT_INFINITE=-1
-	};
-
-	class LockClass
-	{
-		MutexClass& mutex;
-		bool failed;
-	public:
-
-		// In order to lock a mutex create a local instance of LockClass with mutex as a parameter.
-		// Time is in milliseconds, INFINITE means infinite wait.
-		LockClass(MutexClass& m, int time=MutexClass::WAIT_INFINITE);
-		~LockClass();
-
-		// Returns true if the lock failed
-		bool Failed() { return failed; }
-	private:
-		LockClass &operator=(const LockClass&) { return(*this); }
-	};
-	friend class LockClass;
-};
 
 // ----------------------------------------------------------------------------
 //
@@ -83,8 +39,7 @@ public:
 
 class CriticalSectionClass
 {
-	void* handle;
-	unsigned locked;
+    std::recursive_mutex mtx;
 
 	// Lock and unlock are private so that you can't use them directly. Use LockClass as a sentry instead!
 	void Lock();
@@ -114,40 +69,40 @@ public:
 // of it is that it can't be locked multiple times from the same thread.
 //
 // ----------------------------------------------------------------------------
-
+// 2025-08: note: this is /allegedly/ faster than the CriticalSectionClass.
+// The assumptions made circa 2000 may no longer hold.
 class FastCriticalSectionClass
 {
-	volatile unsigned Flag;
+#ifdef FAST_CRITICAL_IS_MUTEX
+    std::mutex mtx;
+#else
+    std::atomic_flag Flag{};
+#endif
 
 	void Thread_Safe_Set_Flag()
 	{
-		volatile unsigned& nFlag=Flag;
-
-		#define ts_lock _emit 0xF0
-		assert(((unsigned)&nFlag % 4) == 0);
-
-		__asm mov ebx, [nFlag]
-		__asm ts_lock
-		__asm bts dword ptr [ebx], 0
-		__asm jc The_Bit_Was_Previously_Set_So_Try_Again
-		return;
-
-		The_Bit_Was_Previously_Set_So_Try_Again:
-		ThreadClass::Switch_Thread();
-		__asm mov ebx, [nFlag]
-		__asm ts_lock
-		__asm bts dword ptr [ebx], 0
-		__asm jc  The_Bit_Was_Previously_Set_So_Try_Again
+#ifdef FAST_CRITICAL_IS_MUTEX
+        mtx.lock();
+#else
+        while (Flag.test_and_set(std::memory_order_acq_rel)) {
+            Flag.wait(true, std::memory_order_relaxed);
+        }
+#endif
 	}
 
-	WWINLINE void Thread_Safe_Clear_Flag()
+    void Thread_Safe_Clear_Flag()
 	{
-		Flag = 0;
+#ifdef FAST_CRITICAL_IS_MUTEX
+        mtx.unlock();
+#else
+        Flag.clear(std::memory_order_release);
+        Flag.notify_one();
+#endif
 	}
 
 public:
 	// Name can (and usually should) be NULL. Use name only if you wish to create a globally unique mutex
-	FastCriticalSectionClass() : Flag(0) {}
+    FastCriticalSectionClass() {}
 
 	class LockClass
 	{


### PR DESCRIPTION
…the current code