### PR TITLE
Implement FFMpeg based bink decoding part 1.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,10 @@ if(SYNTAX_CHECK_ONLY)
     add_compile_options("-fsyntax-only")
 endif(SYNTAX_CHECK_ONLY)
 
+# Do we want to build with ffmpeg for audio/video decoding?
+option(W3D_BUILD_OPTION_FFMPEG "Build with ffmpeg." OFF)
+add_feature_info(FFMpegBuild W3D_BUILD_OPTION_FFMPEG "Build Renegade with FFMpeg")
+
 if(NOT WIN32)
     add_compile_definitions(__cdecl=)
     add_compile_definitions(__stdcall=)
@@ -44,11 +48,24 @@ endif()
 
 include(FetchContent)
 
+if(W3D_BUILD_OPTION_FFMPEG)
+    include(cmake/ffmpeg.cmake)
+endif()
+
 # Find/Add build dependencies and stubs.
 # Only 32bit Windows can make use of these APIs as the libraries shipped with the game.
 if(WIN32)
     include(cmake/miles.cmake)
+    
+    # Do we want to build with bink for video decoding?
+    option(W3D_BUILD_OPTION_BINK "Build with bink." ON)
+    add_feature_info(BinkBuild W3D_BUILD_OPTION_BINK "Build Renegade with Bink")
+    
+    if(W3D_BUILD_OPTION_BINK)
     include(cmake/bink.cmake)
+        target_compile_definitions(binkstub INTERFACE W3D_HAS_BINK)
+    endif()
+    
     include(cmake/dx9.cmake)
 endif()
 

--- a/Code/BinkMovie/BINKMovie.cpp
+++ b/Code/BinkMovie/BINKMovie.cpp
@@ -16,71 +16,41 @@
 **	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "BINKMovie.h"
-#include "dx8wrapper.h"
-#include "formconv.h"
-#include "render2d.h"
-#include "bink.h"
-#include "rect.h"
-#include "subtitlemanager.h"
-#include "dx8caps.h"
+#include "binkmovie.h"
+#include "NullMoviePlayer.h"
 
-class BINKMovieClass
-{
-	private:
-		StringClass Filename;
-		HBINK Bink;
-		bool FrameChanged;
-		unsigned TextureCount;
-		unsigned long TicksPerFrame;
+#if defined W3D_HAS_FFMPEG
+#include "FFMpegPlayer.h"
+#endif
 
-		struct TextureInfoStruct {
-			TextureClass* Texture;
-			int TextureWidth;
-			int TextureHeight;
-			int TextureLocX;
-			int TextureLocY;
-			RectClass UV;
-			RectClass Rect;
-		};
+#if defined W3D_HAS_BINK
+#include "BinkPlayer.h"
+#endif
 
-		TextureInfoStruct* TextureInfos;
-		unsigned char* TempBuffer;
-		Render2DClass Renderer;
-		SubTitleManagerClass* SubTitleManager;
-
-	public:
-		BINKMovieClass(const char* filename,const char* subtitlename,FontCharsClass* font);
-		~BINKMovieClass();
-
-		void Update();
-		void Render();
-		bool Is_Complete();
-};
-
-
-static BINKMovieClass* CurrentMovie;
-
+static MovieClass* CurrentMovie;
 
 void BINKMovie::Play(const char* filename,const char* subtitlename, FontCharsClass* font)
 {
 	if (CurrentMovie) {
 		delete CurrentMovie;
-		CurrentMovie = NULL;
+		CurrentMovie = nullptr;
 	}
-
+#if defined W3D_HAS_FFMPEG
+	CurrentMovie = new FFMpegMovieClass(filename,subtitlename,font);
+#elif defined W3D_HAS_BINK
 	CurrentMovie = new BINKMovieClass(filename,subtitlename,font);
+#else
+	CurrentMovie = new NullMovieClass(filename,subtitlename,font);
+#endif
 }
-
 
 void BINKMovie::Stop()
 {
 	if (CurrentMovie) {
 		delete CurrentMovie;
-		CurrentMovie = NULL;
+		CurrentMovie = nullptr;
 	}
 }
-
 
 void BINKMovie::Update()
 {
@@ -89,7 +59,6 @@ void BINKMovie::Update()
 	}
 }
 
-
 void BINKMovie::Render()
 {
 	if (CurrentMovie) {
@@ -97,18 +66,17 @@ void BINKMovie::Render()
 	}
 }
 
-
 void BINKMovie::Init()
 {
+#ifdef W3D_HAS_BINK
 	BinkSoundUseDirectSound(0);
+#endif
 }
-
 
 void BINKMovie::Shutdown()
 {
 	Stop();
 }
-
 
 bool BINKMovie::Is_Complete()
 {
@@ -118,241 +86,3 @@ bool BINKMovie::Is_Complete()
 
 	return true;
 }
