### PR TITLE
Ensure null terminator character after strncpy

### DIFF
--- a/Code/ww3d2/agg_def.cpp
+++ b/Code/ww3d2/agg_def.cpp
@@ -387,7 +387,8 @@ AggregateDefClass::Initialize (RenderObjClass &base_model)
 	orig_model_name = (orig_model_name == NULL) ? base_model.Get_Name () : orig_model_name;
 
 	// Record information about this base model
-	::strcpy (m_Info.BaseModelName, orig_model_name);
+	::strncpy (m_Info.BaseModelName, orig_model_name, sizeof (m_Info.BaseModelName) - 1);
+	m_Info.BaseModelName[sizeof (m_Info.BaseModelName) - 1] = '\0';
 	m_Info.SubobjectCount = 0;
 	m_MiscInfo.OriginalClassID = base_model.Class_ID ();
 	m_MiscInfo.Flags = 0;	
@@ -467,8 +468,10 @@ AggregateDefClass::Build_Subobject_List
 					 (Is_Object_In_List (prototype_name, orig_node_list) == false)) {
 					
 					// Add this subobject to our list
-					::strcpy (subobj_info.SubobjectName, prototype_name);
-					::strcpy (subobj_info.BoneName, pbone_name);
+					::strncpy (subobj_info.SubobjectName, prototype_name, sizeof (subobj_info.SubobjectName));
+					subobj_info.SubobjectName[sizeof (subobj_info.SubobjectName) - 1] = '\0';
+					::strncpy (subobj_info.BoneName, pbone_name, sizeof (subobj_info.BoneName));
+					subobj_info.BoneName[sizeof (subobj_info.BoneName) - 1] = '\0';
 					Add_Subobject (subobj_info);
 					m_Info.SubobjectCount ++;
 
@@ -672,8 +675,10 @@ AggregateDefClass::Add_Subobject (const W3dAggregateSubobjectStruct &subobj_info
 {
 	// Create a new structure and copy the contents of the src
 	W3dAggregateSubobjectStruct *pnew_entry = new W3dAggregateSubobjectStruct;
-	::strcpy (pnew_entry->SubobjectName, subobj_info.SubobjectName);
-	::strcpy (pnew_entry->BoneName, subobj_info.BoneName);
+	::strncpy (pnew_entry->SubobjectName, subobj_info.SubobjectName, sizeof (pnew_entry->SubobjectName));
+	pnew_entry->SubobjectName[sizeof (pnew_entry->SubobjectName) - 1] = '\0';
+	::strncpy (pnew_entry->BoneName, subobj_info.BoneName, sizeof (pnew_entry->BoneName));
+	pnew_entry->BoneName[sizeof (pnew_entry->BoneName)] = '\0';
 
 	// Add this new entry to the list
 	m_SubobjectList.Add (pnew_entry);

--- a/Code/ww3d2/assetmgr.cpp
+++ b/Code/ww3d2/assetmgr.cpp
@@ -692,8 +692,10 @@ RenderObjClass * WW3DAssetManager::Create_Render_Obj(const char * name)
 		char filename [MAX_PATH];
 		char *mesh_name = (char *)::strchr (name, '.');
 		if (mesh_name != NULL) {
-			::strncpy (filename, name, ((int)mesh_name) - ((int)name) + 1);
-			::strcat (filename, ".w3d");
+			::strncpy (filename, name, mesh_name - name);
+			filename[mesh_name - name] = '\0';
+			::strncat (filename, ".w3d", sizeof(filename) - (mesh_name - name));
+			filename[sizeof(filename) - 1] = '\0';
 		} else {
 			sprintf( filename, "%s.w3d", name);
 		}

--- a/Code/ww3d2/part_ldr.cpp
+++ b/Code/ww3d2/part_ldr.cpp
@@ -310,7 +310,8 @@ ParticleEmitterDefClass::Set_Name (const char *pname)
 void							
 ParticleEmitterDefClass::Set_Texture_Filename (const char *pname)	
 { 
-	::strcpy (m_Info.TextureFilename, pname); 
+	::strncpy (m_Info.TextureFilename, pname, sizeof (m_Info.TextureFilename));
+	m_Info.TextureFilename[sizeof (m_Info.TextureFilename) - 1] = '\0';
 	Normalize_Filename (); 
 	return ;
 }
@@ -324,7 +325,8 @@ void
 ParticleEmitterDefClass::Normalize_Filename (void)
 {	
 	char path[MAX_PATH];
-	::strcpy (path, m_Info.TextureFilename);
+	::strncpy (path, m_Info.TextureFilename, sizeof (path));
+	path[sizeof (path) - 1] = '\0';
 
 	// Find the last occurance of the directory deliminator
 	const char* filename = ::strrchr (path, '\\');
@@ -334,7 +336,8 @@ ParticleEmitterDefClass::Normalize_Filename (void)
 		filename ++;
 
 		// Now copy the filename protion of the path to the structure
-		::strcpy (m_Info.TextureFilename, filename);
+		::strncpy (m_Info.TextureFilename, filename, sizeof (m_Info.TextureFilename));
+		m_Info.TextureFilename[sizeof (m_Info.TextureFilename) - 1] = '\0';
 	}
 
 	return ;

--- a/Code/ww3d2/soundrobj.cpp
+++ b/Code/ww3d2/soundrobj.cpp
@@ -684,7 +684,7 @@ SoundRenderObjDefClass::Write_Header (ChunkSaveClass &csave)
 		header.Version	= W3D_CURRENT_AGGREGATE_VERSION;
 		header.Flags	= Flags;
 		::strncpy (header.Name, (const char *)Name, sizeof (header.Name));
-		header.Name[sizeof (header.Name) - 1] = 0;
+		header.Name[sizeof (header.Name) - 1] = '\0';
 
 		//
 		// Write the header out to the chunk


### PR DESCRIPTION
This fixes a missing null terminator introduced by 7463ef3b78f in Code/ww3d2/assetmgr.cpp

The lstrcpy (and strlcpy) family of functions ensure a terminating null character, whereas ordinary strcpy does not.

Fixes #50
