### PR TITLE
Fix MSVC warning c4032.

### DIFF
--- a/Code/Tools/W3DView/GraphicView.cpp
+++ b/Code/Tools/W3DView/GraphicView.cpp
@@ -764,7 +764,7 @@ CGraphicView::OnLButtonUp
     }
     else
     {
-        ::SetCursor (::LoadCursor (NULL, MAKEINTRESOURCE (IDC_ARROW)));
+        ::SetCursor (::LoadCursor (NULL, IDC_ARROW));
 		  ((CW3DViewDoc *)GetDocument())->Set_Cursor ("cursor.tga");
     }
 
@@ -1325,7 +1325,7 @@ CGraphicView::OnRButtonUp
 	if (m_bMouseDown) {
 		((CW3DViewDoc *)GetDocument())->Set_Cursor ("orbit.tga");		
 	} else {
-		::SetCursor (::LoadCursor (NULL, MAKEINTRESOURCE (IDC_ARROW)));
+		::SetCursor (::LoadCursor (NULL, IDC_ARROW));
 		((CW3DViewDoc *)GetDocument())->Set_Cursor ("cursor.tga");
 		ReleaseCapture ();
 	}


### PR DESCRIPTION
Some resource macros have MAKEINTRESOURCE baked into them and it was being invoked twice leading to narrowing cast warnings.