### PR TITLE
CMake fix to remove the MinGW macro redefinition warning.

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -7,7 +7,7 @@ target_compile_features(wwcommon INTERFACE cxx_std_20)
 target_compile_definitions(wwcommon INTERFACE
     NOMINMAX
     WIN32_LEAN_AND_MEAN
-    _WIN32_WINNT=0x501
+    _WIN32_WINNT=0x0601
     DIRECTINPUT_VERSION=0x800
     _CRT_NONSTDC_NO_WARNINGS
     _CRT_SECURE_NO_WARNINGS

--- a/Code/wwnet/CMakeLists.txt
+++ b/Code/wwnet/CMakeLists.txt
@@ -48,5 +48,4 @@ target_link_libraries(wwnet PRIVATE wwcommon)
 
 if (WIN32)
   target_link_libraries(wwnet PRIVATE ws2_32)
-  target_compile_definitions(wwnet PRIVATE _WIN32_WINNT=0x0601 WINVER=0x0601)
 endif()


### PR DESCRIPTION
- Changed the shared Windows target macro to a single value in "Code/CMakeLists.txt:10":
  - "_WIN32_WINNT=0x501" -> "_WIN32_WINNT=0x0601"
- Removed the conflicting per-target override from "Code/wwnet/CMakeLists.txt:49" (the "_WIN32_WINNT"/"WINVER" line under "if (WIN32)").

fixes #97 