### PR TITLE
Fix MSVC warning C4996.

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -10,6 +10,7 @@ target_compile_definitions(wwcommon INTERFACE
     _WIN32_WINNT=0x501
     _CRT_NONSTDC_NO_WARNINGS
     _CRT_SECURE_NO_WARNINGS
+    _WINSOCK_DEPRECATED_NO_WARNINGS
     $<$<CONFIG:Debug>:WWDEBUG>
 )
 

--- a/Code/Commando/FirewallWait.cpp
+++ b/Code/Commando/FirewallWait.cpp
@@ -244,7 +244,7 @@ WaitCondition::WaitResult FirewallConnectWait::GetResult(void)
 				if (mQueueCount != mLastQueueCount)
 					{
 					wchar_t temp[256];
-					swprintf(temp, TRANSLATION(IDS_FIREWALL_QUEUE_NOTIFICATION), mQueueCount);
+					swprintf(temp, sizeof(temp), TRANSLATION(IDS_FIREWALL_QUEUE_NOTIFICATION), mQueueCount);
 					WideStringClass text(temp, true);
 					SetWaitText(text);
 					mLastQueueCount = mQueueCount;

--- a/Code/Commando/bandwidthcheck.cpp
+++ b/Code/Commando/bandwidthcheck.cpp
@@ -700,7 +700,7 @@ const wchar_t *BandwidthCheckerClass::Get_Bandwidth_As_String(void)
 
 	if (cUserOptions::Get_Bandwidth_Type() == BANDWIDTH_AUTO) {
 		static wchar_t _build_string[256];
-		swprintf(_build_string, L"%s,%s", DownstreamBandwidthString, UpstreamBandwidthString);
+		swprintf(_build_string, sizeof(_build_string), L"%s,%s", DownstreamBandwidthString, UpstreamBandwidthString);
 		return(_build_string);
 	} else {
 		return((wchar_t*)cBandwidth::Get_Bandwidth_String_From_Type(
@@ -730,7 +730,7 @@ const wchar_t *BandwidthCheckerClass::Get_Bandwidth_As_String(PackedBandwidthTyp
 	assert(bandwidth.Bandwidth.Up < NUM_BANDS + 1);
 	assert(bandwidth.Bandwidth.Down < NUM_BANDS + 1);
 
-	swprintf(_build_string, L"%s,%s", BandwidthNames[bandwidth.Bandwidth.Down], BandwidthNames[bandwidth.Bandwidth.Up]);
+	swprintf(_build_string, sizeof(_build_string), L"%s,%s", BandwidthNames[bandwidth.Bandwidth.Down], BandwidthNames[bandwidth.Bandwidth.Up]);
 	return(_build_string);
 }
 

--- a/Code/Commando/dlgmpwolbuddies.cpp
+++ b/Code/Commando/dlgmpwolbuddies.cpp
@@ -323,16 +323,16 @@ void MPWolBuddiesMenuClass::Update_Buddy_Ranking(int index, const RefPtr<WWOnlin
 		if (ladder.IsValid()) {
 			wchar_t text[64];
 
-			swprintf(text, L"%d", ladder->GetWins());
+			swprintf(text, sizeof(text), L"%d", ladder->GetWins());
 			list->Set_Entry_Text(index, COL_WINS, text);
 
-			swprintf(text, L"%d / %d", ladder->GetReserved1(), ladder->GetKills());
+			swprintf(text, sizeof(text), L"%d / %d", ladder->GetReserved1(), ladder->GetKills());
 			list->Set_Entry_Text(index, COL_DEATHS, text);
 
-			swprintf(text, L"%d", ladder->GetPoints());
+			swprintf(text, sizeof(text), L"%d", ladder->GetPoints());
 			list->Set_Entry_Text(index, COL_POINTS, text);
 
-			swprintf(text, L"%d", ladder->GetRung());
+			swprintf(text, sizeof(text), L"%d", ladder->GetRung());
 			list->Set_Entry_Text(index, COL_RANK, text);
 		} else {
 			list->Set_Entry_Text(index, COL_WINS, L"-");

--- a/Code/Tests/PhysTest/PhysTest.cpp
+++ b/Code/Tests/PhysTest/PhysTest.cpp
@@ -162,12 +162,6 @@ BOOL CPhysTestApp::InitInstance()
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	// Is there already an instance of the viewer running?
 	HWND hprev_instance = NULL;
 	::EnumWindows (fnTopLevelWindowSearch, (LPARAM)&hprev_instance);

--- a/Code/Tests/SplineTest/SplineTest.cpp
+++ b/Code/Tests/SplineTest/SplineTest.cpp
@@ -72,12 +72,6 @@ BOOL CSplineTestApp::InitInstance()
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	// Change the registry key under which our settings are stored.
 	// TODO: You should modify this string to be something appropriate
 	// such as the name of your company or organization.

--- a/Code/Tools/ChunkView/ChunkView.cpp
+++ b/Code/Tools/ChunkView/ChunkView.cpp
@@ -91,12 +91,6 @@ BOOL CChunkViewApp::InitInstance()
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	// Change the registry key under which our settings are stored.
 	// TODO: You should modify this string to be something appropriate
 	// such as the name of your company or organization.

--- a/Code/Tools/CommandoUpdate/CommandoUpdate.cpp
+++ b/Code/Tools/CommandoUpdate/CommandoUpdate.cpp
@@ -64,12 +64,6 @@ BOOL CCommandoUpdateApp::InitInstance()
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	CCommandoUpdateDlg dlg;
 	m_pMainWnd = &dlg;
 	int nResponse = dlg.DoModal();

--- a/Code/Tools/CopyLocked/CopyLocked.cpp
+++ b/Code/Tools/CopyLocked/CopyLocked.cpp
@@ -64,12 +64,6 @@ BOOL CCopyLockedApp::InitInstance()
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	CCopyLockedDlg dlg;
 	m_pMainWnd = &dlg;
 	int nResponse = dlg.DoModal();

--- a/Code/Tools/LevelEdit/LevelEdit.cpp
+++ b/Code/Tools/LevelEdit/LevelEdit.cpp
@@ -199,12 +199,6 @@ CLevelEditApp::InitInstance (void)
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	RegisterColorPicker (::AfxGetInstanceHandle ());
 	RegisterColorBar (::AfxGetInstanceHandle ());
 

--- a/Code/Tools/LightMap/LightMap.cpp
+++ b/Code/Tools/LightMap/LightMap.cpp
@@ -152,12 +152,6 @@ BOOL LightMapApp::InitInstance()
 	// of your final executable, you should remove from the following
 	// specific initialization routines you do not need.
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	Do_Version_Check();
 
 	// Set the working path. 

--- a/Code/Tools/MixViewer/MixViewer.cpp
+++ b/Code/Tools/MixViewer/MixViewer.cpp
@@ -72,12 +72,6 @@ BOOL CMixViewerApp::InitInstance()
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	// Change the registry key under which our settings are stored.
 	// TODO: You should modify this string to be something appropriate
 	// such as the name of your company or organization.

--- a/Code/Tools/SimpleGraph/SimpleGraph.cpp
+++ b/Code/Tools/SimpleGraph/SimpleGraph.cpp
@@ -70,12 +70,6 @@ BOOL CSimpleGraphApp::InitInstance()
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	// Change the registry key under which our settings are stored.
 	// TODO: You should modify this string to be something appropriate
 	// such as the name of your company or organization.

--- a/Code/Tools/W3DUpdate/W3DUpdate.cpp
+++ b/Code/Tools/W3DUpdate/W3DUpdate.cpp
@@ -64,12 +64,6 @@ BOOL CW3DUpdateApp::InitInstance()
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	CW3DUpdateDlg dlg;
 	m_pMainWnd = &dlg;
 	int nResponse = dlg.DoModal();

--- a/Code/Tools/W3DView/Utils.cpp
+++ b/Code/Tools/W3DView/Utils.cpp
@@ -827,52 +827,6 @@ Get_File_Time
 	return retval;
 }
 
-
-////////////////////////////////////////////////////////////////////////////
-//
-//  Are_Glide_Drivers_Acceptable
-//
-bool
-Are_Glide_Drivers_Acceptable (void)
-{
-	// Assume success
-	bool retval = true;
-
-	// Is this windows NT?
-	OSVERSIONINFO version = { sizeof (OSVERSIONINFO), 0 };
-	if (::GetVersionEx (&version) && (version.dwPlatformId == VER_PLATFORM_WIN32_NT)) {
-		
-		// Now assume failure
-		retval = false;
-
-		// Get a path to the system directory
-		TCHAR path[MAX_PATH];
-		::GetSystemDirectory (path, sizeof (path));
-		::Delimit_Path (path);
-
-		// Build the full path of the 2 main drivers
-		CString glide2x = CString (path) + "glide2x.dll";
-		CString glide3x = CString (path) + "glide3x.dll";
-
-		// Get the creation time of the glide2x driver
-		FILETIME file_time = { 0 };
-		if (::Get_File_Time (glide2x, NULL, NULL, &file_time)) {
-			CTime time_obj (file_time);
-			retval = ((time_obj.GetYear () == 1998) && (time_obj.GetMonth () == 12)) || (time_obj.GetYear () > 1998);
-		}
-
-		// Get the creation time of the glide3x driver
-		if (::Get_File_Time (glide3x, NULL, NULL, &file_time)) {
-			CTime time_obj (file_time);
-			retval = ((time_obj.GetYear () == 1998) && (time_obj.GetMonth () == 12)) || (time_obj.GetYear () > 1998);
-		}
-	}
-	
-	// Return the true/false result code
-	return retval;
-}
-
-
 ////////////////////////////////////////////////////////////////////////////
 //
 //  Load_RC_Texture

--- a/Code/Tools/W3DView/Utils.h
+++ b/Code/Tools/W3DView/Utils.h
@@ -146,7 +146,6 @@ CString					Filename_From_Asset_Name (LPCTSTR asset_name);
 //	File routines
 //
 bool						Get_File_Time (LPCTSTR path, LPFILETIME pcreation_time, LPFILETIME paccess_time = NULL, LPFILETIME pwrite_time = NULL);
-bool						Are_Glide_Drivers_Acceptable (void);
 bool						Copy_File (LPCTSTR existing_filename, LPCTSTR new_filename, bool bforce_copy = false);
 
 //

--- a/Code/Tools/W3DView/W3DView.cpp
+++ b/Code/Tools/W3DView/W3DView.cpp
@@ -166,12 +166,6 @@ BOOL CW3DViewApp::InitInstance (void)
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	Do_Version_Check ();
 
 	RegisterColorPicker (::AfxGetInstanceHandle ());

--- a/Code/Tools/WWConfig/WWConfig.cpp
+++ b/Code/Tools/WWConfig/WWConfig.cpp
@@ -80,12 +80,6 @@ BOOL CWWConfigApp::InitInstance()
 	//	the specific initialization routines you do not need.
 	//-------------------------------------------------------------------------
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	//-------------------------------------------------------------------------
 	// Get the Command line parameters.
 	//-------------------------------------------------------------------------

--- a/Code/Tools/vidinit/vidinit.cpp
+++ b/Code/Tools/vidinit/vidinit.cpp
@@ -64,12 +64,6 @@ BOOL CVidinitApp::InitInstance()
 	// If you are not using these features and wish to reduce the size
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
-
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
 				 
 	CVidinitDlg dlg(NULL);
 	m_pMainWnd = &dlg;

--- a/Code/Tools/wdump/wdump.cpp
+++ b/Code/Tools/wdump/wdump.cpp
@@ -98,12 +98,6 @@ BOOL CWdumpApp::InitInstance()
 	//  of your final executable, you should remove from the following
 	//  the specific initialization routines you do not need.
 
-#ifdef _AFXDLL
-	Enable3dControls();			// Call this when using MFC in a shared DLL
-#else
-	Enable3dControlsStatic();	// Call this when linking to MFC statically
-#endif
-
 	// Change the registry key under which our settings are stored.
 	// You should modify this string to be something appropriate
 	// such as the name of your company or organization.

--- a/Code/wwui/IMEManager.cpp
+++ b/Code/wwui/IMEManager.cpp
@@ -184,14 +184,9 @@ bool IMEManager::FinalizeCreate(HWND hwnd)
 
 	mHWND = hwnd;
 
-	// Check the OS version, if Win98 or better then we can use unicode
-	OSVERSIONINFO osvi;
-	osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-	GetVersionEx(&osvi);
-
-	bool isWin98orLater = (osvi.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS) && ((osvi.dwMajorVersion > 4) || ((osvi.dwMajorVersion == 4) && (osvi.dwMinorVersion >= 10)));
-	bool isNT4orLater = (osvi.dwPlatformId == VER_PLATFORM_WIN32_NT) && ((osvi.dwMajorVersion > 4) || ((osvi.dwMajorVersion == 4) && (osvi.dwMinorVersion >= 0)));
-	mOSCanUnicode = (isWin98orLater || isNT4orLater);
+	// Assume we have at least Win98 or NT4 which is the min spec
+	// on the box for the original game anyhow.
+	mOSCanUnicode = true;
 
 	// Create new input context for the specified window.
 	mHIMC = ImmCreateContext();


### PR DESCRIPTION
Sets macro to avoid winsock deprecation warnings.
Updates calls to swprintf to use standard function signature.
Removes unneeded calls to CWinApp::Enable3dControls.
Refactors calls to deprecated GetVersionEx.