### PR TITLE
Parse cli arguments following unix conventions

### DIFF
--- a/Code/Commando/CMakeLists.txt
+++ b/Code/Commando/CMakeLists.txt
@@ -84,6 +84,7 @@ set(COMMANDO_SRC
     singletoninstancekeeper.h
     WINMAIN.CPP
     WINMAIN.H
+    winmain_compat.h
     bandwidthcheck.cpp
     bandwidthcheck.h
     FirewallWait.cpp

--- a/Code/Commando/WINMAIN.CPP
+++ b/Code/Commando/WINMAIN.CPP
@@ -44,6 +44,7 @@
 
 #include "winmain.h"
 #define _WIN32_WINDOWS 0x0401
+#include "winmain_compat.h"
 #include "win.h"
 #include "resource.h"
 #include "WW3D.H"
@@ -112,14 +113,12 @@ extern "C"
 //----------------------------------------------------------------------------
 //	Local functions
 //----------------------------------------------------------------------------
-static BOOL Create_Main_Window(HANDLE hInstance, int nCmdShow);
+static BOOL Create_Main_Window(void);
 long FAR PASCAL Main_Window_Proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 void On_Focus_Loss(void);
 void On_Focus_Restore(void);
-void Split_Command_Line_Args(HINSTANCE instance, char *path_to_exe, char *command_line);
-void Set_Working_Directory(char *old_path, char *new_path);
-int Start_Application( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow );
-void Set_Working_Directory(HINSTANCE hInstance);
+int Start_Application( void );
+void Set_Working_Directory(void);
 
 //#include "packet.h"
 
@@ -129,8 +128,6 @@ long Top_Level_Exception_Filter(EXCEPTION_POINTERS *e_info)
 	return(Exception_Handler(e_info->ExceptionRecord->ExceptionCode, e_info));
 }
 #endif //_MSC_VER
-
-
 
 
 /***********************************************************************************************
@@ -149,7 +146,7 @@ long Top_Level_Exception_Filter(EXCEPTION_POINTERS *e_info)
  * HISTORY:                                                                                    *
  *   07/18/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-int PASCAL WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow )
+int main(int argc, char *argv[])
 {
 	WWMemoryLogClass::Init();	// This switches memlog from static to dynamic allocations mode
 
@@ -187,6 +184,19 @@ int PASCAL WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 	}
 #endif //WWDEBUG
 
+	switch (cUserOptions::Parse_Command_Line(argc, argv)) {
+	case cUserOptions::ParseResult::SUCCESS:
+		break;
+	case cUserOptions::ParseResult::FAILURE:
+        fprintf(stderr, "Error during parsing arguments\n");
+		cUserOptions::Print_Command_Line_Help(true);
+		return 1;
+	case cUserOptions::ParseResult::PRINT_HELP:
+		cUserOptions::Print_Command_Line_Help(false);
+		return 0;
+	}
+	LocalFree(argv);
+
 #ifdef _DEBUG // Denzil - DO NOT COMPILE INTO FINAL BUILD
 	bool webInstalled = WebBrowser::InstallPrerequisites();
 
@@ -196,16 +206,12 @@ int PASCAL WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 	}
 #endif // WWDEBUG
 
-   if (!cUserOptions::Parse_Command_Line(lpCmdLine)) {
-		return(0);
-	}
-
 	//
 	// There's a couple of options we need for the FDS
 	//
 #ifdef FREEDEDICATEDSERVER
 	if (!SlaveMaster.Am_I_Slave() && !ServerSettingsClass::Is_Server_Settings_File_Set()) {
-		cUserOptions::Set_Server_INI_File("STARTSERVER=server.ini");
+		cUserOptions::Set_Server_INI_File("server.ini");
 	}
 	ConsoleBox.Set_Exclusive(true);
 #endif //FREEDEDICATEDSERVER
@@ -221,7 +227,7 @@ int PASCAL WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLin
 	//
 	//	Start the game!
 	//
-	int retval = Start_Application( hInstance, hPrevInstance, lpCmdLine, nCmdShow );
+	int retval = Start_Application();
 	return retval;
 }
 
@@ -267,7 +273,7 @@ static bool Graphics_Settings_Trouble_Shooting()
 
 typedef IDirect3D8* (WINAPI *Direct3DCreate8Type) (UINT SDKVersion);
 static Direct3DCreate8Type	Direct3DCreate8Ptr = NULL;
-static HINSTANCE D3D8Lib = NULL;
+static HMODULE D3D8Lib = NULL;
 
 static bool Video_Card_Driver_Check()
 {
@@ -402,22 +408,20 @@ static bool Video_Card_Driver_Check()
 
 
 /***********************************************************************************************
- * Start_Application -- Handles WinMain execution.															  *
+ * Start_Application -- Handles main execution.	                                               *
  *                                                                                             *
  * INPUT:                                                                                      *
- *  																														  *
- * 	Standard WinMain inputs :-)																				  *
- * 																														  *
- * OUTPUT:																												  *
- *  																														  *
- * 	Standard WinMain output																						  *
- * 																														  *
- * WARNINGS:																											  *
+ *                                                                                             *
+ * OUTPUT:                                                                                     *
+ *                                                                                             *
+ * 	Standard main output                                                                       *
+ *                                                                                             *
+ * WARNINGS:                                                                                   *
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   09/19/2001 PDS  : Created.                                                                *
  *=============================================================================================*/
