### PR TITLE
Fixes warning C4930.

### DIFF
--- a/Code/Tools/LevelEdit/MainFrm.cpp
+++ b/Code/Tools/LevelEdit/MainFrm.cpp
@@ -5226,7 +5226,7 @@ CMainFrame::OnUpdateEnableVisSectorFallback(CCmdUI* pCmdUI)
 void
 CMainFrame::OnRunManualVisPoints (void)
 {
-	CWaitCursor wait_cursor ();
+	CWaitCursor wait_cursor;
 
 	VisMgrClass::Render_Manual_Vis_Points ();
 	return ;


### PR DESCRIPTION
Looks like unintended typo creating a function prototype rather than a variable based on other instances in the file.