### PR TITLE
Get to win main

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,9 @@ project(commando LANGUAGES C CXX)
 include(cmake/compilers.cmake)
 
 # Set where the build results will end up
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}" CACHE PATH "Where to output archives")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}" CACHE PATH "Where to output libraries")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}" CACHE PATH "Where to output binaries")
 
 option(RENEGADE_CLIENT "Build full game client." ON)
 add_feature_info(RenegadeClient RENEGADE_CLIENT "Build Renegade game client")

--- a/Code/wwlib/cpudetect.cpp
+++ b/Code/wwlib/cpudetect.cpp
@@ -1271,8 +1271,42 @@ void Get_OS_Info(
 				os_info.Code="WINXP";
 				return;
 			}
-			os_info.Code="WINXX";
+			if (OSVersionNumberMinor==2) {
+				os_info.Code="WIN2K3";
+				return;
+			}
+			os_info.Code="WIN5.X";
 			return;
 		}
+		if (OSVersionNumberMajor==6) {
+			if (OSVersionNumberMinor == 0) {
+				os_info.Code = "WIN2K8";
+				return;
+			}
+			if (OSVersionNumberMinor == 1) {
+				os_info.Code = "WIN7";
+				return;
+			}
+			if (OSVersionNumberMinor == 2) {
+				os_info.Code = "WIN2013";
+				return;
+			}
+			if (OSVersionNumberMinor == 3) {
+				os_info.Code = "WIN8";
+				return;
+			}
+			os_info.Code="WIN6.X";
+			return;
+		}
+		if (OSVersionNumberMajor==10) {
+			if (OSVersionNumberMinor == 0) {
+				os_info.Code = "WIN10";
+				return;
+			}
+			os_info.Code="WIN10.X";
+			return;
+		}
+		os_info.Code="UNKNOWN";
+		return;
 	}
 }


### PR DESCRIPTION
- The CMake patch allows one to override the output paths during configuration
- The `Get_OS_Info` allows me to get to `WinMain` without an error (`OSInfoStruct::Code` was left uninitialized, causing an error when accessing it)