### PR TITLE
argv is owned and freed by WinMain in winmain_compat.h

### DIFF
--- a/Code/Commando/WINMAIN.CPP
+++ b/Code/Commando/WINMAIN.CPP
@@ -205,7 +205,6 @@ int main(int argc, char *argv[])
 		cUserOptions::Print_Command_Line_Help(false);
 		return 0;
 	}
-	LocalFree(argv);
 
 #ifdef _DEBUG // Denzil - DO NOT COMPILE INTO FINAL BUILD
 	bool webInstalled = WebBrowser::InstallPrerequisites();


### PR DESCRIPTION
This fixes a segmentation fault when exiting the game.