### PR TITLE
Warning cleanup, C5055.

### DIFF
--- a/Code/Combat/SoundEnvironment.h
+++ b/Code/Combat/SoundEnvironment.h
@@ -66,9 +66,7 @@ class SoundEnvironmentClass : public RefCountClass
 
 	protected:
 		
-		enum {
-			AMPLITUDE_BUFFER_SIZE = 8
-		};
+		static constexpr int AMPLITUDE_BUFFER_SIZE = 8;
 
 		unsigned	 UserCount;
 		unsigned	 AmplitudeIndex;

--- a/Code/Combat/WeatherMgr.h
+++ b/Code/Combat/WeatherMgr.h
@@ -146,11 +146,9 @@ class WeatherSystemClass : public RenderObjClass
 
 	protected:
 
-		enum {
-			VERTICES_PER_TRIANGLE = 3,
-			MAX_IB_PARTICLE_COUNT = 2048,
-			MAX_AGE					 = 1000000
-		};
+		static constexpr int VERTICES_PER_TRIANGLE = 3;
+		static constexpr int MAX_IB_PARTICLE_COUNT = 2048;
+		static constexpr int MAX_AGE					 = 1000000;
 
 		struct RayStruct : public AutoPoolClass <RayStruct, GROWTH_STEP>
 		{

--- a/Code/Combat/clientcontrol.cpp
+++ b/Code/Combat/clientcontrol.cpp
@@ -46,7 +46,7 @@ CClientControl *		PClientControl = NULL;
 
 DECLARE_NETWORKOBJECT_FACTORY(CClientControl, NETCLASSID_CLIENTCONTROL);
 
-#pragma message("(TSS) high priority for me to fix this CClientControl bug...")
+// FIXME (TSS) high priority for me to fix this CClientControl bug...
 //
 // TSS2001 problem: destruction of this object on the server. Quitting and rejoining 
 // a game will crash the server.

--- a/Code/Combat/gameobjmanager.cpp
+++ b/Code/Combat/gameobjmanager.cpp
@@ -216,7 +216,7 @@ void GameObjManager::Destroy_All()		// Destroy each object in the list
 		objnode->Data()->Set_Delete_Pending();
 	}
 
-#pragma message ("Disabling Think and Post_Think in GameObjManager::Destroy_All()")
+// FIXME Disabling Think and Post_Think in GameObjManager::Destroy_All()
 #if 0
 	Think();	
 	Post_Think();

--- a/Code/Combat/humanstate.cpp
+++ b/Code/Combat/humanstate.cpp
@@ -410,7 +410,7 @@ void	HumanStateClass::Set_State( HumanStateType state, int sub_state )
 //			return;
 		}
 
-#pragma MESSAGE( "StateLocked Hack" )
+// FIXME StateLocked Hack
 		if ( !IS_SOLOPLAY ) {		// E3 HACK
 			StateLocked = false;
 		}
@@ -437,7 +437,7 @@ void	HumanStateClass::Set_State( HumanStateType state, int sub_state )
 	}
 
 	// Turn off shadows in vehicles
-#pragma message ("(gth) shadow review hacking")
+// FIXME (gth) shadow review hacking
 #if 0
 	if ( State == IN_VEHICLE )  {
 		HumanPhys->Enable_Shadow_Generation( false );

--- a/Code/Combat/mapmgr.h
+++ b/Code/Combat/mapmgr.h
@@ -67,12 +67,9 @@ public:
 	////////////////////////////////////////////////////////////////
 	//	Public constants
 	////////////////////////////////////////////////////////////////
-	enum
-	{
-		CLOUD_WIDTH			= 20,
-		CLOUD_HEIGHT		= 20,
-		CLOUD_VECTOR_SIZE	= ((CLOUD_WIDTH * CLOUD_HEIGHT) / 32) + 1,
-	};
+	static constexpr int CLOUD_WIDTH			= 20;
+	static constexpr int CLOUD_HEIGHT		= 20;
+	static constexpr int CLOUD_VECTOR_SIZE	= ((CLOUD_WIDTH * CLOUD_HEIGHT) / 32) + 1;
 
 	////////////////////////////////////////////////////////////////
 	//	Public methods

--- a/Code/Combat/physicalgameobj.cpp
+++ b/Code/Combat/physicalgameobj.cpp
@@ -772,7 +772,7 @@ void PhysicalGameObj::Post_Think( void )
 		}
 	}
 
