### PR TITLE
chore(warn): Fix warning C4309.

### DIFF
--- a/Code/Tools/LevelEdit/ScriptEditDialog.cpp
+++ b/Code/Tools/LevelEdit/ScriptEditDialog.cpp
@@ -133,7 +133,7 @@ ScriptEditDialogClass::OnInitDialog (void)
 	m_ValueNumberEdit.SetWindowPos (NULL, rect.left, rect.top, rect.Width (), rect.Height (), SWP_NOZORDER);
 	m_ValueListCombo.SetWindowPos (NULL, rect.left, rect.top, rect.Width (), rect.Height () * 10, SWP_NOZORDER);
 	m_ValueBoolCheck.SetWindowPos (NULL, rect.left, rect.top, rect.Width (), rect.Height (), SWP_NOZORDER);
-	m_ValueNumberSpin.SetRange (-1000000, 1000000);
+	m_ValueNumberSpin.SetRange32 (-1000000, 1000000);
 	m_ValueNumberSpin.SetBuddy (&m_ValueNumberEdit);
 
 	//

--- a/Code/Tools/W3DView/SceneLightDialog.cpp
+++ b/Code/Tools/W3DView/SceneLightDialog.cpp
@@ -154,11 +154,11 @@ CSceneLightDialog::OnInitDialog (void)
 		::SetDlgItemFloat (m_hWnd, IDC_DISTANCE_EDIT, distance);
 		
 		// Set-up the spin controls
-		m_DistanceSpin.SetRange (0, 1000000L);
+		m_DistanceSpin.SetRange32 (0, 1000000);
 		m_DistanceSpin.SetPos ((distance * 100));
-		m_StartAttenSpin.SetRange (0, 1000000L);
+		m_StartAttenSpin.SetRange32 (0, 1000000);
 		m_StartAttenSpin.SetPos ((start * 100));
-		m_EndAttenSpin.SetRange (0, 1000000L);
+		m_EndAttenSpin.SetRange32 (0, 1000000);
 		m_EndAttenSpin.SetPos ((end * 100));
 
 		// Setup the slider control


### PR DESCRIPTION
MFC function changed where original call didn't accept values in the provided range.
This fixes C4305 warnings on the same lines as well.