-
-
-// ----------------------------------------------------------------------------
-
-BINKMovieClass::BINKMovieClass(const char* filename, const char* subtitlename, FontCharsClass* font)
-	:
-	Filename(filename),
-	Bink(0),
-	FrameChanged(true),
-	TicksPerFrame(0),
-	SubTitleManager(NULL)
-{
-	Bink = BinkOpen(Filename, 0);
-
-	if (Bink == NULL) {
-		return;
-	}
-
-	TempBuffer = new unsigned char[Bink->Width * Bink->Height*2];
-
-	const D3DCAPS9& dx8caps = DX8Wrapper::Get_Current_Caps()->Get_DX8_Caps();
-	unsigned poweroftwowidth = 1;
-
-	while (poweroftwowidth < Bink->Width) {
-		poweroftwowidth <<= 1;
-	}
-
-	unsigned poweroftwoheight = 1;
-	
-	while (poweroftwoheight < Bink->Height) {
-		poweroftwoheight <<= 1;
-	}
-
-	if (poweroftwowidth > dx8caps.MaxTextureWidth) {
-		poweroftwowidth = dx8caps.MaxTextureWidth;
-	}
-	
-	if (poweroftwoheight > dx8caps.MaxTextureHeight) {
-		poweroftwoheight = dx8caps.MaxTextureHeight;
-	}
-
-	TextureCount = 0;
-	unsigned max_width = poweroftwowidth;
-	unsigned max_height = poweroftwoheight;
-	unsigned x, y;
-
-	for (y = 0; y < Bink->Height; y += max_height-2) {		// Two pixels are lost due to duplicated edges to prevent bilinear artifacts
-		for (x = 0; x < Bink->Width; x += max_width-2) {
-			++TextureCount;
-		}
-	}
-
-	TextureInfos = new TextureInfoStruct[TextureCount];
-	unsigned cnt = 0;
-	
-	for (y = 0; y < Bink->Height; y += max_height-1) {
-		for (x = 0; x < Bink->Width; x += max_width-1) {
-			TextureInfos[cnt].Texture = new TextureClass(
-				max_width, max_height, D3DFormat_To_WW3DFormat(D3DFMT_R5G6B5),
-				TextureClass::MIP_LEVELS_1, TextureClass::POOL_MANAGED, false);
-
-			TextureInfos[cnt].TextureLocX = x;
-			TextureInfos[cnt].TextureLocY = y;
-			TextureInfos[cnt].TextureWidth = max_width;
-			TextureInfos[cnt].UV.Right = float(max_width) / float(max_width);
-
-			if ((TextureInfos[cnt].TextureWidth + x) > Bink->Width) {
-				TextureInfos[cnt].TextureWidth = Bink->Width - x;
-				TextureInfos[cnt].UV.Right = float(TextureInfos[cnt].TextureWidth - 1) / float(max_width);
-			}
-
-			TextureInfos[cnt].TextureHeight = max_height;
-			TextureInfos[cnt].UV.Bottom = float(max_height) / float(max_height);
-
-			if ((TextureInfos[cnt].TextureHeight + y) > Bink->Height) {
-				TextureInfos[cnt].TextureHeight = Bink->Height - y;
-				TextureInfos[cnt].UV.Bottom = float(TextureInfos[cnt].TextureHeight + 1) / float(max_height);
-			}
-
-			TextureInfos[cnt].UV.Left = 1.0f / float(max_width);
-			TextureInfos[cnt].UV.Top = 1.0f / float(max_height);
-
-			TextureInfos[cnt].Rect.Left = float(TextureInfos[cnt].TextureLocX) / float(Bink->Width);
-			TextureInfos[cnt].Rect.Top = float(TextureInfos[cnt].TextureLocY) / float(Bink->Height);
-			TextureInfos[cnt].Rect.Right = float(TextureInfos[cnt].TextureLocX + TextureInfos[cnt].TextureWidth) / float(Bink->Width);
-			TextureInfos[cnt].Rect.Bottom = float(TextureInfos[cnt].TextureLocY + TextureInfos[cnt].TextureHeight) / float(Bink->Height);
-
-			++cnt;
-		}
-	}
-
-	Renderer.Reset();
-
-	// Calculate the time per frame of video
-	unsigned int rate = (Bink->FrameRate / Bink->FrameRateDiv);
-	TicksPerFrame = (60 / rate);
-
-	if (subtitlename && font) {
-		SubTitleManager = SubTitleManagerClass::Create(filename, subtitlename, font);
-	}
-}
-
-
-BINKMovieClass::~BINKMovieClass()
-{
-	if (Bink == NULL) {
-		return;
-	}
-
-	if (Bink) {
-		BinkClose(Bink);
-	}
-
-	delete[] TempBuffer;
-
-	if (TextureInfos) {
-		for (unsigned t = 0; t < TextureCount; ++t) {
-			REF_PTR_RELEASE(TextureInfos[t].Texture);
-		}
-
-		delete[] TextureInfos;
-	}
-
-	if (SubTitleManager) {
-		delete SubTitleManager;
-	}
-}
-
-
-void BINKMovieClass::Update()
-{
-	if (!Bink) {
-		return;
-	}
-
-	FrameChanged |= !BinkWait(Bink);
-}
-
-
-static unsigned char* Get_Tex_Address(unsigned char* buffer, int x, int y, int w, int h)
-{
-	if (x < 0) {
-		x = 0;
-	} else if (x >= w) {
-		x = w - 1;
-	}
-
-	if (y < 0) {
-		y = 0;
-	} else if (y >= h) {
-		y = h - 1;
-	}
-
-	return buffer + x * 2 + y * 2 * w;
-}
-
-
-void BINKMovieClass::Render()
-{
-	if (!Bink) {
-		return;
-	}
-
-	// decompress a frame
-	if (FrameChanged) {
-		BinkDoFrame(Bink);
-		FrameChanged = false;
-
-		BinkCopyToBuffer(Bink, TempBuffer, Bink->Width * 2, Bink->Height, 0, 0, BINKSURFACE565|BINKCOPYNOSCALING);
-
-		for (unsigned t = 0; t < TextureCount; ++t) {
-			IDirect3DTexture9* d3d_texture = TextureInfos[t].Texture->Peek_DX8_Texture();
-
-			if (d3d_texture) {
-				unsigned char* cur_tex_ptr = Get_Tex_Address(TempBuffer, TextureInfos[t].TextureLocX,
-					TextureInfos[t].TextureLocY, Bink->Width, Bink->Height);
-
-				unsigned w = TextureInfos[t].TextureWidth;
-				unsigned h = TextureInfos[t].TextureHeight;
-
-				if (w > Bink->Width-TextureInfos[t].TextureLocX) {
-					w = Bink->Width-TextureInfos[t].TextureLocX;
-				}
-
-				if (h > Bink->Height-TextureInfos[t].TextureLocY) {
-					h = Bink->Height-TextureInfos[t].TextureLocY;
-				}
-
-				D3DSURFACE_DESC d3d_surf_desc;
-				D3DLOCKED_RECT locked_rect;
-
-				DX8_ErrorCode(d3d_texture->GetLevelDesc(0, &d3d_surf_desc));
-
-				RECT rect;
-				rect.left = 0;
-				rect.top = 0;
-				rect.right = w;
-				rect.bottom = h;
-				DX8_ErrorCode(d3d_texture->LockRect(0,&locked_rect,&rect,0));
-
-				for (unsigned y = 0; y < h; ++y) {
-					unsigned char* dest = (unsigned char*)locked_rect.pBits + y * locked_rect.Pitch;
-					memcpy(dest, cur_tex_ptr, w * 2);
-					cur_tex_ptr += Bink->Width * 2;
-				}
-
-				DX8_ErrorCode(d3d_texture->UnlockRect(0));
-			}
-		}
-
-		if (Bink->FrameNum < Bink->Frames) // goto the next if not on the last
-			BinkNextFrame(Bink);
-	}
-
-	for (unsigned t = 0; t < TextureCount; ++t) {
-		Renderer.Reset();
-		Renderer.Set_Texture(TextureInfos[t].Texture);
-		Renderer.Set_Coordinate_Range(RectClass(0.0f, 0.0f, 1.0f, 1.0f));//Bink->Width,Bink->Height));
-
-		RectClass rect(TextureInfos[t].TextureLocX, TextureInfos[t].TextureLocY, TextureInfos[t].TextureWidth, TextureInfos[t].TextureHeight);
-		Renderer.Add_Quad(TextureInfos[t].Rect, TextureInfos[t].UV, 0xffffffff);
-		Renderer.Render();
-	}
-
-	if (SubTitleManager) {
-		unsigned long movieTime = (Bink->FrameNum * TicksPerFrame);
-		SubTitleManager->Process(movieTime);
-		SubTitleManager->Render();
-	}
-}
-
-
-bool BINKMovieClass::Is_Complete()
-{
-	if (!Bink) return true;
-	return (Bink->FrameNum>=Bink->Frames);
-}
-

--- a/Code/BinkMovie/BINKMovie.h
+++ b/Code/BinkMovie/BINKMovie.h
@@ -15,20 +15,12 @@
 **	You should have received a copy of the GNU General Public License
 **	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-#if defined(_MSV_VER)
-#pragma once
-#endif
-
 #if defined(_MSC_VER)
 #pragma once
 #endif
 
 #ifndef BINKMOVIE_H
 #define BINKMOVIE_H
-
-#include "always.h"
-#include "wwstring.h"
 
 class FontCharsClass;
 