-int Start_Application( HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR /*lpCmdLine*/, int nCmdShow )
+int Start_Application(void)
 {
 	{
 		WWMEMLOG(MEM_GAMEINIT);
@@ -426,7 +430,7 @@ int Start_Application( HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR /
 		/*
 		** Set the working directory.
 		*/
-		Set_Working_Directory(hInstance);
+		Set_Working_Directory();
 
 		//
 		// TEMP Dev code - check the working folder is correct!
@@ -454,7 +458,7 @@ int Start_Application( HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR /
 
 		//Debug_Say(("Started logging at time %s", cMiscUtil::Get_Text_Time()));
 
-		if (!Create_Main_Window(hInstance, nCmdShow)) return 0;
+		if (!Create_Main_Window()) return 0;
 
 		Register_Thread_ID(GetCurrentThreadId(), "Main Thread", true);
 	}
@@ -685,8 +689,6 @@ long FAR PASCAL Main_Window_Proc( HWND hwnd, UINT message, WPARAM wParam, LPARAM
  *                                                                                             *
  * INPUT:                                                                                      *
  *  																														  *
- * 	hInstance -- Instance handle of the application														  *
- * 	nCmdShow -- how the window is to be shown																  *
  * 																														  *
  * OUTPUT:																												  *
  * 																														  *
@@ -697,19 +699,19 @@ long FAR PASCAL Main_Window_Proc( HWND hwnd, UINT message, WPARAM wParam, LPARAM
  * HISTORY:                                                                                    *
  *   07/18/1997 GH  : Created.                                                                 *
  *=============================================================================================*/
-static BOOL Create_Main_Window(HANDLE hInstance, int nCmdShow)
+static BOOL Create_Main_Window(void)
 {
 	WNDCLASS    wc;
 	BOOL        rc;
 
-	ProgramInstance = (HINSTANCE)hInstance;
+	ProgramInstance = (HINSTANCE)GetModuleHandle(NULL);
 
 	if (!ConsoleBox.Is_Exclusive()) {
 		wc.style			= CS_HREDRAW | CS_VREDRAW | CS_DBLCLKS;
 		wc.lpfnWndProc		= Main_Window_Proc;
 		wc.cbClsExtra		= 0;
 		wc.cbWndExtra		= 0;
-		wc.hInstance		= (HINSTANCE)hInstance;
+		wc.hInstance		= ProgramInstance;
 		wc.hIcon				= LoadIcon( NULL, IDI_APPLICATION);
 		wc.hCursor			= LoadCursor( NULL, IDC_ARROW);
 		wc.hbrBackground	= (HBRUSH)GetStockObject( BLACK_BRUSH);
@@ -794,14 +796,14 @@ void Prog_End(void)
  * HISTORY:                                                                                    *
  *   11/6/2001 12:11PM ST : Created                                                            *
  *=============================================================================================*/
-void Set_Working_Directory(HINSTANCE instance)
+void Set_Working_Directory(void)
 {
 	char path_to_exe[256];
 	char drive[_MAX_DRIVE];
 	char dir[_MAX_DIR];
 	char path[_MAX_PATH];
 
-	GetModuleFileName(instance, path_to_exe, sizeof(path_to_exe));
+	GetModuleFileName(NULL, path_to_exe, sizeof(path_to_exe));
 	_splitpath(path_to_exe, drive, dir, NULL, NULL);
 	_makepath(path, drive, dir, NULL, NULL);
 	SetCurrentDirectory(path);

--- a/Code/Commando/useroptions.h
+++ b/Code/Commando/useroptions.h
@@ -45,10 +45,16 @@
 class cUserOptions
 {
 	public:
+		enum ParseResult {
+			SUCCESS,
+			FAILURE,
+			PRINT_HELP,
+		};
 
-		static bool Parse_Command_Line(LPCSTR command);
+		static ParseResult Parse_Command_Line(int argc, char *argv[]);
+		static void Print_Command_Line_Help(bool error);
 
-		static void Set_Server_INI_File(const char *cmd_line_entry);
+		static void Set_Server_INI_File(const char *ini_file);
 
 		static void Set_Bandwidth_Type(BANDWIDTH_TYPE_ENUM bandwidth_type);
 		static BANDWIDTH_TYPE_ENUM Get_Bandwidth_Type(void);

--- a/Code/Commando/winmain_compat.h
+++ b/Code/Commando/winmain_compat.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#ifdef _WIN32
+#include <windows.h>
+
+#include <io.h>
+#include <shellapi.h>
+#include <stdio.h>
+
+// main actually called something else when we wrap it to avoid linker issues.
+#define main local_main
+
+#ifdef _MSC_VER
+#pragma comment(linker, "/ENTRY:WinMainCRTStartup")
+#endif
+
+// Forward declare main so WinMain can call it.
+int main(int argc, char *argv[]);
+
+// Taken from https://github.com/thpatch/win32_utf8/blob/master/src/shell32_dll.c
+// Get the command line as UTF-8 as it would be on other platforms.
+static char **CommandLineToArgvU(LPCWSTR lpCmdLine, int *pNumArgs)
+{
+	int cmd_line_pos; // Array "index" of the actual command line string
+	// int lpCmdLine_len = wcslen(lpCmdLine) + 1;
+	int lpCmdLine_len = WideCharToMultiByte(CP_UTF8, 0, lpCmdLine, -1, NULL, 0, NULL, NULL) + 1;
+	char **argv_u;
+
+	wchar_t **argv_w = CommandLineToArgvW(lpCmdLine, pNumArgs);
+
+	if (!argv_w) {
+		return NULL;
+	}
+
+	cmd_line_pos = *pNumArgs + 1;
+
+	// argv is indeed terminated with an additional sentinel NULL pointer.
+	argv_u = (char **)LocalAlloc(LMEM_FIXED, cmd_line_pos * sizeof(char *) + lpCmdLine_len);
+
+	if (argv_u) {
+		int i;
+		char *cur_arg_u = (char *)&argv_u[cmd_line_pos];
+
+		for (i = 0; i < *pNumArgs; i++) {
+			size_t cur_arg_u_len;
+			int conv_len;
+			argv_u[i] = cur_arg_u;
+			conv_len = WideCharToMultiByte(CP_UTF8, 0, argv_w[i], -1, cur_arg_u, lpCmdLine_len, NULL, NULL);
+
+			cur_arg_u_len = argv_w[i] != NULL ? conv_len : conv_len + 1;
+			cur_arg_u += cur_arg_u_len;
+			lpCmdLine_len -= cur_arg_u_len;
+		}
+
+		argv_u[i] = NULL;
+	}
+
+	LocalFree(argv_w);
+
+	return argv_u;
+}
+
+int __stdcall WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
+{
+	// Get args as UTF-8
+	int argc;
+	char **argv = CommandLineToArgvU(GetCommandLineW(), &argc);
+
+	// Attach to the console we were run from if we were.
+	if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+		// We attached successfully, lets redirect IO to the consoles handles
+		if (_fileno(stdout) == -2 || _get_osfhandle(fileno(stdout)) == -2) {
+			freopen("CONOUT$", "w", stdout);
+		}
+
+		if (_fileno(stderr) == -2 || _get_osfhandle(fileno(stderr)) == -2) {
+			freopen("CONOUT$", "w", stderr);
+		}
+
+		if (_fileno(stdin) == -2 || _get_osfhandle(fileno(stdin)) == -2) {
+			freopen("CONIN$", "r", stdin);
+		}
+	}
+
+	// Call the real main function.
+	int ret = main(argc, argv);
+	LocalFree(argv);
+
+	return ret;
+}
+#endif

--- a/Code/ww3d2/dx8renderer.h
+++ b/Code/ww3d2/dx8renderer.h
@@ -315,6 +315,7 @@ struct MeshRegKeyStruct
 };
 
 
+template <>
 inline unsigned int HashTemplateKeyClass<MeshRegKeyStruct>::Get_Hash_Value(const MeshRegKeyStruct& key)
 {
 	unsigned int hval = (unsigned int)(key.Model) + (unsigned int)(key.UserLighting);


### PR DESCRIPTION
Before, arguments such as `IP=1.2.3.4 +CONNECT 3.4.5.6:7777` were accepted.
Now these are `--ip 1.2.3.4 --gamespy-connect 3.4.5.6:7777`