-#pragma message ("Going to hell on a client is problematic.")
+// FIXME Going to hell on a client is problematic.
 #ifndef PARAM_EDITING_ON  //(gth) don't go to hell in the editor cause it will cause a crash!
 	if (CombatManager::I_Am_Only_Client () == false && COMBAT_SCENE != NULL) {
 		Vector3 pos;

--- a/Code/Combat/playerdata.cpp
+++ b/Code/Combat/playerdata.cpp
@@ -262,7 +262,7 @@ void	PlayerDataClass::Increment_Money( float add )
 	//
 	// Look out for very big increments
 	//
-#pragma message ("(gth) this caused a crash and seems like debugging code so I'm disabling it...")
+// FIXME (gth) this caused a crash and seems like debugging code so I'm disabling it...
 #if 0 
 	static int warning_num = 0;
 	if (add >= 10000 && ++warning_num < 10) {

--- a/Code/Combat/repairbaygameobj.cpp
+++ b/Code/Combat/repairbaygameobj.cpp
@@ -698,7 +698,7 @@ RepairBayGameObj::Repair_Vehicle (void)
 					float repair_cost_per_pt	= vehicle_cost / (health_max + shield_max);
 
 					//int available_funds			= 1000; //player_data->Get_Score ()
-#pragma message("(TSS) available_funds			= 1000 looks suspect...")
+// FIXME (TSS) available_funds			= 1000 looks suspect...
 					int available_funds			= 1000; //player_data->Get_Money ()
 					
 					int points_restored			= int(available_funds / repair_cost_per_pt);

--- a/Code/Combat/scriptablegameobj.cpp
+++ b/Code/Combat/scriptablegameobj.cpp
@@ -611,7 +611,7 @@ void	ScriptableGameObj::Start_Custom_Timer( ScriptableGameObj * from, float dela
 void	ScriptableGameObj::Think( void )
 {
 	if (Is_Always_Dirty()) {
-#pragma message ("Forcing game objects to be network dirty for updates.\n")
+// FIXME Forcing game objects to be network dirty for updates.\n
 		Set_Object_Dirty_Bit (NetworkObjectClass::BIT_FREQUENT, true);
 	}
 

--- a/Code/Combat/specialbuilds.h
+++ b/Code/Combat/specialbuilds.h
@@ -81,19 +81,19 @@
 //-----------------------------------------------------------------------------
 
 #ifdef BETASERVER
-#pragma message("*** BETASERVER is defined ***")
+// FIXME *** BETASERVER is defined ***
 #endif // BETACLIENT
 
 #ifdef BETACLIENT
-#pragma message("*** BETACLIENT is defined ***")
+// FIXME *** BETACLIENT is defined ***
 #endif // BETACLIENT
 
 #ifdef FREEDEDICATEDSERVER
-#pragma message("*** FREEDEDICATEDSERVER is defined ***")
+// FIXME *** FREEDEDICATEDSERVER is defined ***
 #endif // FREEDEDICATEDSERVER
 
 #ifdef MULTIPLAYERDEMO
-#pragma message("*** MULTIPLAYERDEMO is defined ***")
+// FIXME *** MULTIPLAYERDEMO is defined ***
 #endif // MULTIPLAYERDEMO
 
 //
@@ -157,7 +157,7 @@
 
 /*
 #ifdef BETASERVER
-#pragma message("*** BETASERVER is defined ***")
+// FIXME *** BETASERVER is defined ***
 #endif // BETASERVER
 */
 

--- a/Code/Commando/WOLQuickMatch.cpp
+++ b/Code/Commando/WOLQuickMatch.cpp
@@ -356,7 +356,7 @@ void WOLQuickMatch::SendServerInfo(const char* exInfo, const char* topic)
 	{
 	if (exInfo && topic)
 		{
-#pragma message(__FILE__" *** HACK ALERT *** SINFO msg is imitating WOLAPI IRC topic!")
+// FIXME  *** HACK ALERT *** SINFO msg is imitating WOLAPI IRC topic!
 
 		// *** WARNING *** DANGER *** HACK ALERT ****
 		//

--- a/Code/Commando/clientfps.cpp
+++ b/Code/Commando/clientfps.cpp
@@ -47,7 +47,7 @@ CClientFps *		PClientFps = NULL;
 
 DECLARE_NETWORKOBJECT_FACTORY(CClientFps, NETCLASSID_CLIENTFPS);
 
-#pragma message("(TSS) high priority for me to fix this CClientFps bug...")
+// FIXME (TSS) high priority for me to fix this CClientFps bug...
 //
 // TSS2001 problem: destruction of this object on the server. Quitting and rejoining 
 // a game will crash the server.

--- a/Code/Commando/cnetwork.cpp
+++ b/Code/Commando/cnetwork.cpp
@@ -590,7 +590,7 @@ void cNetwork::Onetime_Shutdown(void)
 	}
 #endif // 0
 
-#pragma message("(TSS) This packet ref count assert very occasionally fails.")
+// FIXME (TSS) This packet ref count assert very occasionally fails.
    //WWASSERT(cPacket::Get_Ref_Count() == 0);
 
 	REF_PTR_RELEASE(VisTable);

--- a/Code/Commando/console.cpp
+++ b/Code/Commando/console.cpp
@@ -218,7 +218,7 @@ void 	ConsoleGameModeClass::Think()
    if ( !InputActive ) {
       bool enable_console = false;
 
-#pragma message("TODO: relocate and provide UI for player communication.")
+// FIXME TODO: relocate and provide UI for player communication.
 
 
 

--- a/Code/Commando/gameinitmgr.cpp
+++ b/Code/Commando/gameinitmgr.cpp
@@ -394,7 +394,7 @@ GameInitMgrClass::End_Game (void)
 		is_quick_full_exit_requested = cDevOptions::QuickFullExit.Get();
 #endif // WWDEBUG
 
-#pragma message("(TSS) ***** Memory leak here - please fix (ST - 6/14/2001 2:06PM) *****")
+// FIXME (TSS) ***** Memory leak here - please fix (ST - 6/14/2001 2:06PM) *****
 		cSvrGoodbyeEvent * p_event = new cSvrGoodbyeEvent;
 		p_event->Init(is_quick_full_exit_requested);
 	}
@@ -705,7 +705,7 @@ GameInitMgrClass::Shutdown_SP (void)
 
    WWDEBUG_SAY (("GameInitMgrClass::Shutdown_SP\n"));
 
-//#pragma message ("TSS Fix memory leak here")
+//// FIXME TSS Fix memory leak here
 
 	//cSingleData::Set_Is_Single_Player(false);
 	cGameType::Set_Game_Type(GAMETYPE_NONE);

--- a/Code/Commando/gamespyadmin.cpp
+++ b/Code/Commando/gamespyadmin.cpp
@@ -128,7 +128,7 @@ void cGameSpyAdmin::HandleNotification(DlgWOLWaitEvent& event) {
 					Join_Server();
 				} else { // This must be an Abort...
 					DetectingBandwidth = false;
-#pragma message ("Is Stop_Main_Loop() safe here?")
+// FIXME Is Stop_Main_Loop() safe here?
 					extern void Stop_Main_Loop (int);
 					Stop_Main_Loop(EXIT_SUCCESS);
 				}
@@ -140,7 +140,7 @@ void cGameSpyAdmin::HandleNotification(DlgWOLWaitEvent& event) {
 		case WaitCondition::Error:
 		{
 			DetectingBandwidth = false;
-#pragma message ("Is Stop_Main_Loop() safe here?")
+// FIXME Is Stop_Main_Loop() safe here?
 			extern void Stop_Main_Loop (int);
 			Stop_Main_Loop(EXIT_SUCCESS);
 		}

--- a/Code/Commando/lanchat.cpp
+++ b/Code/Commando/lanchat.cpp
@@ -58,7 +58,7 @@
 // Class statics
 //
 const USHORT	cLanChat::LAN_BROADCAST_INTERVAL_MS		= 1000;
-#pragma message ("(TSS) BUMP LAN BCAST PORT FOR D1P")
+// FIXME (TSS) BUMP LAN BCAST PORT FOR D1P
 //const USHORT	cLanChat::LAN_PORT							= 0xEA00;
 const USHORT	cLanChat::LAN_PORT							= 3373;
 

--- a/Code/Commando/pkthandlers.cpp
+++ b/Code/Commando/pkthandlers.cpp
@@ -135,7 +135,7 @@ void cNetwork::Server_Packet_Handler(cPacket & packet, int rhost_id)
 			//sockaddr_in rhost_addr = PServerConnection->Get_Remote_Host(rhost_id)->Get_Address();
 #endif //WWDEBUG
 
-//#pragma message("(TSS) APPPACKETTYPE_CSDAMAGEEVENT workaround for unknown crash bug.\n")
+//// FIXME (TSS) APPPACKETTYPE_CSDAMAGEEVENT workaround for unknown crash bug.\n
 
 			//WWDEBUG_SAY(("\n"));
 			//WWDEBUG_SAY(("cNetwork::Server_Packet_Handler: received BIT_CREATION (id %d, is_delete_pending = %d, net_classid = %d, from rhost %d - %s) for existing object:\n",

--- a/Code/Commando/player.cpp
+++ b/Code/Commando/player.cpp
@@ -449,7 +449,7 @@ void cPlayer::Get_Player_String(int rank, WideStringClass & string, bool force_v
    //
    // Compose a string description of a player's stats for display
    //
-#pragma message("TODO: (TSS) Examine all wide string %s formatting for errors...")
+// FIXME TODO: (TSS) Examine all wide string %s formatting for errors...
 
 	string.Format(L"");
 

--- a/Code/Commando/winevent.cpp
+++ b/Code/Commando/winevent.cpp
@@ -202,7 +202,7 @@ cWinEvent::Import_Creation(BitStreamClass & packet)
 	// This is just causing no end of trouble so I'm going to simplify it.
 	// The host has no business sending win events to people not in the same game anyway. ST - 1/18/2002 2:33PM
 	//
-#pragma message("(TSS) Could this be causing problems?")
+// FIXME (TSS) Could this be causing problems?
 	The_Game()->Set_Hosted_Game_Number(HostedGameNumber + 1);
 #if (0)
 	if (HostedGameNumber != The_Game()->Get_Hosted_Game_Number())

--- a/Code/WWMath/colmathobbobb.cpp
+++ b/Code/WWMath/colmathobbobb.cpp
@@ -757,7 +757,7 @@ static inline void compute_contact_normal(ObbCollisionStruct & context,CastResul
 	switch(context.AxisId) 
 	{
 	case INTERSECTION:
-#pragma message("Fatal assert disabled for demo, obb-obb collision")
+// FIXME Fatal assert disabled for demo, obb-obb collision
 //		WWASSERT(0);
 //		break;
 

--- a/Code/WWMath/colmathobbtri.cpp
+++ b/Code/WWMath/colmathobbtri.cpp
@@ -1063,7 +1063,7 @@ bool CollisionMath::Collide
 
 exit:
 
-#pragma message ("(gth) disabling an assert in obb->tri collision, investigate later\n")
+// FIXME (gth) disabling an assert in obb->tri collision, investigate later\n
 #if 0
 	WWASSERT((context.AxisId != INTERSECTION) || (context.StartBad));
 #else

--- a/Code/ww3d2/dx8wrapper.cpp
+++ b/Code/ww3d2/dx8wrapper.cpp
@@ -1015,7 +1015,7 @@ bool DX8Wrapper::Set_Device_Resolution(int width,int height,int bits,int windowe
 		if (height != -1) {
 			_PresentParameters.BackBufferHeight = ResolutionHeight = height;
 		}
-#pragma message("TODO: support changing windowed status and changing the bit depth")
+// FIXME TODO: support changing windowed status and changing the bit depth
 		return Reset_Device();
 	} else {
 		return false;

--- a/Code/ww3d2/meshmatdesc.cpp
+++ b/Code/ww3d2/meshmatdesc.cpp
@@ -939,7 +939,7 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 	// - there will be a single vertex material, shader, and texture for the first pass
 	// - the texture will be named razorw.tga
 	// - the mesh name will contain b_wire
-#pragma message("(gth) Renegade-specific hack, forcing b_wire mesh to use alpha-test...")
+// FIXME (gth) Renegade-specific hack, forcing b_wire mesh to use alpha-test...
 	if (	(parent != NULL) &&
 			(PassCount == 1) &&
 			(Has_Shader_Array(0) == false) && 

--- a/Code/ww3d2/meshmdl.cpp
+++ b/Code/ww3d2/meshmdl.cpp
@@ -191,7 +191,7 @@ void MeshModelClass::Register_For_Rendering()
 
 void MeshModelClass::Replace_Texture(TextureClass* texture,TextureClass* new_texture)
 {
-#pragma message("gth - TEMPORARILY REMOVING Replace_Texture")
+// FIXME gth - TEMPORARILY REMOVING Replace_Texture
 #if 0
 	WWASSERT(texture);
 	WWASSERT(new_texture);
@@ -222,7 +222,7 @@ void MeshModelClass::Replace_Texture(TextureClass* texture,TextureClass* new_tex
 
 void MeshModelClass::Replace_VertexMaterial(VertexMaterialClass* vmat,VertexMaterialClass* new_vmat)
 {
-#pragma message("gth - TEMPORARILY REMOVING Replace_Texture")
+// FIXME gth - TEMPORARILY REMOVING Replace_Texture
 #if 0
 	WWASSERT(vmat);
 	WWASSERT(new_vmat);

--- a/Code/ww3d2/shattersystem.cpp
+++ b/Code/ww3d2/shattersystem.cpp
@@ -1215,7 +1215,7 @@ void ShatterSystem::Process_Clip_Pools
 						** If there were UV coordinates in the original mesh for either stage,
 						** then copy the vertex's uv's into into the new mesh.
 						*/
-						#pragma MESSAGE("HY- Naty, will dynamesh support multiple stages of UV?")
+						// FIXME HY- Naty, will dynamesh support multiple stages of UV?
 						for (istage=0; istage<MeshMatDescClass::MAX_TEX_STAGES; istage++) {
 							if (mtl_params.UV[ipass][istage] != NULL) {
 								SHATTER_DEBUG_SAY(("UV: pass:%d stage: %d: %f %f\n",ipass,istage,vert.TexCoord[ipass][istage].X,vert.TexCoord[ipass][istage].Y));

--- a/Code/wwnet/netutil.cpp
+++ b/Code/wwnet/netutil.cpp
@@ -583,7 +583,7 @@ void cNetUtil::Broadcast(SOCKET & sock, USHORT port, cPacket & packet)
    //   0, &broadcast_address, sizeof(SOCKADDR_IN)));
 	bytes_sent = sendto(sock, packet.Get_Data(), packet.Get_Compressed_Size_Bytes(),
       0, (LPSOCKADDR) &broadcast_address, sizeof(SOCKADDR_IN));
-#pragma message("(TSS) WSAENOBUFS")
+// FIXME (TSS) WSAENOBUFS
    //WWDEBUG_SAY(("Sent broadcast, length = %d bytes\n", bytes_sent));
 }
 

--- a/Code/wwphys/animcollisionmanager.cpp
+++ b/Code/wwphys/animcollisionmanager.cpp
@@ -1294,7 +1294,7 @@ bool AnimCollisionManagerClass::Check_Collision(CollideableObjClass & collisiono
 			*/
 			//obj->Notify_Squished(this);
 			revert = true;
-#pragma message ("(gth) commenting out rider squishing code for critical review!")
+// FIXME (gth) commenting out rider squishing code for critical review!
 			VERBOSE_LOG(("Squishing a rider!\r\n"));
 		
 		} else {

--- a/Code/wwphys/dynamicshadowmanager.cpp
+++ b/Code/wwphys/dynamicshadowmanager.cpp
@@ -168,7 +168,7 @@ void DynamicShadowManagerClass::Update_Shadow(void)
 
 	} else {
 
-#pragma message ("(gth) Disabling local shadows")
+// FIXME (gth) Disabling local shadows
 #if 0
 		/*
 		** We couldn't use the sunlight so now we look for the nearest

--- a/Code/wwphys/lightsolve.cpp
+++ b/Code/wwphys/lightsolve.cpp
@@ -356,7 +356,7 @@ void VertexSolveClass::Add_Light_To_Vertex(LightSolveContextClass & context,int 
 		// cast ray...
 		bool is_occluded = false;
 
-#pragma message("need a collision group for light occlusion here...")
+// FIXME need a collision group for light occlusion here...
 		if (context.Is_Occlusion_Enabled()) {
 			CastResultStruct res;
 			Vector3 p0 = Position[vi];

--- a/Code/wwphys/phys.cpp
+++ b/Code/wwphys/phys.cpp
@@ -315,7 +315,7 @@ void PhysClass::Update_Sun_Status(void)
 	scene->Get_Sun_Light_Vector(&sunlight);
 	Vector3 center = Model->Get_Bounding_Sphere().Center; 
 
-#pragma message ("(gth) Need a collision group for sun-rays")
+// FIXME (gth) Need a collision group for sun-rays
 	CastResultStruct sunresult;
 	LineSegClass sunray(center,center - sunlight * SUN_CHECK_DISTANCE);
 	PhysRayCollisionTestClass sunraytest(sunray,&sunresult,0,COLLISION_TYPE_PROJECTILE);

--- a/Code/wwphys/rbody.cpp
+++ b/Code/wwphys/rbody.cpp
@@ -1237,7 +1237,7 @@ void RigidBodyClass::Compute_Force_And_Torque(Vector3 * force,Vector3 * torque)
 		vel_dir.Normalize();
 		
 // DEBUG DEBUG
-#pragma message ("(gth) HACK! zeroing bad velocities.")
+// FIXME (gth) HACK! zeroing bad velocities.
 const float MAX_VEL = 500.0f;
 const float MAX_ACCEL = 100.0f;
 if (	(Velocity.Is_Valid() == false) || 
@@ -1264,7 +1264,7 @@ if (	(Velocity.Is_Valid() == false) ||
 	Vector3 a_dir = AngularVelocity;
 
 // DEBUG DEBUG
-#pragma message ("(gth) HACK! zeroing bad angular velocities.")
+// FIXME (gth) HACK! zeroing bad angular velocities.
 const float MAX_AVEL = 5.0f * 2.0f * WWMATH_PI;
 if (a_dir.Length2() > MAX_AVEL * MAX_AVEL) {
 	WWDEBUG_SAY(("clearing angluar velocity, model=%s avel=(%f,%f,%f)\r\n",Model->Get_Name(),AngularVelocity.X,AngularVelocity.Y,AngularVelocity.Z));


### PR DESCRIPTION
Disables the noisy message pragmas and fixes warnings related to enums being used in floating point equations which was deprecated in C++20.