### PR TITLE
refactor: All targets link wwcommon.

### DIFF
--- a/Code/BandTest/BandTest.cpp
+++ b/Code/BandTest/BandTest.cpp
@@ -58,6 +58,8 @@
 
 #include "../Combat/specialbuilds.h"
 
+#include <algorithm>
+
 // warning C4711: function 'xxx' selected for automatic inline expansion
 #pragma warning(disable:4711)
 
@@ -815,7 +817,7 @@ unsigned long Upstream_Detect(unsigned long server_ip, unsigned long my_ip, int 
 
 	if (calc_down && upstream_bandwidth < 576 * 1000 && upstream_bandwidth > 8) {
 
-		int new_ping_timeout = max((int)(average_ping * 5), 200);
+		int new_ping_timeout = std::max((int)(average_ping * 5), 200);
 #if (0)
 		if (upstream_bandwidth > 80000) {
 			method_one = true;
@@ -926,7 +928,7 @@ unsigned long Upstream_Detect(unsigned long server_ip, unsigned long my_ip, int 
 			}
 		}
 
-		//int new_ping_timeout = max((int)(average_ping * 5), 200);
+		//int new_ping_timeout = std::max((int)(average_ping * 5), 200);
 		float old_average_ping = average_ping;
 		//float old_lowest_ping = lowest_ping;
 		average_ping = 0.0f;
@@ -1180,8 +1182,8 @@ void Ping_Profile(SOCKADDR_IN *router_addr, unsigned long my_ip)
 	int i;
 
 	for (i=0 ; i<ping_number ; i++) {
-		min_ping = min(min_ping, ping_averages[i]);
-		max_ping = max(max_ping, ping_averages[i]);
+		min_ping = std::min(min_ping, ping_averages[i]);
+		max_ping = std::max(max_ping, ping_averages[i]);
 	}
 
 	sprintf(temp_buffer, "%3.1f", max_ping);
@@ -1640,7 +1642,7 @@ float Lowest_Ping(int num_pings, unsigned long *ping_times)
 {
 	float lowest_ping = 1000000.0;
 	for (int i=0 ; i<num_pings ; i++) {
-		lowest_ping = min(lowest_ping, (float)(ping_times[i]));
+		lowest_ping = std::min(lowest_ping, (float)(ping_times[i]));
 	}
 	return(lowest_ping);
 }

--- a/Code/BandTest/CMakeLists.txt
+++ b/Code/BandTest/CMakeLists.txt
@@ -7,6 +7,7 @@ target_compile_definitions(bandtest PRIVATE
 target_link_libraries(bandtest PRIVATE
     winmm
     ws2_32
+    wwcommon
 )
 
 set(BANDTEST_SRC
@@ -14,8 +15,6 @@ set(BANDTEST_SRC
     BandTest.h
     BandTest.rc
 )
-
-target_include_directories(bandtest PRIVATE ../Commando)
 
 target_sources(bandtest PRIVATE
     ${BANDTEST_SRC}

--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -2,8 +2,8 @@
 add_library(wwcommon INTERFACE)
 
 target_compile_definitions(wwcommon INTERFACE
-    #NOMINMAX
-    #WIN32_LEAN_AND_MEAN
+    NOMINMAX
+    WIN32_LEAN_AND_MEAN
     #_WIN32_WINNT=0x400
     #_MBCS
     _CRT_NONSTDC_NO_WARNINGS

--- a/Code/Commando/CMakeLists.txt
+++ b/Code/Commando/CMakeLists.txt
@@ -429,11 +429,8 @@ target_link_libraries(commando INTERFACE
     winmm
     vfw32
     wsock32
-    d3d8lib
     version
-    milesstub
-    binkstub
-    gamespy
+    wwcommon
     bandtest
     wwdebug
     wwlib
@@ -451,41 +448,6 @@ target_link_libraries(commando INTERFACE
     binkmovie
     wwphys
     combat
-)
-
-target_compile_definitions(commando INTERFACE
-    #NOMINMAX
-    #WIN32_LEAN_AND_MEAN
-    #_WIN32_WINNT=0x400
-    #DIRECTX
-    _CRT_NONSTDC_NO_WARNINGS
-    _CRT_SECURE_NO_WARNINGS
-    $<$<CONFIG:Debug>:WWDEBUG>
-    $<$<CONFIG:Debug>:_DEBUG>
-)
-
-target_compile_options(commando INTERFACE
-    ${WARNING_FLAGS}
-)
-
-target_include_directories(commando INTERFACE
-    ../WWMath
-    ../ww3d2
-    ../wwphys
-    ../wwdebug
-    ../wwui
-    ../wwbitpack
-    ../Combat
-    ../WWAudio
-    ../wolapi
-    ../wwutil
-    ../wwnet
-    ../wwlib
-    ../wwsaveload
-    ../wwtranslatedb
-    ../BinkMovie
-    ../SControl
-    ..
 )
 
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")

--- a/Code/Commando/WebBrowser.cpp
+++ b/Code/Commando/WebBrowser.cpp
@@ -43,6 +43,8 @@
 #include "win.h"
 #include "_globals.h"
 
+#include <shellapi.h>
+
 WebBrowser* WebBrowser::_mInstance = NULL;
 
 /******************************************************************************

--- a/Code/Scripts/always.h
+++ b/Code/Scripts/always.h
@@ -95,7 +95,6 @@ void* __cdecl operator new(unsigned int s);
 ** I'm relpacing all occurances of 'min' and 'max with 'MIN' and 'MAX'.  For code which
 ** is out of our domain (e.g. Max sdk) I'm declaring template functions for 'min' and 'max'
 */
-#define NOMINMAX
 
 #ifndef MAX
 #define MAX(a,b)            (((a) > (b)) ? (a) : (b))

--- a/Code/Tools/LevelEdit/CMakeLists.txt
+++ b/Code/Tools/LevelEdit/CMakeLists.txt
@@ -427,33 +427,9 @@ add_executable(leveledit WIN32)
 target_compile_definitions(leveledit PRIVATE
     _AFXDLL
     PARAM_EDITING_ON
-    #WIN32_LEAN_AND_MEAN
-    $<$<CONFIG:Debug>:WWDEBUG>
-    $<$<CONFIG:Debug>:_DEBUG>
-)
-
-target_compile_options(leveledit PRIVATE
-    ${WARNING_FLAGS}
 )
 
 target_include_directories(leveledit PRIVATE
-    ../../WWMath
-    ../../ww3d2
-    ../../wwphys
-    ../../wwdebug
-    ../../wwui
-    ../../wwbitpack
-    ../../Combat
-    ../../WWAudio
-    ../../wolapi
-    ../../wwutil
-    ../../wwnet
-    ../../wwlib
-    ../../wwsaveload
-    ../../wwtranslatedb
-    ../../BinkMovie
-    ../../SControl
-    ../..
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 
@@ -462,11 +438,7 @@ target_link_libraries(leveledit PRIVATE
     vfw32
     wsock32
     shlwapi
-    d3d8lib
     version
-    milesstub
-    binkstub
-    gamespy
     bandtest
     wwcommon
     wwdebuge

--- a/Code/Tools/MixViewer/CMakeLists.txt
+++ b/Code/Tools/MixViewer/CMakeLists.txt
@@ -28,18 +28,6 @@ add_executable(mixviewer WIN32)
 
 target_compile_definitions(mixviewer PRIVATE
     _AFXDLL
-    $<$<CONFIG:Debug>:WWDEBUG>
-    $<$<CONFIG:Debug>:_DEBUG>
-)
-
-target_include_directories(mixviewer PRIVATE
-    ../../wwdebug
-    ../../wwlib
-    ../..
-)
-
-target_compile_options(mixviewer PRIVATE
-    ${WARNING_FLAGS}
 )
 
 target_link_libraries(mixviewer PRIVATE wwcommon wwdebug wwlib winmm)

--- a/Code/Tools/RenRem/RenRem.cpp
+++ b/Code/Tools/RenRem/RenRem.cpp
@@ -47,6 +47,8 @@
 
 #include "servercontrol.h"
 
+#include <timeapi.h>
+
 #define RENREM_PORT 1234
 #define PROMPT ">"
 

--- a/Code/Tools/WWConfig/CMakeLists.txt
+++ b/Code/Tools/WWConfig/CMakeLists.txt
@@ -28,18 +28,12 @@ add_executable(wwconfig WIN32)
 
 target_compile_definitions(wwconfig PRIVATE
     _AFXDLL
-    $<$<CONFIG:Debug>:WWDEBUG>
-    $<$<CONFIG:Debug>:_DEBUG>
-    $<$<CONFIG:Debug>:WWDEBUG>
-    $<$<CONFIG:Debug>:_DEBUG>
 )
 
 target_link_libraries(wwconfig PRIVATE
     vfw32
-    d3d8lib
     version
     winmm
-    milesstub
     wwcommon
     wwdebug
     wwlib
@@ -48,21 +42,6 @@ target_link_libraries(wwconfig PRIVATE
     wwsaveload
     ww3d2
     wwaudio
-)
-
-target_compile_options(wwconfig PRIVATE
-    ${WARNING_FLAGS}
-)
-
-target_include_directories(wwconfig PRIVATE
-    ../../wwdebug
-    ../../wwlib
-    ../../ww3d2
-    ../../WWMath
-    ../../wwphys
-    ../../wwsaveload
-    ../../WWAudio
-    ../..
 )
 
 target_sources(wwconfig PRIVATE ${WWCONFIG_SRC})

--- a/Code/WWOnline/GameResPacket.cpp
+++ b/Code/WWOnline/GameResPacket.cpp
@@ -36,6 +36,7 @@
 #include <assert.h>
 #include <string.h>
 #include <winsock.h>
+#include <algorithm>
 
 namespace WWOnline {
 
@@ -471,7 +472,7 @@ bool GameResPacket::Get_Field(char *id, void *data, int &length)
 
 	if (field)
 		{
-		memcpy(data, field->mData, min((int)field->mSize, length));
+		memcpy(data, field->mData, std::min((int)field->mSize, length));
 		length = (int) field->mSize;
 		}
 

--- a/Code/wwlib/always.h
+++ b/Code/wwlib/always.h
@@ -95,7 +95,6 @@ void* __cdecl operator new(unsigned int s);
 ** I'm relpacing all occurances of 'min' and 'max with 'MIN' and 'MAX'.  For code which
 ** is out of our domain (e.g. Max sdk) I'm declaring template functions for 'min' and 'max'
 */
-#define NOMINMAX
 
 #ifndef MAX
 #define MAX(a,b)            (((a) > (b)) ? (a) : (b))


### PR DESCRIPTION
All targets now compile with WIN32_LEAN_AND_MEAN defined.
All targets now compile with NOMINMAX defined, prelude to replacing all custom min/max with std.