### PR TITLE
fix: Don't redefine errno.

### DIFF
--- a/Code/Commando/natsock.h
+++ b/Code/Commando/natsock.h
@@ -60,12 +60,7 @@
 #define fw_assert assert
 #endif //WWASSERT
 
-#ifdef errno
-#undef errno
-#endif	//errno
-
-#define errno (WSAGetLastError())
-#define LAST_ERROR errno
+#define LAST_ERROR LastSocketError
 
 #define TIMER_SECOND 1000
 

--- a/Code/SControl/servercontrolsocket.h
+++ b/Code/SControl/servercontrolsocket.h
@@ -59,12 +59,7 @@
 #define fw_assert assert
 #endif //WWASSERT
 
-#ifdef errno
-#undef errno
-#endif	//errno
-
-#define errno (WSAGetLastError())
-#define LAST_ERROR errno
+#define LAST_ERROR LastSocketError
 
 #ifndef TIMER_SECOND
 #define TIMER_SECOND 1000

--- a/Code/wwnet/network-typedefs.h
+++ b/Code/wwnet/network-typedefs.h
@@ -3,6 +3,7 @@
 
 #ifdef _WIN32
 #include <winsock2.h>
+#define LastSocketError      (WSAGetLastError())
 #else
 #include <arpa/inet.h>
 #include <errno.h>


### PR DESCRIPTION
errno is used internally in windows headers, redefining it causes compile errors depending on include order.