@@ -46,7 +38,7 @@ class FontCharsClass;
 class BINKMovie
 {
 public:
-	static void Play(const char* filename,const char* subtitlename=NULL, FontCharsClass* font = NULL);
+	static void Play(const char* filename,const char* subtitlename=nullptr, FontCharsClass* font = nullptr);
 	static void Stop();
 	static void Update();
 	static void Render();

--- a/Code/BinkMovie/BinkPlayer.cpp
+++ b/Code/BinkMovie/BinkPlayer.cpp
@@ -1,0 +1,268 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "BinkPlayer.h"
+#include "dx8wrapper.h"
+#include "formconv.h"
+#include "subtitlemanager.h"
+#include "ffactory.h"
+#include "wwfile.h"
+
+// This is missing from the stub SDK headers as its unused in original game code.
+#ifndef BINKFROMMEMORY
+#define BINKFROMMEMORY 0x04000000
+#endif
+
+BINKMovieClass::BINKMovieClass(const char* filename, const char* subtitlename, FontCharsClass* font)
+	:
+	Filename(filename),
+	Bink(0),
+	FrameChanged(true),
+	TicksPerFrame(0),
+	SubTitleManager(NULL)
+{
+	// Load the whole file so we can use our own file IO to access it.
+	file_auto_ptr file(_TheFileFactory, filename);
+	FileBuffer.resize(file->Size());
+	file->Read(&FileBuffer[0], file->Size());
+
+	Bink = BinkOpen(&FileBuffer[0], BINKFROMMEMORY);
+
+	if (Bink == NULL) {
+		return;
+	}
+
+	TempBuffer = new unsigned char[Bink->Width * Bink->Height*2];
+
+	const D3DCAPS9& dx8caps = DX8Wrapper::Get_Current_Caps()->Get_DX8_Caps();
+	unsigned poweroftwowidth = 1;
+
+	while (poweroftwowidth < Bink->Width) {
+		poweroftwowidth <<= 1;
+	}
+
+	unsigned poweroftwoheight = 1;
+	
+	while (poweroftwoheight < Bink->Height) {
+		poweroftwoheight <<= 1;
+	}
+
+	if (poweroftwowidth > dx8caps.MaxTextureWidth) {
+		poweroftwowidth = dx8caps.MaxTextureWidth;
+	}
+	
+	if (poweroftwoheight > dx8caps.MaxTextureHeight) {
+		poweroftwoheight = dx8caps.MaxTextureHeight;
+	}
+
+	TextureCount = 0;
+	unsigned max_width = poweroftwowidth;
+	unsigned max_height = poweroftwoheight;
+	unsigned x, y;
+
+	for (y = 0; y < Bink->Height; y += max_height-2) {		// Two pixels are lost due to duplicated edges to prevent bilinear artifacts
+		for (x = 0; x < Bink->Width; x += max_width-2) {
+			++TextureCount;
+		}
+	}
+
+	TextureInfos = new TextureInfoStruct[TextureCount];
+	unsigned cnt = 0;
+	
+	for (y = 0; y < Bink->Height; y += max_height-1) {
+		for (x = 0; x < Bink->Width; x += max_width-1) {
+			TextureInfos[cnt].Texture = new TextureClass(
+				max_width, max_height, D3DFormat_To_WW3DFormat(D3DFMT_R5G6B5),
+				TextureClass::MIP_LEVELS_1, TextureClass::POOL_MANAGED, false);
+
+			TextureInfos[cnt].TextureLocX = x;
+			TextureInfos[cnt].TextureLocY = y;
+			TextureInfos[cnt].TextureWidth = max_width;
+			TextureInfos[cnt].UV.Right = float(max_width) / float(max_width);
+
+			if ((TextureInfos[cnt].TextureWidth + x) > Bink->Width) {
+				TextureInfos[cnt].TextureWidth = Bink->Width - x;
+				TextureInfos[cnt].UV.Right = float(TextureInfos[cnt].TextureWidth - 1) / float(max_width);
+			}
+
+			TextureInfos[cnt].TextureHeight = max_height;
+			TextureInfos[cnt].UV.Bottom = float(max_height) / float(max_height);
+
+			if ((TextureInfos[cnt].TextureHeight + y) > Bink->Height) {
+				TextureInfos[cnt].TextureHeight = Bink->Height - y;
+				TextureInfos[cnt].UV.Bottom = float(TextureInfos[cnt].TextureHeight + 1) / float(max_height);
+			}
+
+			TextureInfos[cnt].UV.Left = 1.0f / float(max_width);
+			TextureInfos[cnt].UV.Top = 1.0f / float(max_height);
+
+			TextureInfos[cnt].Rect.Left = float(TextureInfos[cnt].TextureLocX) / float(Bink->Width);
+			TextureInfos[cnt].Rect.Top = float(TextureInfos[cnt].TextureLocY) / float(Bink->Height);
+			TextureInfos[cnt].Rect.Right = float(TextureInfos[cnt].TextureLocX + TextureInfos[cnt].TextureWidth) / float(Bink->Width);
+			TextureInfos[cnt].Rect.Bottom = float(TextureInfos[cnt].TextureLocY + TextureInfos[cnt].TextureHeight) / float(Bink->Height);
+
+			++cnt;
+		}
+	}
+
+	Renderer.Reset();
+
+	// Calculate the time per frame of video
+	unsigned int rate = (Bink->FrameRate / Bink->FrameRateDiv);
+	TicksPerFrame = (60 / rate);
+
+	if (subtitlename && font) {
+		SubTitleManager = SubTitleManagerClass::Create(filename, subtitlename, font);
+	}
+}
+
+
+BINKMovieClass::~BINKMovieClass()
+{
+	if (Bink == NULL) {
+		return;
+	}
+
+	if (Bink) {
+		BinkClose(Bink);
+	}
+
+	delete[] TempBuffer;
+
+	if (TextureInfos) {
+		for (unsigned t = 0; t < TextureCount; ++t) {
+			REF_PTR_RELEASE(TextureInfos[t].Texture);
+		}
+
+		delete[] TextureInfos;
+	}
+
+	if (SubTitleManager) {
+		delete SubTitleManager;
+	}
+}
+
+
+void BINKMovieClass::Update()
+{
+	if (!Bink) {
+		return;
+	}
+
+	FrameChanged |= !BinkWait(Bink);
+}
+
+
+static unsigned char* Get_Tex_Address(unsigned char* buffer, int x, int y, int w, int h)
+{
+	if (x < 0) {
+		x = 0;
+	} else if (x >= w) {
+		x = w - 1;
+	}
+
+	if (y < 0) {
+		y = 0;
+	} else if (y >= h) {
+		y = h - 1;
+	}
+
+	return buffer + x * 2 + y * 2 * w;
+}
+
+
+void BINKMovieClass::Render()
+{
+	if (!Bink) {
+		return;
+	}
+
+	// decompress a frame
+	if (FrameChanged) {
+		BinkDoFrame(Bink);
+		FrameChanged = false;
+
+		BinkCopyToBuffer(Bink, TempBuffer, Bink->Width * 2, Bink->Height, 0, 0, BINKSURFACE565|BINKCOPYNOSCALING);
+
+		for (unsigned t = 0; t < TextureCount; ++t) {
+			IDirect3DTexture9* d3d_texture = TextureInfos[t].Texture->Peek_DX8_Texture();
+
+			if (d3d_texture) {
+				unsigned char* cur_tex_ptr = Get_Tex_Address(TempBuffer, TextureInfos[t].TextureLocX,
+					TextureInfos[t].TextureLocY, Bink->Width, Bink->Height);
+
+				unsigned w = TextureInfos[t].TextureWidth;
+				unsigned h = TextureInfos[t].TextureHeight;
+
+				if (w > Bink->Width-TextureInfos[t].TextureLocX) {
+					w = Bink->Width-TextureInfos[t].TextureLocX;
+				}
+
+				if (h > Bink->Height-TextureInfos[t].TextureLocY) {
+					h = Bink->Height-TextureInfos[t].TextureLocY;
+				}
+
+				D3DSURFACE_DESC d3d_surf_desc;
+				D3DLOCKED_RECT locked_rect;
+
+				DX8_ErrorCode(d3d_texture->GetLevelDesc(0, &d3d_surf_desc));
+
+				RECT rect;
+				rect.left = 0;
+				rect.top = 0;
+				rect.right = w;
+				rect.bottom = h;
+				DX8_ErrorCode(d3d_texture->LockRect(0,&locked_rect,&rect,0));
+
+				for (unsigned y = 0; y < h; ++y) {
+					unsigned char* dest = (unsigned char*)locked_rect.pBits + y * locked_rect.Pitch;
+					memcpy(dest, cur_tex_ptr, w * 2);
+					cur_tex_ptr += Bink->Width * 2;
+				}
+
+				DX8_ErrorCode(d3d_texture->UnlockRect(0));
+			}
+		}
+
+		if (Bink->FrameNum < Bink->Frames) // goto the next if not on the last
+			BinkNextFrame(Bink);
+	}
+
+	for (unsigned t = 0; t < TextureCount; ++t) {
+		Renderer.Reset();
+		Renderer.Set_Texture(TextureInfos[t].Texture);
+		Renderer.Set_Coordinate_Range(RectClass(0.0f, 0.0f, 1.0f, 1.0f));//Bink->Width,Bink->Height));
+
+		RectClass rect(TextureInfos[t].TextureLocX, TextureInfos[t].TextureLocY, TextureInfos[t].TextureWidth, TextureInfos[t].TextureHeight);
+		Renderer.Add_Quad(TextureInfos[t].Rect, TextureInfos[t].UV, 0xffffffff);
+		Renderer.Render();
+	}
+
+	if (SubTitleManager) {
+		unsigned long movieTime = (Bink->FrameNum * TicksPerFrame);
+		SubTitleManager->Process(movieTime);
+		SubTitleManager->Render();
+	}
+}
+
+
+bool BINKMovieClass::Is_Complete()
+{
+	if (!Bink) return true;
+	return (Bink->FrameNum>=Bink->Frames);
+}

--- a/Code/BinkMovie/BinkPlayer.h
+++ b/Code/BinkMovie/BinkPlayer.h
@@ -1,0 +1,62 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include "MoviePlayer.h"
+#include "rect.h"
+#include "render2dsentence.h"
+#include "wwstring.h"
+#include <bink.h>
+#include <vector>
+
+class FontCharsClass;
+class SubTitleManagerClass;
+
+class BINKMovieClass : public MovieClass
+{
+	private:
+		StringClass Filename;
+		HBINK Bink;
+		bool FrameChanged;
+		unsigned TextureCount;
+		unsigned long TicksPerFrame;
+
+		struct TextureInfoStruct {
+			TextureClass* Texture;
+			int TextureWidth;
+			int TextureHeight;
+			int TextureLocX;
+			int TextureLocY;
+			RectClass UV;
+			RectClass Rect;
+		};
+
+		TextureInfoStruct* TextureInfos;
+		unsigned char* TempBuffer;
+		Render2DClass Renderer;
+		SubTitleManagerClass* SubTitleManager;
+		std::vector<char> FileBuffer;
+
+	public:
+		BINKMovieClass(const char* filename,const char* subtitlename,FontCharsClass* font);
+		~BINKMovieClass() override;
+
+		void Update() override;
+		void Render() override;
+		bool Is_Complete() override;
+};

--- a/Code/BinkMovie/CMakeLists.txt
+++ b/Code/BinkMovie/CMakeLists.txt
@@ -5,17 +5,35 @@ set(BINKMOVIE_SRC
     subtitlemanager.cpp
     subtitleparser.cpp
     BINKMovie.h
+    MoviePlayer.h
     subtitle.h
     subtitlemanager.h
     subtitleparser.h
 )
 
+if(W3D_BUILD_OPTION_FFMPEG)
+    list(APPEND BINKMOVIE_SRC
+        FFMpegPlayer.cpp
+        FFMpegPlayer.h
+    )
+elseif(W3D_BUILD_OPTION_BINK)
+    list(APPEND BINKMOVIE_SRC
+        BinkPlayer.cpp
+        BinkPlayer.h
+    )
+endif()
+
 # Targets to build.
 add_library(binkmovie STATIC)
 
 target_link_libraries(binkmovie PRIVATE
-    binkstub
     wwcommon
 )
+
+if(W3D_BUILD_OPTION_BINK)
+    target_link_libraries(binkmovie PRIVATE
+        binkstub
+    )
+endif()
 
 target_sources(binkmovie PRIVATE ${BINKMOVIE_SRC})

--- a/Code/BinkMovie/FFMpegPlayer.cpp
+++ b/Code/BinkMovie/FFMpegPlayer.cpp
@@ -1,0 +1,295 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 OpenW3D.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "FFMpegPlayer.h"
+#include "FFMpegFile.h"
+#include "formconv.h"
+#include "dx8wrapper.h"
+#include "subtitlemanager.h"
+#include "wwdebug.h"
+#include <chrono>
+#include <d3d9types.h>
+
+extern "C" {
+	#include <libavcodec/avcodec.h>
+	#include <libswscale/swscale.h>
+}
+
+void FFMpegMovieClass::On_Frame(AVFrame *frame, int stream_idx, int stream_type)
+{
+	if (stream_type == AVMEDIA_TYPE_VIDEO) {
+		av_frame_free(&CurrentFrame);
+		CurrentFrame = av_frame_clone(frame);
+		GotFrame = true;
+	}
+}
+
+FFMpegMovieClass::FFMpegMovieClass(const char *filename, const char *subtitlename, FontCharsClass *font) :
+	TextureCount(0),
+	TicksPerFrame(0),
+	Bink(new FFmpegFile(filename)),
+	CurrentFrame(nullptr),
+	ScalingContext(nullptr),
+	StartTime(0),
+	GotFrame(false),
+	FrameChanged(true),
+	TextureInfos(),
+	SubTitleManager(nullptr)
+{
+	if (Bink == nullptr) {
+		return;
+	}
+
+	// Can't play a movie if no video in the file.
+	if (!Bink->Has_Video()) {
+		Bink.reset();
+		return;
+	}
+
+	Bink->Set_Frame_Callback(On_Frame);
+	Bink->Set_User_Data(this);
+
+	bool good = true;
+	// Decode until we have our first video frame
+	while (good && GotFrame == false) {
+		good = Bink->Decode_Packet();
+	}
+
+	const D3DCAPS9& dx8caps = DX8Wrapper::Get_Current_Caps()->Get_DX8_Caps();
+	unsigned poweroftwowidth = 1;
+
+	while (poweroftwowidth < static_cast<unsigned>(Bink->Get_Width())) {
+		poweroftwowidth <<= 1;
+	}
+
+	unsigned poweroftwoheight = 1;
+	
+	while (poweroftwoheight < static_cast<unsigned>(Bink->Get_Height())) {
+		poweroftwoheight <<= 1;
+	}
+
+	if (poweroftwowidth > dx8caps.MaxTextureWidth) {
+		poweroftwowidth = dx8caps.MaxTextureWidth;
+	}
+	
+	if (poweroftwoheight > dx8caps.MaxTextureHeight) {
+		poweroftwoheight = dx8caps.MaxTextureHeight;
+	}
+
+	unsigned max_width = poweroftwowidth;
+	unsigned max_height = poweroftwoheight;
+	int x, y;
+
+	for (y = 0; y < Bink->Get_Height(); y += max_height-2) {		// Two pixels are lost due to duplicated edges to prevent bilinear artifacts
+		for (x = 0; x < Bink->Get_Width(); x += max_width-2) {
+			++TextureCount;
+		}
+	}
+
+	TextureInfos.resize(TextureCount);
+	unsigned cnt = 0;
+	
+	for (y = 0; y < Bink->Get_Height(); y += max_height-1) {
+		for (x = 0; x < Bink->Get_Width(); x += max_width-1) {
+			TextureInfos[cnt].Texture = new TextureClass(
+				max_width, max_height, D3DFormat_To_WW3DFormat(D3DFMT_R5G6B5),
+				TextureClass::MIP_LEVELS_1, TextureClass::POOL_MANAGED, false);
+
+			TextureInfos[cnt].TextureLocX = x;
+			TextureInfos[cnt].TextureLocY = y;
+			TextureInfos[cnt].TextureWidth = max_width;
+			TextureInfos[cnt].UV.Right = float(max_width) / float(max_width);
+
+			if ((TextureInfos[cnt].TextureWidth + x) > Bink->Get_Width()) {
+				TextureInfos[cnt].TextureWidth = Bink->Get_Width() - x;
+				TextureInfos[cnt].UV.Right = float(TextureInfos[cnt].TextureWidth - 1) / float(max_width);
+			}
+
+			TextureInfos[cnt].TextureHeight = max_height;
+			TextureInfos[cnt].UV.Bottom = float(max_height) / float(max_height);
+
+			if ((TextureInfos[cnt].TextureHeight + y) > Bink->Get_Height()) {
+				TextureInfos[cnt].TextureHeight = Bink->Get_Height() - y;
+				TextureInfos[cnt].UV.Bottom = float(TextureInfos[cnt].TextureHeight + 1) / float(max_height);
+			}
+
+			TextureInfos[cnt].UV.Left = 1.0f / float(max_width);
+			TextureInfos[cnt].UV.Top = 1.0f / float(max_height);
+
+			TextureInfos[cnt].Rect.Left = float(TextureInfos[cnt].TextureLocX) / float(Bink->Get_Width());
+			TextureInfos[cnt].Rect.Top = float(TextureInfos[cnt].TextureLocY) / float(Bink->Get_Height());
+			TextureInfos[cnt].Rect.Right = float(TextureInfos[cnt].TextureLocX + TextureInfos[cnt].TextureWidth) / float(Bink->Get_Width());
+			TextureInfos[cnt].Rect.Bottom = float(TextureInfos[cnt].TextureLocY + TextureInfos[cnt].TextureHeight) / float(Bink->Get_Height());
+
+			++cnt;
+		}
+	}
+
+	Renderer.Reset();
+
+	// Calculate the time per frame of video
+	unsigned rate = Bink->Get_Frame_Time();
+	TicksPerFrame = (60 / rate);
+	StartTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+
+	if (subtitlename && font) {
+		SubTitleManager = std::unique_ptr<SubTitleManagerClass>(SubTitleManagerClass::Create(filename, subtitlename, font));
+	}
+}
+
+FFMpegMovieClass::~FFMpegMovieClass()
+{
+	if (Bink == nullptr) {
+		return;
+	}
+
+	if (!TextureInfos.empty()) {
+		for (unsigned t = 0; t < TextureCount; ++t) {
+			REF_PTR_RELEASE(TextureInfos[t].Texture);
+		}
+	}
+}
+
+void FFMpegMovieClass::Update()
+{
+	if (Bink == nullptr) {
+		return;
+	}
+
+	if (!FrameChanged) {
+		uint64_t time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+		FrameChanged = (time - StartTime) >= Bink->Get_Frame_Time() * Bink->Get_Current_Frame();
+	}
+}
+
+void FFMpegMovieClass::Render() 
+{
+	if (Bink == nullptr) {
+		return;
+	}
+
+	if (CurrentFrame == nullptr) {
+		return;
+	}
+
+	if (CurrentFrame->data == nullptr) {
+		return;
+	}
+
+	// decompress a frame
+	if (FrameChanged) {
+		FrameChanged = false;
+
+		for (unsigned t = 0; t < TextureCount; ++t) {
+			IDirect3DTexture9* d3d_texture = TextureInfos[t].Texture->Peek_DX8_Texture();
+
+			if (d3d_texture) {
+				unsigned w = TextureInfos[t].TextureWidth;
+				unsigned h = TextureInfos[t].TextureHeight;
+
+				if (w > static_cast<unsigned>(Bink->Get_Width()-TextureInfos[t].TextureLocX)) {
+					w = Bink->Get_Width()-TextureInfos[t].TextureLocX;
+				}
+
+				if (h > static_cast<unsigned>(Bink->Get_Height()-TextureInfos[t].TextureLocY)) {
+					h = Bink->Get_Height()-TextureInfos[t].TextureLocY;
+				}
+
+				D3DSURFACE_DESC d3d_surf_desc;
+				D3DLOCKED_RECT locked_rect;
+
+				DX8_ErrorCode(d3d_texture->GetLevelDesc(0, &d3d_surf_desc));
+				AVPixelFormat dst_pix_fmt;
+				switch (d3d_surf_desc.Format) {
+					case D3DFMT_R8G8B8:
+						dst_pix_fmt = AV_PIX_FMT_RGB24;
+						break;
+					case D3DFMT_X8R8G8B8:
+						dst_pix_fmt = AV_PIX_FMT_BGR0;
+						break;
+					case D3DFMT_R5G6B5:
+						dst_pix_fmt = AV_PIX_FMT_RGB565;
+						break;
+					case D3DFMT_X1R5G5B5:
+						dst_pix_fmt = AV_PIX_FMT_RGB555;
+						break;
+					default:
+						return;
+				}
+
+				ScalingContext = sws_getCachedContext(ScalingContext,
+					Bink->Get_Width(),
+					Bink->Get_Height(),
+					static_cast<AVPixelFormat>(CurrentFrame->format),
+					w,
+					h,
+					dst_pix_fmt,
+					SWS_BICUBIC,
+					nullptr,
+					nullptr,
+					nullptr);
+
+				RECT rect;
+				rect.left = 0;
+				rect.top = 0;
+				rect.right = w;
+				rect.bottom = h;
+				DX8_ErrorCode(d3d_texture->LockRect(0,&locked_rect,&rect,0));
+				
+				int dst_strides[] = { locked_rect.Pitch };
+				uint8_t *dst_data[] = { static_cast<uint8_t *>(locked_rect.pBits) };
+				[[maybe_unused]] int result =
+					sws_scale(ScalingContext, CurrentFrame->data, CurrentFrame->linesize, 0, h, dst_data, dst_strides);
+				
+				WWASSERT_PRINT(result > 0, ("Failed to scale frame"));
+				DX8_ErrorCode(d3d_texture->UnlockRect(0));
+			}
+			GotFrame = false;
+		}
+
+		bool good = true;
+		// Decode until we have our next video frame
+		while (good && GotFrame == false) {
+			good = Bink->Decode_Packet();
+		}
+	}
+
+	for (unsigned t = 0; t < TextureCount; ++t) {
+		Renderer.Reset();
+		Renderer.Set_Texture(TextureInfos[t].Texture);
+		Renderer.Set_Coordinate_Range(RectClass(0.0f, 0.0f, 1.0f, 1.0f));//Bink->Get_Width(),Bink->Get_Height()));
+
+		RectClass rect(TextureInfos[t].TextureLocX, TextureInfos[t].TextureLocY, TextureInfos[t].TextureWidth, TextureInfos[t].TextureHeight);
+		Renderer.Add_Quad(TextureInfos[t].Rect, TextureInfos[t].UV, 0xffffffff);
+		Renderer.Render();
+	}
+
+	if (SubTitleManager) {
+		unsigned movieTime = (Bink->Get_Current_Frame() * TicksPerFrame);
+		SubTitleManager->Process(movieTime);
+		SubTitleManager->Render();
+	}
+}
+
+bool FFMpegMovieClass::Is_Complete()
+{ 
+	if (Bink == nullptr) {
+		return true;
+	}
+
+	return (Bink->Get_Current_Frame() >= Bink->Get_Num_Frames());
+}

--- a/Code/BinkMovie/FFMpegPlayer.h
+++ b/Code/BinkMovie/FFMpegPlayer.h
@@ -1,0 +1,73 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 OpenW3D.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include "MoviePlayer.h"
+#include "rect.h"
+#include "render2dsentence.h"
+#include "wwstring.h"
+#include <memory>
+#include <vector>
+
+class FontCharsClass;
+class SubTitleManagerClass;
+class FFmpegFile;
+struct AVFrame;
+struct SwsContext;
+
+class FFMpegMovieClass : public MovieClass
+{
+private:
+	unsigned TextureCount;
+	unsigned TicksPerFrame;
+	std::unique_ptr<FFmpegFile> Bink;
+	AVFrame *CurrentFrame;
+	SwsContext *ScalingContext;
+	uint64_t StartTime;
+	bool GotFrame;
+	bool FrameChanged;
+
+	struct TextureInfoStruct {
+		TextureClass* Texture;
+		int TextureWidth;
+		int TextureHeight;
+		int TextureLocX;
+		int TextureLocY;
+		RectClass UV;
+		RectClass Rect;
+	};
+
+	std::vector<TextureInfoStruct> TextureInfos;
+	Render2DClass Renderer;
+	std::unique_ptr<SubTitleManagerClass> SubTitleManager;
+	
+	void On_Frame(AVFrame *frame, int stream_idx, int stream_type);
+
+	static void On_Frame(AVFrame *frame, int stream_idx, int stream_type, void *user_data)
+	{
+		static_cast<FFMpegMovieClass*>(user_data)->On_Frame(frame, stream_idx, stream_type);
+	}
+
+public:
+	FFMpegMovieClass(const char* filename, const char* subtitlename, FontCharsClass* font);
+	~FFMpegMovieClass() override;
+
+	void Update() override;
+	void Render() override;
+	bool Is_Complete() override;
+};

--- a/Code/BinkMovie/MoviePlayer.h
+++ b/Code/BinkMovie/MoviePlayer.h
@@ -1,0 +1,28 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 OpenW3D.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+class MovieClass
+{
+	public:
+		virtual ~MovieClass() {}
+
+		virtual void Update() = 0;
+		virtual void Render() = 0;
+		virtual bool Is_Complete() = 0;
+};

--- a/Code/BinkMovie/NullMoviePlayer.h
+++ b/Code/BinkMovie/NullMoviePlayer.h
@@ -1,0 +1,33 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 OpenW3D.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include "MoviePlayer.h"
+
+class FontCharsClass;
+
+class NullMovieClass : public MovieClass
+{
+	public:
+		NullMovieClass(const char* filename, const char* subtitlename, FontCharsClass* font) {}
+		~NullMovieClass() override {}
+
+		void Update() override {}
+		void Render() override {}
+		bool Is_Complete() override { return true; }
+};

--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -47,6 +47,10 @@ target_link_libraries(wwcommon INTERFACE
     d3d9lib
 )
 
+if(TARGET ffmpeg)
+    target_link_libraries(wwcommon INTERFACE ffmpeg)
+endif()
+
 # Module static libraries
 add_subdirectory(BinkMovie)
 add_subdirectory(Combat)

--- a/Code/Commando/dlgmovieoptions.cpp
+++ b/Code/Commando/dlgmovieoptions.cpp
@@ -81,7 +81,7 @@ MovieOptionsMenuClass::On_Init_Dialog (void)
 		RegistryClass registry (APPLICATION_SUB_KEY_NAME_MOVIES);
 		if (registry.Is_Valid ()) {
 
-			const char *INTRO_MOVIE	= "DATA\\MOVIES\\R_INTRO.BIK";
+			const char *INTRO_MOVIE	= "MOVIES\\R_INTRO.BIK";
 						
 			//
 			//	Insert the renegade intro movie by default...

--- a/Code/Commando/movie.cpp
+++ b/Code/Commando/movie.cpp
@@ -47,6 +47,8 @@
 #include "specialbuilds.h"
 #include "stylemgr.h"
 #include "render2dsentence.h"
+#include "ffactory.h"
+#include "wwfile.h"
 
 enum {
 	STARTUP_MOVIE_OFF,
@@ -150,7 +152,8 @@ void	MovieGameModeClass::Start_Movie( const char * filename )
 	//
 	//	Play the movie (if it exists locally)
 	//
-	if ( ::GetFileAttributesA ( filename ) != 0xFFFFFFFF ) {
+	FileClass *file = _TheFileFactory->Get_File(filename);
+	if (file->Is_Available()) {
 		Play_Movie ( filename );
 	} else {
 
@@ -250,7 +253,7 @@ void	MovieGameModeClass::Startup_Movies( void )
 		MovieGameModeClass::Movie_Done();
 	} else {
 		MovieStartupMode = STARTUP_MOVIE_EA;
-		Start_Movie( "DATA\\MOVIES\\EA_WW.BIK" );		// Play WW/EA movie
+		Start_Movie( "MOVIES\\EA_WW.BIK" );		// Play WW/EA movie
 	}
 }
 
@@ -264,7 +267,7 @@ void	MovieGameModeClass::Movie_Done( void )
 
 	if ( MovieStartupMode == STARTUP_MOVIE_EA ) {
 		MovieStartupMode = STARTUP_MOVIE_INTRO;
-		Start_Movie( "DATA\\MOVIES\\R_INTRO.BIK" );		// Play Renegade intro movie
+		Start_Movie( "MOVIES\\R_INTRO.BIK" );		// Play Renegade intro movie
 	} else if ( MovieStartupMode == STARTUP_MOVIE_INTRO ) {
 		MovieStartupMode = STARTUP_MOVIE_OFF;
 		// Goto main menu

--- a/Code/wwlib/CMakeLists.txt
+++ b/Code/wwlib/CMakeLists.txt
@@ -204,6 +204,10 @@ set(WWLIB_SRC
     xsurface.h
 )
 
+if(TARGET ffmpeg)
+    list(APPEND WWLIB_SRC FFMpegFile.cpp FFMpegFile.h)
+endif()
+
 # Targets to build.
 add_library(wwlib STATIC)
 

--- a/Code/wwlib/FFmpegFile.cpp
+++ b/Code/wwlib/FFmpegFile.cpp
@@ -1,0 +1,398 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 TheSuperHackers
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+//////// FFmpegFile.cpp ///////////////////////////
+// Stephan Vedder, April 2025
+/////////////////////////////////////////////////
+
+#include "FFmpegFile.h"
+#include "ffactory.h"
+#include "wwdebug.h"
+#include "wwfile.h"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+}
+
+
+FFmpegFile::FFmpegFile() {}
+
+FFmpegFile::FFmpegFile(const char *file)
+{
+	Open(file);
+}
+
+FFmpegFile::~FFmpegFile()
+{
+	Close();
+}
+
+bool FFmpegFile::Open(const char *file)
+{
+	WWASSERT_PRINT(File == nullptr, ("already open"));
+	WWASSERT_PRINT(file != nullptr, ("null file pointer"));
+#ifdef WWDEBUG
+	av_log_set_level(AV_LOG_INFO);
+#endif
+
+// This is required for FFmpeg older than 4.0 -> deprecated afterwards though
+#if LIBAVFORMAT_VERSION_MAJOR < 58
+	av_register_all();
+#endif
+	Factory = _TheFileFactory;
+	File = _TheFileFactory->Get_File(file);
+	File->Open(FileClass::READ);
+
+	// FFmpeg setup
+	FmtCtx = avformat_alloc_context();
+	if (!FmtCtx) {
+		WWDEBUG_SAY(("Failed to alloc AVFormatContext"));
+		Close();
+		return false;
+	}
+
+	constexpr size_t avio_ctx_buffer_size = 0x10000;
+	uint8_t *buffer = static_cast<uint8_t *>(av_malloc(avio_ctx_buffer_size));
+	if (buffer == nullptr) {
+		WWDEBUG_SAY(("Failed to alloc AVIOContextBuffer"));
+		Close();
+		return false;
+	}
+
+	AvioCtx = avio_alloc_context(buffer, avio_ctx_buffer_size, 0, File, &Read_Packet, nullptr, nullptr);
+	if (AvioCtx == nullptr) {
+		WWDEBUG_SAY(("Failed to alloc AVIOContext"));
+		Close();
+		return false;
+	}
+
+	FmtCtx->pb = AvioCtx;
+	FmtCtx->flags |= AVFMT_FLAG_CUSTOM_IO;
+
+	int result = avformat_open_input(&FmtCtx, nullptr, nullptr, nullptr);
+	if (result < 0) {
+		char error_buffer[1024];
+		av_strerror(result, error_buffer, sizeof(error_buffer));
+		WWDEBUG_SAY(("Failed 'avformat_open_input': %s", error_buffer));
+		Close();
+		return false;
+	}
+
+	result = avformat_find_stream_info(FmtCtx, nullptr);
+	if (result < 0) {
+		char error_buffer[1024];
+		av_strerror(result, error_buffer, sizeof(error_buffer));
+		WWDEBUG_SAY(("Failed 'avformat_find_stream_info': %s", error_buffer));
+		Close();
+		return false;
+	}
+
+	Streams.resize(FmtCtx->nb_streams);
+	for (unsigned int stream_idx = 0; stream_idx < FmtCtx->nb_streams; stream_idx++) {
+		AVStream *av_stream = FmtCtx->streams[stream_idx];
+		const AVCodec *input_codec = avcodec_find_decoder(av_stream->codecpar->codec_id);
+		if (input_codec == nullptr) {
+			WWDEBUG_SAY(("Codec not supported: '%s'", avcodec_get_name(av_stream->codecpar->codec_id)));
+			Close();
+			return false;
+		}
+
+		AVCodecContext *codec_ctx = avcodec_alloc_context3(input_codec);
+		if (codec_ctx == nullptr) {
+			WWDEBUG_SAY(("Could not allocate codec context"));
+			Close();
+			return false;
+		}
+
+		result = avcodec_parameters_to_context(codec_ctx, av_stream->codecpar);
+		if (result < 0) {
+			char error_buffer[1024];
+			av_strerror(result, error_buffer, sizeof(error_buffer));
+			WWDEBUG_SAY(("Failed 'avcodec_parameters_to_context': %s", error_buffer));
+			Close();
+			return false;
+		}
+
+		result = avcodec_open2(codec_ctx, input_codec, nullptr);
+		if (result < 0) {
+			char error_buffer[1024];
+			av_strerror(result, error_buffer, sizeof(error_buffer));
+			WWDEBUG_SAY(("Failed 'avcodec_open2': %s", error_buffer));
+			Close();
+			return false;
+		}
+
+		FFmpegStream &output_stream = Streams[stream_idx];
+		output_stream.codec_ctx = codec_ctx;
+		output_stream.codec = input_codec;
+		output_stream.stream_type = input_codec->type;
+		output_stream.stream_idx = stream_idx;
+		output_stream.frame = av_frame_alloc();
+	}
+
+	Packet = av_packet_alloc();
+
+	return true;
+}
+
+/**
+ * Read an FFmpeg packet from file
+ */
+int FFmpegFile::Read_Packet(void *opaque, uint8_t *buf, int buf_size)
+{
+	FileClass *file = static_cast<FileClass *>(opaque);
+	const int read = file->Read(buf, buf_size);
+
+	// Streaming protocol requires us to return real errors - when we read less equal 0 we're at EOF
+	if (read <= 0) {
+		return AVERROR_EOF;
+	}
+
+	return read;
+}
+
+/**
+ * close all the open FFmpeg handles for an open file.
+ */
+void FFmpegFile::Close()
+{
+	if (FmtCtx != nullptr) {
+		avformat_close_input(&FmtCtx);
+	}
+
+	for (auto &stream : Streams) {
+		if (stream.codec_ctx != nullptr) {
+			avcodec_free_context(&stream.codec_ctx);
+			av_frame_free(&stream.frame);
+		}
+	}
+	Streams.clear();
+
+	if (AvioCtx != nullptr) {
+		av_freep(&AvioCtx->buffer);
+		avio_context_free(&AvioCtx);
+		AvioCtx = nullptr;
+	}
+
+	if (Packet != nullptr) {
+		av_packet_free(&Packet);
+		Packet = nullptr;
+	}
+
+	if (File != nullptr) {
+		Factory->Return_File(File);
+		File = nullptr;
+	}
+
+	if (Factory != nullptr) {
+		Factory = nullptr;
+	}
+}
+
+bool FFmpegFile::Decode_Packet()
+{
+	WWASSERT_PRINT(FmtCtx != nullptr, ("null format context"));
+	WWASSERT_PRINT(Packet != nullptr, ("null packet pointer"));
+
+	int result = av_read_frame(FmtCtx, Packet);
+	if (result == AVERROR_EOF) {
+		return false;
+	}
+
+	const int stream_idx = Packet->stream_index;
+	WWASSERT_PRINT(Streams.size() > stream_idx, ("stream index out of bounds"));
+
+	auto &stream = Streams[stream_idx];
+	AVCodecContext *codec_ctx = stream.codec_ctx;
+	result = avcodec_send_packet(codec_ctx, Packet);
+	// Check if we need more data
+	if (result == AVERROR(EAGAIN)) {
+		return true;
+	}
+
+	// Handle any other errors
+	if (result < 0) {
+		char error_buffer[1024];
+		av_strerror(result, error_buffer, sizeof(error_buffer));
+		WWDEBUG_SAY(("Failed 'avcodec_send_packet': %s", error_buffer));
+		return false;
+	}
+	av_packet_unref(Packet);
+
+	// Get all frames in this packet
+	while (result >= 0) {
+		result = avcodec_receive_frame(codec_ctx, stream.frame);
+
+		// Check if we need more data
+		if (result == AVERROR(EAGAIN)) {
+			return true;
+		}
+
+		// Handle any other errors
+		if (result < 0) {
+			char error_buffer[1024];
+			av_strerror(result, error_buffer, sizeof(error_buffer));
+			WWDEBUG_SAY(("Failed 'avcodec_receive_frame': %s", error_buffer));
+			return false;
+		}
+
+		if (FrameCallback != nullptr) {
+			FrameCallback(stream.frame, stream_idx, stream.stream_type, UserData);
+		}
+	}
+
+	return true;
+}
+
+void FFmpegFile::Seek_Frame(int frame_idx)
+{
+	// Note: not tested, since not used ingame
+	for (const auto &stream : Streams) {
+		int64_t timestamp = av_q2d(FmtCtx->streams[stream.stream_idx]->time_base) * frame_idx
+			* av_q2d(FmtCtx->streams[stream.stream_idx]->avg_frame_rate);
+		int result = av_seek_frame(FmtCtx, stream.stream_idx, timestamp, AVSEEK_FLAG_ANY);
+		if (result < 0) {
+			char error_buffer[1024];
+			av_strerror(result, error_buffer, sizeof(error_buffer));
+			WWDEBUG_SAY(("Failed 'av_seek_frame': %s", error_buffer));
+		}
+	}
+}
+
+bool FFmpegFile::Has_Audio() const
+{
+	const FFmpegStream *stream = Find_Match(AVMEDIA_TYPE_AUDIO);
+	return stream != nullptr;
+}
+
+bool FFmpegFile::Has_Video() const
+{
+	const FFmpegStream *stream = Find_Match(AVMEDIA_TYPE_VIDEO);
+	return stream != nullptr;
+}
+
+const FFmpegFile::FFmpegStream *FFmpegFile::Find_Match(int type) const
+{
+	for (auto &stream : Streams) {
+		if (stream.stream_type == type) {
+			return &stream;
+		}
+	}
+
+	return nullptr;
+}
+
+int FFmpegFile::Get_Num_Channels() const
+{
+	const FFmpegStream *stream = Find_Match(AVMEDIA_TYPE_AUDIO);
+	if (stream == nullptr) {
+		return 0;
+	}
+
+	return stream->codec_ctx->ch_layout.nb_channels;
+}
+
+int FFmpegFile::Get_Sample_Rate() const
+{
+	const FFmpegStream *stream = Find_Match(AVMEDIA_TYPE_AUDIO);
+	if (stream == nullptr) {
+		return 0;
+	}
+
+	return stream->codec_ctx->sample_rate;
+}
+
+int FFmpegFile::Get_Bytes_Per_Sample() const
+{
+	const FFmpegStream *stream = Find_Match(AVMEDIA_TYPE_AUDIO);
+	if (stream == nullptr) {
+		return 0;
+	}
+
+	return av_get_bytes_per_sample(stream->codec_ctx->sample_fmt);
+}
+
+int FFmpegFile::Get_Size_For_Samples(int numSamples) const
+{
+	const FFmpegStream *stream = Find_Match(AVMEDIA_TYPE_AUDIO);
+	if (stream == nullptr) {
+		return 0;
+	}
+
+	return av_samples_get_buffer_size(nullptr, stream->codec_ctx->ch_layout.nb_channels, numSamples, stream->codec_ctx->sample_fmt, 1);
+}
+
+int FFmpegFile::Get_Height() const
+{
+	const FFmpegStream *stream = Find_Match(AVMEDIA_TYPE_VIDEO);
+	if (stream == nullptr) {
+		return 0;
+	}
+
+	return stream->codec_ctx->height;
+}
+
+int FFmpegFile::Get_Width() const
+{
+	const FFmpegStream *stream = Find_Match(AVMEDIA_TYPE_VIDEO);
+	if (stream == nullptr) {
+		return 0;
+	}
+
+	return stream->codec_ctx->width;
+}
+
+int FFmpegFile::Get_Num_Frames() const
+{
+	const FFmpegStream *stream = Find_Match(AVMEDIA_TYPE_VIDEO);
+	if (FmtCtx == nullptr || stream == nullptr || FmtCtx->streams[stream->stream_idx] == nullptr) {
+		return 0;
+	}
+
+	return (FmtCtx->duration / (double)AV_TIME_BASE) * av_q2d(FmtCtx->streams[stream->stream_idx]->avg_frame_rate);
+}
+
+int FFmpegFile::Get_Current_Frame() const
+{
+	const FFmpegStream *stream = Find_Match(AVMEDIA_TYPE_VIDEO);
+	if (stream == nullptr) {
+		return 0;
+	}
+
+	return stream->codec_ctx->frame_num;
+}
+
+int FFmpegFile::Get_Pixel_Format() const
+{
+	const FFmpegStream *stream = Find_Match(AVMEDIA_TYPE_VIDEO);
+	if (stream == nullptr) {
+		return AV_PIX_FMT_NONE;
+	}
+
+	return stream->codec_ctx->pix_fmt;
+}
+
+unsigned FFmpegFile::Get_Frame_Time() const
+{
+	const FFmpegStream *stream = Find_Match(AVMEDIA_TYPE_VIDEO);
+	if (stream == nullptr) {
+		return 0u;
+	}
+
+	return 1000u / av_q2d(FmtCtx->streams[stream->stream_idx]->avg_frame_rate);
+}

--- a/Code/wwlib/FFmpegFile.h
+++ b/Code/wwlib/FFmpegFile.h
@@ -1,0 +1,91 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 OpenW3D
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+//////// FFmpegFile.h ///////////////////////////
+// Stephan Vedder, April 2025
+/////////////////////////////////////////////////
+
+#pragma once
+
+#include <vector>
+
+struct AVFormatContext;
+struct AVIOContext;
+struct AVCodec;
+struct AVCodecContext;
+struct AVFrame;
+struct AVPacket;
+class FileClass;
+class FileFactoryClass;
+
+typedef void(*FFmpegFrameCallback)(AVFrame *, int, int, void *);
+
+class FFmpegFile
+{
+public:
+	FFmpegFile();
+	// The constructur takes ownership of the file
+	explicit FFmpegFile(const char *file);
+	~FFmpegFile();
+
+	bool Open(const char *file);
+	void Close();
+	void Set_Frame_Callback(FFmpegFrameCallback callback) { FrameCallback = callback; }
+	void Set_User_Data(void *user_data) { UserData = user_data; }
+	// Read & decode a packet from the container. Note that we could/should split this step
+	bool Decode_Packet();
+	void Seek_Frame(int frame_idx);
+	bool Has_Audio() const;
+	bool Has_Video() const;
+
+	// Audio specific
+	int Get_Size_For_Samples(int numSamples) const;
+	int Get_Num_Channels() const;
+	int Get_Sample_Rate() const;
+	int Get_Bytes_Per_Sample() const;
+
+	// Video specific
+	int Get_Width() const;
+	int Get_Height() const;
+	int Get_Num_Frames() const;
+	int Get_Current_Frame() const;
+	int Get_Pixel_Format() const;
+	unsigned Get_Frame_Time() const;
+
+private:
+	struct FFmpegStream
+	{
+		AVCodecContext *codec_ctx = nullptr;
+		const AVCodec *codec = nullptr;
+		int stream_idx = -1;
+		int stream_type = -1;
+		AVFrame *frame = nullptr;
+	};
+
+	static int Read_Packet(void *opaque, uint8_t *buf, int buf_size);
+	const FFmpegStream *Find_Match(int type) const;
+
+	FFmpegFrameCallback 		FrameCallback = nullptr; ///< Callback for frame processing
+	AVFormatContext 			*FmtCtx = nullptr; ///< Format context for AVFormat
+	AVIOContext 				*AvioCtx = nullptr; ///< IO context for AVFormat
+	AVPacket 					*Packet = nullptr; ///< Current packet
+	std::vector<FFmpegStream> 	Streams; ///< List of streams in the file
+	FileClass 					*File = nullptr;	///< File handle for the file
+	FileFactoryClass			*Factory = nullptr;
+	void 						*UserData = nullptr; ///< User data for the callback
+};

--- a/cmake/ffmpeg.cmake
+++ b/cmake/ffmpeg.cmake
@@ -1,0 +1,7 @@
+find_package(FFMPEG REQUIRED)
+
+add_library(ffmpeg INTERFACE)
+target_include_directories(ffmpeg INTERFACE ${FFMPEG_INCLUDE_DIRS})
+target_link_directories(ffmpeg INTERFACE ${FFMPEG_LIBRARY_DIRS})
+target_link_libraries(ffmpeg INTERFACE ${FFMPEG_LIBRARIES})
+target_compile_definitions(ffmpeg INTERFACE W3D_HAS_FFMPEG)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "builtin-baseline": "b02e341c927f16d991edbd915d8ea43eac52096c",
+  "dependencies": [
+    "ffmpeg"
+  ]
+}


### PR DESCRIPTION
Implements an FFMpeg based Bink video decoder. Also adds a vcpkg config to handle the dependency when using that package manager.

Audio support is currently missing as the Bink dll handled it entirely rather than handing off to the game's audio engine so additional work is required there.