### PR TITLE
Bump CMake version so preset debug settings respected.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.24)
+cmake_minimum_required(VERSION 3.25...4.0)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 


### PR DESCRIPTION
Bumps the CMake version to 3.25 min. This will allow adjusting the format used for generating debug information on MSVC which was set in the presets but ignored. Release built with the presets will now have debug information in addition to Debug.