### PR TITLE
Various fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,9 +36,8 @@ if(SYNTAX_CHECK_ONLY)
     add_compile_options("-fsyntax-only")
 endif(SYNTAX_CHECK_ONLY)
 
-if(UNIX AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+if(NOT WIN32)
     add_compile_definitions(__cdecl=)
-    add_compile_definitions(_cdecl=)
 endif()
 
 include(FetchContent)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include(FetchContent)
 
 # Find/Add build dependencies and stubs.
 # Only 32bit Windows can make use of these APIs as the libraries shipped with the game.
-if((WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows") AND ${CMAKE_SIZEOF_VOID_P} EQUAL 4)
+if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
     include(cmake/miles.cmake)
     include(cmake/bink.cmake)
     include(cmake/dx8.cmake)

--- a/Code/BinkMovie/BINKMovie.cpp
+++ b/Code/BinkMovie/BINKMovie.cpp
@@ -20,7 +20,7 @@
 #include "dx8wrapper.h"
 #include "formconv.h"
 #include "render2d.h"
-#include "Bink.h"
+#include "bink.h"
 #include "rect.h"
 #include "subtitlemanager.h"
 #include "dx8caps.h"

--- a/Code/BinkMovie/CMakeLists.txt
+++ b/Code/BinkMovie/CMakeLists.txt
@@ -14,6 +14,7 @@ set(BINKMOVIE_SRC
 add_library(binkmovie STATIC)
 
 target_link_libraries(binkmovie PRIVATE
+    binkstub
     wwcommon
 )
 

--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -41,7 +41,6 @@ target_include_directories(wwcommon INTERFACE
 
 target_link_libraries(wwcommon INTERFACE
     milesstub
-    binkstub
     gamespy
     d3d8lib
 )

--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -66,6 +66,7 @@ add_subdirectory(wwutil)
 
 # Final targets
 add_subdirectory(BandTest)
+add_subdirectory(Launcher)
 add_subdirectory(Scripts)
 add_subdirectory(Commando)
 

--- a/Code/Combat/savegame.cpp
+++ b/Code/Combat/savegame.cpp
@@ -96,7 +96,7 @@ enum	{
 /*
 **
 */
-void _cdecl SaveGameManager::Save_Game( const char * filename, ... )
+void __cdecl SaveGameManager::Save_Game( const char * filename, ... )
 {
 	Debug_Say(( "Save Game %s\n", filename ));
 	CurrentGameFilename = filename;
@@ -515,7 +515,7 @@ void	SaveGameManager::Load_Definitions( const char * filename )
 /*
 **
 */
-void _cdecl SaveGameManager::Save_Save_Load_System( const char * filename, ... )
+void __cdecl SaveGameManager::Save_Save_Load_System( const char * filename, ... )
 {
 	FileClass * file = _TheWritingFileFactory->Get_File( filename );
 	WWASSERT(file);

--- a/Code/Combat/savegame.h
+++ b/Code/Combat/savegame.h
@@ -67,7 +67,7 @@ public:
 	static bool Peek_Map_Name( const char * filename, StringClass &map_name );
 
 	// LDD Access - Editor only calls Save_Game, App calls both
-	static void _cdecl Save_Game( const char * filename, ... );
+	static void __cdecl Save_Game( const char * filename, ... );
 	static void	Load_Game( const char * filename );
 	static void	Pre_Load_Game( const char * filename, StringClass &filename_to_load, StringClass &lsd_filename );
 	static const char * Get_Current_Game_Filename( void )	{ return CurrentGameFilename; }
@@ -82,7 +82,7 @@ public:
 
 	// Generic SaveLoadSubSystem Access
 	static void	Load_Save_Load_System( const char * filename, bool auto_post_load );
-	static void _cdecl Save_Save_Load_System( const char * filename, ... );
+	static void __cdecl Save_Save_Load_System( const char * filename, ... );
 
 protected:
 	static StringClass		MapFilename;

--- a/Code/Commando/CMakeLists.txt
+++ b/Code/Commando/CMakeLists.txt
@@ -427,7 +427,6 @@ add_library(commando INTERFACE)
 
 target_link_libraries(commando INTERFACE
     winmm
-    vfw32
     wsock32
     version
     wwcommon

--- a/Code/Commando/CMakeLists.txt
+++ b/Code/Commando/CMakeLists.txt
@@ -449,7 +449,7 @@ target_link_libraries(commando INTERFACE
     combat
 )
 
-if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
+if(WIN32)
     target_link_options(commando INTERFACE "/NODEFAULTLIB:libci.lib")
 
     list(APPEND COMMANDO_SRC

--- a/Code/Commando/wolgmode.cpp
+++ b/Code/Commando/wolgmode.cpp
@@ -94,7 +94,7 @@ using namespace WWOnline;
 const int RENEGADE_GAMECODE = 12;
 const wchar_t* RENEGADE_LOBBY_PASSWORD = L"not_a_valid_password";	// Password removed per Security review requirements. LFeenanEA - 27th January 2025
 
-const wchar_t* _cdecl Translate_WOLString(const char* token)
+const wchar_t* __cdecl Translate_WOLString(const char* token)
 {
 	if (token) {
 		StringClass desc(80, true);

--- a/Code/Installer/RegistryManager.cpp
+++ b/Code/Installer/RegistryManager.cpp
@@ -794,7 +794,7 @@ bool RegistryManagerClass::Get_Value (HKEY rootkey, DWORD *value, ...)
  * HISTORY:                                                                                    *
  *   08/22/01    IML : Created.                                                                * 
  *=============================================================================================*/
-bool _cdecl RegistryManagerClass::Set_String (HKEY rootkey, const WCHAR *string, ...)
+bool __cdecl RegistryManagerClass::Set_String (HKEY rootkey, const WCHAR *string, ...)
 {
 	HKEY	   key;
 	DWORD	   disposition;
@@ -848,7 +848,7 @@ bool _cdecl RegistryManagerClass::Set_String (HKEY rootkey, const WCHAR *string,
  * HISTORY:                                                                                    *
  *   08/22/01    IML : Created.                                                                * 
  *=============================================================================================*/
-bool _cdecl RegistryManagerClass::Set_Value (HKEY rootkey, DWORD value, ...)
+bool __cdecl RegistryManagerClass::Set_Value (HKEY rootkey, DWORD value, ...)
 {
 	HKEY	   key;
 	DWORD	   disposition;
@@ -899,7 +899,7 @@ bool _cdecl RegistryManagerClass::Set_Value (HKEY rootkey, DWORD value, ...)
  * HISTORY:                                                                                    *
  *   08/22/01    IML : Created.                                                                * 
  *=============================================================================================*/
-bool _cdecl RegistryManagerClass::Get_Key (HKEY rootkey, DWORD keyindex, StringClass *keyname, ...)
+bool __cdecl RegistryManagerClass::Get_Key (HKEY rootkey, DWORD keyindex, StringClass *keyname, ...)
 {
 	bool			 success = false;
 	va_list		 marker;

--- a/Code/Installer/RegistryManager.h
+++ b/Code/Installer/RegistryManager.h
@@ -104,11 +104,11 @@ class RegistryManagerClass {
 
 	protected:
 		
-		bool _cdecl Get_String (HKEY rootkey, WideStringClass *string, ...);
-		bool _cdecl Get_Value (HKEY rootkey, DWORD *value, ...);
-		bool _cdecl Set_String (HKEY rootkey, const WCHAR *string, ...);
-		bool _cdecl Set_Value (HKEY rootkey, DWORD value, ...);
-		bool _cdecl Get_Key (HKEY rootkey, DWORD keyindex, StringClass *keyname, ...);
+		bool __cdecl Get_String (HKEY rootkey, WideStringClass *string, ...);
+		bool __cdecl Get_Value (HKEY rootkey, DWORD *value, ...);
+		bool __cdecl Set_String (HKEY rootkey, const WCHAR *string, ...);
+		bool __cdecl Set_Value (HKEY rootkey, DWORD value, ...);
+		bool __cdecl Get_Key (HKEY rootkey, DWORD keyindex, StringClass *keyname, ...);
 
 		char *WOLKeys [COMPONENT_COUNT];
 };

--- a/Code/Launcher/CMakeLists.txt
+++ b/Code/Launcher/CMakeLists.txt
@@ -1,0 +1,53 @@
+add_executable(launcher WIN32
+    configfile.cpp
+    configfile.h
+    dictionary.h
+    filed.h
+    monod.cpp
+    monod.h
+    odevice.h
+    streamer.cpp
+    streamer.h
+    wdebug.cpp
+    wstring.cpp
+    wstring.h
+
+
+    Toolkit/Storage/File.cpp
+    Toolkit/Storage/File.h
+    Toolkit/Storage/Rights.h
+    Toolkit/Storage/Stream.h
+
+    Toolkit/Debug/DebugPrint.cpp
+    Toolkit/Debug/DebugPrint.h
+
+    Toolkit/Support/RefCounted.h
+    Toolkit/Support/RefPtr.h
+    Toolkit/Support/StringConvert.cpp
+    Toolkit/Support/StringConvert.h
+    Toolkit/Support/UString.cpp
+    Toolkit/Support/UString.h
+    Toolkit/Support/UTypes.h
+    Toolkit/Support/Visualc.h
+
+    BFISH.H
+    dialog.cpp
+    dialog.h
+    findpatch.cpp
+    findpatch.h
+    launcher1.rc
+
+    loadbmp.cpp
+    loadbmp.h
+    main.cpp
+    patch.cpp
+    patch.h
+    process.cpp
+    process.h
+    Protect.h
+    winblows.cpp
+    winblows.h
+    wstypes.h
+)
+target_include_directories(launcher PRIVATE "Toolkit")
+target_link_libraries(launcher PRIVATE comctl32)

--- a/Code/Launcher/Toolkit/Support/UString.cpp
+++ b/Code/Launcher/Toolkit/Support/UString.cpp
@@ -776,7 +776,7 @@ Int UString::Find(Char c) const
 
 Int UString::Find(WChar c) const
 	{
-	WChar* ptr = wcschr(Get(), c);
+	const WChar *ptr = wcschr(Get(), c);
 
 	// Not found?
 	if (ptr == NULL)

--- a/Code/Launcher/Toolkit/Support/UTypes.h
+++ b/Code/Launcher/Toolkit/Support/UTypes.h
@@ -68,7 +68,7 @@ typedef char Char;
 typedef unsigned char UChar;
 
 //! Wide character (Unicode)
-typedef unsigned short WChar;
+typedef wchar_t WChar;
 
 //! 32bit floating point value
 typedef float Float32;

--- a/Code/Launcher/Util/wdebug.h
+++ b/Code/Launcher/Util/wdebug.h
@@ -72,7 +72,7 @@ extern Sem4 DebugLibSemaphore;
   DebugLibSemaphore.Wait(); \
   if (MsgManager::infoStream()) \
     (*(MsgManager::infoStream())) << "INF " << timebuf << " [" << \
-        __FILE__ <<  " " << __LINE__ << "] " << X << endl; \
+        __FILE__ <<  " " << __LINE__ << "] " << X << std::endl; \
   DebugLibSemaphore.Post(); \
 }
 
@@ -85,7 +85,7 @@ extern Sem4 DebugLibSemaphore;
   DebugLibSemaphore.Wait(); \
   if (MsgManager::warnStream()) \
     (*(MsgManager::warnStream())) << "WRN " << timebuf << " [" << \
-        __FILE__ <<  " " << __LINE__ << "] " << X << endl; \
+        __FILE__ <<  " " << __LINE__ << "] " << X << std::endl; \
   DebugLibSemaphore.Post(); \
 }
 
@@ -98,7 +98,7 @@ extern Sem4 DebugLibSemaphore;
   DebugLibSemaphore.Wait(); \
   if (MsgManager::errorStream()) \
     (*(MsgManager::errorStream())) << "ERR " << timebuf << " [" << \
-        __FILE__ <<  " " << __LINE__ << "] " << X << endl; \
+        __FILE__ <<  " " << __LINE__ << "] " << X << std::std::endl; \
   DebugLibSemaphore.Post(); \
 }
 
@@ -154,7 +154,7 @@ extern Sem4 DebugLibSemaphore;
   DebugLibSemaphore.Wait(); \
   if (MsgManager::debugStream()) \
     (*(MsgManager::debugStream())) << __FILE__ << "[" << __LINE__ << \
-       "]: " << ##V << " = " << V << endl; \
+       "]: " << ##V << " = " << V << std::endl; \
   DebugLibSemaphore.Post(); \
 }
 
@@ -164,7 +164,7 @@ extern Sem4 DebugLibSemaphore;
   DebugLibSemaphore.Wait(); \
   if (MsgManager::debugStream()) \
     (*(MsgManager::debugStream())) << "DBG [" << __FILE__ <<  \
-    " " << __LINE__ << "] " << X << endl;\
+    " " << __LINE__ << "] " << X << std::endl;\
   DebugLibSemaphore.Post(); \
 }
 
@@ -183,7 +183,7 @@ extern Sem4 DebugLibSemaphore;
   DebugLibSemaphore.Wait(); \
   if (MsgManager::debugStream()) \
     (*(DebugManager::debugStream())) << __FILE__ << "[" << __LINE__ << \
-     "]: " << ##X << endl; X \
+     "]: " << ##X << std::endl; X \
   DebugLibSemaphore.Post(); \
 }
 

--- a/Code/Launcher/main.cpp
+++ b/Code/Launcher/main.cpp
@@ -229,7 +229,7 @@ int main(int argc, char *argv[])
 	InitCommonControls();
 
 	// Goto the folder where launcher is installed
-	myChdir(argv[0]);
+	//myChdir(argv[0]);
 
 	// extract the program name from argv[0].  Change the extension to
 	//   .lcf (Launcher ConFig).  This is the name of our config file.

--- a/Code/Launcher/patch.cpp
+++ b/Code/Launcher/patch.cpp
@@ -478,7 +478,7 @@ __declspec(dllexport) LPVOID CALLBACK PatchCallBack(UINT Id, LPVOID Param)
 
 	case 4:
 	  // Error message header/text
-      ///////*g_LogFile << (char *)Parm << endl;
+      ///////*g_LogFile << (char *)Parm << std::endl;
       char errmsg[256];
       LoadString(NULL,IDS_ERR_PATCH,errmsg,256);
       MessageBox(NULL,(char *)Param,errmsg,MB_OK);
@@ -550,7 +550,7 @@ __declspec(dllexport) LPVOID CALLBACK PatchCallBack(UINT Id, LPVOID Param)
 	  //// end patch
 	  //LoadString(g_AppInstance, IDS_PROCCOMPLETE, lpcBuf, 256);
 	  //g_DlgPtr->SetProgressText(lpcBuf);
-	  //*g_LogFile << " complete" << endl;
+	  //*g_LogFile << " complete" << std::endl;
       percent=100;
       PostMessage(GetDlgItem(PatchDialog,IDC_PROGRESS2),PBM_SETPOS,percent,0);
 		DBGMSG("P_DONE");
@@ -560,13 +560,13 @@ __declspec(dllexport) LPVOID CALLBACK PatchCallBack(UINT Id, LPVOID Param)
 	  //// this one shouldn't happen (only occurs if the command line
 	  ////   doesn't have a patch file in it, and we insure that it does).
 	  //Abort = TRUE;
-	  //*g_LogFile << "Incorrect (or none) patch file specified in command line." << endl;
+	  //*g_LogFile << "Incorrect (or none) patch file specified in command line." << std::endl;
 	break;
 
 	case 0xe:
 	  //// this one shouldn't happen either (same reason)
 	  //Abort = TRUE;
-	  //*g_LogFile << "Incorrect (or none) path specified in command line." << endl;
+	  //*g_LogFile << "Incorrect (or none) path specified in command line." << std::endl;
 	break;
 
 	case 0xf:
@@ -592,7 +592,7 @@ __declspec(dllexport) LPVOID CALLBACK PatchCallBack(UINT Id, LPVOID Param)
 	case 0x14:
 	  //// Location Dialog
 	  //Abort = TRUE;
-      //*g_LogFile << "Specified path is incorrect." << endl;
+      //*g_LogFile << "Specified path is incorrect." << std::endl;
 	break;
 
 	case 0x16:

--- a/Code/Launcher/streamer.h
+++ b/Code/Launcher/streamer.h
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdarg.h>
-#include <iostream.h>
+#include <iostream>
 #include <string.h>
 
 #include "odevice.h"
@@ -36,7 +36,7 @@
 
 
 // Provide a streambuf interface for a class that can 'print'
-class Streamer : public streambuf
+class Streamer : public std::streambuf
 {
  public:
                Streamer();
@@ -46,12 +46,12 @@ class Streamer : public streambuf
 
  protected:
     // Virtual methods from streambuf
-    int       xsputn(const char* s, int n); // buffer some characters
-    int       overflow(int = EOF);          // flush buffer and make more room
-    int       underflow(void);              // Does nothing
-    int       sync();
+    std::streamsize xsputn(const char* s, std::streamsize n) override;    // buffer some characters
+    int             overflow(int = EOF) override;                         // flush buffer and make more room
+    int             underflow(void) override;                             // Does nothing
+    int             sync() override;
 
-    int       doallocate();                 // allocate a buffer
+    int             doallocate();                                         // allocate a buffer
 
 
     OutputDevice  *Output_Device;

--- a/Code/Launcher/wdebug.cpp
+++ b/Code/Launcher/wdebug.cpp
@@ -25,19 +25,19 @@
 static MsgManager         *msg_manager=NULL;
 
 static int                debug_enabled=0;
-static ostream           *debug_ostream=NULL;
+static std::ostream      *debug_ostream=NULL;
 static Streamer           debug_streamer;
 
 static int                info_enabled=0;
-static ostream           *info_ostream=NULL;
+static std::ostream      *info_ostream=NULL;
 static Streamer           info_streamer;
 
 static int                warn_enabled=0;
-static ostream           *warn_ostream=NULL;
+static std::ostream      *warn_ostream=NULL;
 static Streamer           warn_streamer;
 
 static int                error_enabled=0;
-static ostream           *error_ostream=NULL;  
+static std::ostream      *error_ostream=NULL;
 static Streamer           error_streamer;
 
 
@@ -50,19 +50,19 @@ int MsgManager::setAllStreams(OutputDevice *device)
 
   debug_streamer.setOutputDevice(device);
   delete(debug_ostream);
-  debug_ostream=new ostream(&debug_streamer);
+  debug_ostream=new std::ostream(&debug_streamer);
 
   info_streamer.setOutputDevice(device);
   delete(info_ostream);
-  info_ostream=new ostream(&info_streamer);
+  info_ostream=new std::ostream(&info_streamer);
 
   warn_streamer.setOutputDevice(device);
   delete(warn_ostream);
-  warn_ostream=new ostream(&warn_streamer);
+  warn_ostream=new std::ostream(&warn_streamer);
 
   error_streamer.setOutputDevice(device);
   delete(error_ostream);
-  error_ostream=new ostream(&error_streamer);
+  error_ostream=new std::ostream(&error_streamer);
 
   return(0);
 }
@@ -76,7 +76,7 @@ int MsgManager::setDebugStream(OutputDevice *device)
  
   debug_streamer.setOutputDevice(device);
   delete(debug_ostream);
-  debug_ostream=new ostream(&debug_streamer);
+  debug_ostream=new std::ostream(&debug_streamer);
 
   return(0);
 }
@@ -89,7 +89,7 @@ int MsgManager::setInfoStream(OutputDevice *device)
 
   info_streamer.setOutputDevice(device);
   delete(info_ostream);
-  info_ostream=new ostream(&info_streamer);
+  info_ostream=new std::ostream(&info_streamer);
 
   return(0);
 }
@@ -102,7 +102,7 @@ int MsgManager::setWarnStream(OutputDevice *device)
 
   warn_streamer.setOutputDevice(device);
   delete(warn_ostream);
-  warn_ostream=new ostream(&warn_streamer);
+  warn_ostream=new std::ostream(&warn_streamer);
 
   return(0);
 }
@@ -115,29 +115,29 @@ int MsgManager::setErrorStream(OutputDevice *device)
 
   error_streamer.setOutputDevice(device);
   delete(error_ostream);
-  error_ostream=new ostream(&error_streamer);
+  error_ostream=new std::ostream(&error_streamer);
 
   return(0);
 }
 
 
 
-ostream *MsgManager::debugStream(void)
+std::ostream *MsgManager::debugStream(void)
 {
   return(debug_ostream);
-}   
+}
 
-ostream *MsgManager::infoStream(void)
+std::ostream *MsgManager::infoStream(void)
 {
   return(info_ostream);
-}   
+}
 
-ostream *MsgManager::warnStream(void)
+std::ostream *MsgManager::warnStream(void)
 {
   return(warn_ostream);
 }
 
-ostream *MsgManager::errorStream(void)
+std::ostream *MsgManager::errorStream(void)
 {
   return(error_ostream);
 }   

--- a/Code/Launcher/wdebug.h
+++ b/Code/Launcher/wdebug.h
@@ -53,7 +53,7 @@ will you be ready to leave grasshopper.
 #ifndef WDEBUG_HEADER
 #define WDEBUG_HEADER
 
-#include <iostream.h>
+#include <iostream>
 #include "odevice.h"
 #include "streamer.h"
 #include <time.h>
@@ -68,7 +68,7 @@ will you be ready to leave grasshopper.
   cftime(timebuf,"%D %T",&clock); \
   if (MsgManager::infoStream()) \
     (*(MsgManager::infoStream())) << "INF " << timebuf << " [" << \
-        __FILE__ <<  " " << __LINE__ << "] " << X << endl; \
+        __FILE__ <<  " " << __LINE__ << "] " << X << std::endl; \
 }
 
 // Print a warning message
@@ -79,7 +79,7 @@ will you be ready to leave grasshopper.
   cftime(timebuf,"%D %T",&clock); \
   if (MsgManager::warnStream()) \
     (*(MsgManager::warnStream())) << "WRN " << timebuf << " [" << \
-        __FILE__ <<  " " << __LINE__ << "] " << X << endl; \
+        __FILE__ <<  " " << __LINE__ << "] " << X << std::endl; \
 }
 
 // Print an error message
@@ -90,7 +90,7 @@ will you be ready to leave grasshopper.
   strcpy(timebuf,ctime(&clock)); \
   if (MsgManager::errorStream()) \
     (*(MsgManager::errorStream())) << "ERR " << timebuf << " [" << \
-        __FILE__ <<  " " << __LINE__ << "] " << X << endl; \
+        __FILE__ <<  " " << __LINE__ << "] " << X << std::endl; \
 }
 
 
@@ -138,7 +138,7 @@ will you be ready to leave grasshopper.
 { \
   if (MsgManager::debugStream()) \
     (*(MsgManager::debugStream())) << __FILE__ << "[" << __LINE__ << \
-       "]: " << ##V << " = " << V << endl; \
+       "]: " << ##V << " = " << V << std::endl; \
 }
 
 
@@ -146,7 +146,7 @@ will you be ready to leave grasshopper.
 {\
   if (MsgManager::debugStream()) \
     (*(MsgManager::debugStream())) << "DBG [" << __FILE__ <<  \
-    " " << __LINE__ << "] " << X << endl;\
+    " " << __LINE__ << "] " << X << std::endl;\
 }
 
 // Just get a stream to the debugging device, no extra junk
@@ -161,7 +161,7 @@ will you be ready to leave grasshopper.
 { \
   if (MsgManager::debugStream()) \
     (*(DebugManager::debugStream())) << __FILE__ << "[" << __LINE__ << \
-     "]: " << ##X << endl; X \
+     "]: " << ##X << std::endl; X \
 }
 
 #endif  // DEBUG
@@ -184,10 +184,10 @@ class MsgManager
    static void                enableWarn(int flag);
    static void                enableError(int flag);
 
-   static ostream            *debugStream(void);
-   static ostream            *infoStream(void);
-   static ostream            *warnStream(void);
-   static ostream            *errorStream(void);
+   static std::ostream        *debugStream(void);
+   static std::ostream        *infoStream(void);
+   static std::ostream        *warnStream(void);
+   static std::ostream        *errorStream(void);
 };
 
 #endif

--- a/Code/Tools/LevelEdit/CMakeLists.txt
+++ b/Code/Tools/LevelEdit/CMakeLists.txt
@@ -458,7 +458,7 @@ target_link_libraries(leveledit PRIVATE
     combate
 )
 
-if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
+if(WIN32)
     target_link_options(leveledit PRIVATE /NODEFAULTLIB:libci.lib /NODEFAULTLIB:libc.lib)
     add_custom_command(
         OUTPUT VSS.h VSS_i.c

--- a/Code/Tools/LevelEdit/CMakeLists.txt
+++ b/Code/Tools/LevelEdit/CMakeLists.txt
@@ -435,7 +435,6 @@ target_include_directories(leveledit PRIVATE
 
 target_link_libraries(leveledit PRIVATE
     winmm
-    vfw32
     wsock32
     shlwapi
     version

--- a/Code/Tools/W3DView/CMakeLists.txt
+++ b/Code/Tools/W3DView/CMakeLists.txt
@@ -202,6 +202,6 @@ target_link_libraries(w3dview PRIVATE
 
 target_sources(w3dview PRIVATE ${W3DVIEW_SRC})
 
-if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
+if(WIN32)
     target_link_options(w3dview PRIVATE "/NODEFAULTLIB:libci.lib")
 endif()

--- a/Code/Tools/W3DView/CMakeLists.txt
+++ b/Code/Tools/W3DView/CMakeLists.txt
@@ -186,7 +186,6 @@ target_compile_options(w3dview PRIVATE
 )
 
 target_link_libraries(w3dview PRIVATE
-    vfw32
     d3d8lib
     version
     winmm

--- a/Code/Tools/WWConfig/CMakeLists.txt
+++ b/Code/Tools/WWConfig/CMakeLists.txt
@@ -31,7 +31,6 @@ target_compile_definitions(wwconfig PRIVATE
 )
 
 target_link_libraries(wwconfig PRIVATE
-    vfw32
     version
     winmm
     wwcommon

--- a/Code/Tools/WWConfig/CMakeLists.txt
+++ b/Code/Tools/WWConfig/CMakeLists.txt
@@ -45,6 +45,6 @@ target_link_libraries(wwconfig PRIVATE
 
 target_sources(wwconfig PRIVATE ${WWCONFIG_SRC})
 
-if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
+if(WIN32)
     target_link_options(wwconfig PRIVATE "/NODEFAULTLIB:libci.lib")
 endif()

--- a/Code/Tools/WWConfig/VideoConfigDialog.cpp
+++ b/Code/Tools/WWConfig/VideoConfigDialog.cpp
@@ -46,7 +46,7 @@ WW3DAssetManager *_TheAssetMgr = NULL;;
 /////////////////////////////////////////////////////////////////////////////
 //	Local prototypes
 /////////////////////////////////////////////////////////////////////////////
-int _cdecl ResolutionSortCallback (const void *elem1, const void *elem2);
+int __cdecl ResolutionSortCallback (const void *elem1, const void *elem2);
 
 
 /////////////////////////////////////////////////////////////////////////////
@@ -547,7 +547,7 @@ VideoConfigDialogClass::OnItemchangedDriverList
 // ResolutionSortCallback
 //
 /////////////////////////////////////////////////////////////////////////////
-int _cdecl
+int __cdecl
 ResolutionSortCallback (const void *elem1, const void *elem2)
 {
 	const ResolutionDescClass *res1 = ((const ResolutionDescClass *)elem1);

--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -226,6 +226,8 @@ add_library(ww3d2 STATIC)
 
 target_link_libraries(ww3d2 PRIVATE
     wwcommon
+    vfw32
+    winmm
 )
 
 target_sources(ww3d2 PRIVATE ${WW3D2_SRC})
@@ -237,6 +239,8 @@ if (RENEGADE_TOOLS)
 
     target_link_libraries(ww3d2e PRIVATE
         wwcommon
+        vfw32
+        winmm
     )
 
     target_compile_definitions(ww3d2e PRIVATE PARAM_EDITING_ON)

--- a/Code/ww3d2/dx8wrapper.h
+++ b/Code/ww3d2/dx8wrapper.h
@@ -853,12 +853,15 @@ not_changed:
 
 WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 {
+#if defined(_M_X86)
 	if (!CPUDetectClass::Has_CMOV_Instruction()) {
+#endif
 		for (int i=0;i<4;++i) {
 			float f=(color[i]<0.0f) ? 0.0f : color[i];
 			color[i]=(f>1.0f) ? 1.0f : f;
 		}
 		return;
+#if defined(_M_X86)
 	}
 
 	__asm
@@ -903,6 +906,7 @@ WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 		cmovnb edi,edx
 		mov dword ptr[esi+12],edi
 	}
+#endif
 }
 
 // ----------------------------------------------------------------------------

--- a/Code/ww3d2/dx8wrapper.h
+++ b/Code/ww3d2/dx8wrapper.h
@@ -767,6 +767,7 @@ WWINLINE void DX8Wrapper::Clamp_Color(Vector4& color)
 
 WWINLINE unsigned int DX8Wrapper::Convert_Color(const Vector3& color,float alpha)
 {
+#if defined(_M_IX86)
 	const float scale = 255.0;
 	unsigned int col;
 
@@ -834,6 +835,13 @@ not_changed:
 
 		mov	col,eax
 	}
+#else
+	unsigned r = (int)(Vector.x * 255.f) & 0xff;
+	unsigned g = (int)(Vector.g * 255.f) & 0xff;
+	unsigned b = (int)(Vector.b * 255.f) & 0xff;
+	unsigned a = (int)(alpha * 255.f) & 0xff;
+	col = (a << 24) | (r << 16) | (g << 8) | (b << 0);
+#endif
 	return col;
 }
 

--- a/Code/ww3d2/dx8wrapper.h
+++ b/Code/ww3d2/dx8wrapper.h
@@ -45,7 +45,7 @@
 
 #include "always.h"
 #include "dllist.h"
-#include "d3d8.h"
+#include <d3d8.h>
 #include "matrix4.h"
 #include "statistics.h"
 #include "wwstring.h"

--- a/Code/wwlib/bool.h
+++ b/Code/wwlib/bool.h
@@ -40,24 +40,9 @@
 #if !defined(TRUE_FALSE_DEFINED) && !defined(__BORLANDC__) && (_MSC_VER < 1100) && !defined(__WATCOMC__)
 #define TRUE_FALSE_DEFINED
 
-/**********************************************************************
-**      The "bool" integral type was defined by the C++ comittee in
-**      November of '94. Until the compiler supports this, use the following
-**      definition.
-*/
 #ifdef _MSC_VER
 
 #include        "yvals.h"
-#define bool    unsigned
-
-#elif defined(_UNIX)
-
-/////#define bool    unsigned
-
-#else
-
-enum {false=0,true=1};
-typedef int bool;
 
 #endif
 

--- a/Code/wwlib/widestring.cpp
+++ b/Code/wwlib/widestring.cpp
@@ -243,7 +243,7 @@ WideStringClass::Free_String (void)
 //	Format
 //
 ///////////////////////////////////////////////////////////////////
-int _cdecl
+int __cdecl
 WideStringClass::Format_Args (const WCHAR *format, const va_list & arg_list )
 {
 	if (format == NULL) {
@@ -274,7 +274,7 @@ WideStringClass::Format_Args (const WCHAR *format, const va_list & arg_list )
 //	Format
 //
 ///////////////////////////////////////////////////////////////////
-int _cdecl
+int __cdecl
 WideStringClass::Format (const WCHAR *format, ...)
 {
 	if (format == NULL) {

--- a/Code/wwlib/widestring.h
+++ b/Code/wwlib/widestring.h
@@ -113,8 +113,8 @@ public:
 	bool			Is_Empty (void) const;
 
 	void			Erase (int start_index, int char_count);
-	int _cdecl  Format (const WCHAR *format, ...);
-	int _cdecl  Format_Args (const WCHAR *format, const va_list & arg_list );
+	int __cdecl  Format (const WCHAR *format, ...);
+	int __cdecl  Format_Args (const WCHAR *format, const va_list & arg_list );
 	bool			Convert_From (const char *text);
 	bool			Convert_To (StringClass &string);
 	bool			Convert_To (StringClass &string) const;

--- a/Code/wwlib/wwmouse.h
+++ b/Code/wwlib/wwmouse.h
@@ -40,6 +40,8 @@
 #include	"win.h"
 #include	"xmouse.h"
 
+#include <mmsystem.h>
+
 class BSurface;
 
 /*

--- a/Code/wwlib/wwstring.cpp
+++ b/Code/wwlib/wwstring.cpp
@@ -237,7 +237,7 @@ StringClass::Free_String (void)
 //	Format
 //
 ///////////////////////////////////////////////////////////////////
-int _cdecl
+int __cdecl
 StringClass::Format_Args (const TCHAR *format, const va_list & arg_list )
 {
 	//
@@ -269,7 +269,7 @@ StringClass::Format_Args (const TCHAR *format, const va_list & arg_list )
 //	Format
 //
 ///////////////////////////////////////////////////////////////////
-int _cdecl
+int __cdecl
 StringClass::Format (const TCHAR *format, ...)
 {
 	va_list arg_list;

--- a/Code/wwlib/wwstring.h
+++ b/Code/wwlib/wwstring.h
@@ -130,8 +130,8 @@ public:
 	bool			Is_Empty (void) const;
 
 	void			Erase (int start_index, int char_count);
-	int _cdecl  Format (const TCHAR *format, ...);
-	int _cdecl  Format_Args (const TCHAR *format, const va_list & arg_list );
+	int __cdecl  Format (const TCHAR *format, ...);
+	int __cdecl  Format_Args (const TCHAR *format, const va_list & arg_list );
 
 	// Trim leading and trailing whitespace characters (values <= 32)
 	void Trim(void);

--- a/Code/wwui/dialogparser.cpp
+++ b/Code/wwui/dialogparser.cpp
@@ -293,6 +293,7 @@ DialogParserClass::Parse_Template
 				buffer = (WORD *)(((char *)ALIGN_WORD_PTR(buffer)) + extra_data_size);
 			}
 		}
+		::FreeResource(hglobal);
 	}
 
 	return ;

--- a/cmake/gamespy.cmake
+++ b/cmake/gamespy.cmake
@@ -4,7 +4,7 @@ set(GAMESPY_SERVER_NAME "server.cnc-online.net")
 FetchContent_Declare(
     gamespy
     GIT_REPOSITORY https://github.com/TheAssemblyArmada/GamespySDK.git
-    GIT_TAG        d7ec6d4fea1c11fc37173ea954fc1ec47202a931
+    GIT_TAG        112ee06236193fe5bd3f5164c6b3515eb50b437d
 )
 
 FetchContent_MakeAvailable(gamespy)

--- a/cmake/miles.cmake
+++ b/cmake/miles.cmake
@@ -1,7 +1,7 @@
 FetchContent_Declare(
     miles
     GIT_REPOSITORY https://github.com/TheSuperHackers/miles-sdk-stub.git
-    GIT_TAG        564a0cb6dcf94bd17a1adf8f6110c108189efbae
+    GIT_TAG        1485965c24be1a0d5633620f3febdbbebfe5822e
 )
 
 FetchContent_MakeAvailable(miles)


### PR DESCRIPTION
This PR is a combination of (very) small changes that should advance the project:
- Build launcher executable (this executable will probably be removed in the future, but cmake is now able to build it)
- vfw32 Windows libray is only used by ww3d2, bink only by BinkMovie
- Bump bink and gamespy
- cmake: use WIN32 instead of comparing `CMAKE_SYSTEM_NAME` with Windows ([`WIN32` is defined by CMake automatically](https://github.com/Kitware/CMake/blob/82f7407632fd09e1e723b7c91d34087ce70c84b7/Modules/Platform/Windows-Initialize.cmake#L1))
- Remove some inline assembly in ww3d2