### PR TITLE
config: add shared openw3d.conf path handling and --ini override

### DIFF
--- a/Code/Commando/WINMAIN.CPP
+++ b/Code/Commando/WINMAIN.CPP
@@ -246,7 +246,13 @@ static bool Graphics_Settings_Trouble_Shooting()
 		const char * args[] = {
 			"wwconfig.exe",
 			nullptr,
+			nullptr,
+			nullptr,
 		};
+		if (OpenW3D::Has_Config_File_Path_Override()) {
+			args[1] = "--ini";
+			args[2] = OpenW3D::Get_Config_File_Path();
+		}
 		Process *process = ProcessManager::Create_Process(args);
 		if (!process) {
 			return 1;
@@ -359,7 +365,7 @@ static bool Video_Card_Driver_Check()
 	case DX8Caps::DRIVER_STATUS_OK:
 	case DX8Caps::DRIVER_STATUS_UNKNOWN:
 		ini.Put_Int(W3D_SECTION_RENDER, "DriverVersionCheckDisabled", 87);
-		ini.Save(W3D_CONF_FILE);
+		OpenW3D::Save_Config(ini);
 		return true;
 	case DX8Caps::DRIVER_STATUS_BAD:
 		break;
@@ -369,7 +375,13 @@ static bool Video_Card_Driver_Check()
 		"wwconfig.exe",
 		"-driverversion",
 		nullptr,
+		nullptr,
+		nullptr,
 	};
+	if (OpenW3D::Has_Config_File_Path_Override()) {
+		options[2] = "--ini";
+		options[3] = OpenW3D::Get_Config_File_Path();
+	}
 	Process *process = ProcessManager::Create_Process(options);
 	if (!process) {
 		return true;

--- a/Code/Commando/consolefunction.cpp
+++ b/Code/Commando/consolefunction.cpp
@@ -1135,7 +1135,7 @@ public:
 		ini.Put_Int(W3D_SECTION_SYSTEM, "Brightness", 0);
 		ini.Put_Int(W3D_SECTION_SYSTEM, "Contrast", 1);
 
-		ini.Save(W3D_CONF_FILE);
+		OpenW3D::Save_Config(ini);
 	}
 };
 
@@ -5485,4 +5485,3 @@ void	ConsoleFunctionManager::Print( const char *format, ... )
 	ConsoleBox.Print(string.Peek_Buffer());
 	va_end (arg_list);
 }
-

--- a/Code/Commando/dlgconfigperformancetab.cpp
+++ b/Code/Commando/dlgconfigperformancetab.cpp
@@ -657,6 +657,6 @@ DlgConfigPerformanceTabClass::On_Apply (void)
 	}
 	WW3D::Set_Texture_Reduction (std::max (2 - texture_red, 0));
 	SurfaceEffectsManager::Set_Mode ((SurfaceEffectsManager::MODE)surface_effect);
-	ini.Save(W3D_CONF_FILE);
+	OpenW3D::Save_Config(ini);
 	return true;
 }

--- a/Code/Commando/systemsettings.cpp
+++ b/Code/Commando/systemsettings.cpp
@@ -78,7 +78,7 @@ void	SystemSettings::Registry_Save( const char * /* sub_key */ )
 	for ( int index = 0; index < SettingList.Count(); index++ ) {
 		SettingList[ index ]->INI_Save( ini );
 	}
-	ini.Save(W3D_CONF_FILE);
+	OpenW3D::Save_Config(ini);
 }
 
 void	SystemSettings::Registry_Load( const char * /* sub_key */ )

--- a/Code/Commando/useroptions.cpp
+++ b/Code/Commando/useroptions.cpp
@@ -47,6 +47,7 @@
 #include "GameSpy_QnR.h"
 #include "gamespyadmin.h"
 #include "specialbuilds.h"
+#include "openw3d.h"
 #include "useroptions.h"
 
 extern char DefaultRegistryModifier[1024];
@@ -89,6 +90,13 @@ cUserOptions::ParseResult cUserOptions::Parse_Command_Line(int argc, char *argv[
 {
 	ParseResult retcode = ParseResult::SUCCESS;
 
+	if (!OpenW3D::Set_Config_File_Path_From_Command_Line(argc, argv)) {
+		return ParseResult::FAILURE;
+	}
+
+	// Resolve the config file path before later arguments can change the working directory.
+	OpenW3D::Get_Config_File_Path();
+
 	//
 	// Loop through all the command line arguments.
 	//
@@ -104,6 +112,15 @@ cUserOptions::ParseResult cUserOptions::Parse_Command_Line(int argc, char *argv[
 				break;
 			}
 			Set_GameDir(argval);
+			continue;
+		}
+
+		if (strcmp(cmd, "--ini") == 0) {
+			i++;
+			if (i >= argc) {
+				retcode = FAILURE;
+				break;
+			}
 			continue;
 		}
 
@@ -291,6 +308,7 @@ void cUserOptions::Print_Command_Line_Help(bool error)
 
 	fprintf(file, "usage: %s [--ip IP] [--multi] [--regmod MOD] [--slave] [--startserver INI]\n", path);
 	fprintf(file, "    [--gamedir PATH]\n");
+	fprintf(file, "    [--ini PATH]\n");
 	fprintf(file, "    [--gamespyserver ADDRESS] [--nodx]\n");
 #ifndef BETACLIENT
 	fprintf(file, "    [--gamespy-connect IP[:PORT]]\n");

--- a/Code/Tools/WWConfig/DriverVersionWarning.cpp
+++ b/Code/Tools/WWConfig/DriverVersionWarning.cpp
@@ -306,7 +306,7 @@ void DriverVersionWarning::OnDisableDriverVersionDialogCheckbox()
 	INIClass ini(W3D_CONF_FILE);
 
 	ini.Put_Int(W3D_SECTION_RENDER, "DriverVersionCheckDisabled", is_disabled ? 87 : 0);
-	ini.Save(W3D_CONF_FILE);
+	OpenW3D::Save_Config(ini);
 
 }
 

--- a/Code/Tools/WWConfig/PerformanceConfigDialog.cpp
+++ b/Code/Tools/WWConfig/PerformanceConfigDialog.cpp
@@ -748,7 +748,7 @@ PerformanceConfigDialogClass::Apply_Changes (void)
 	ini.Put_Int (W3D_SECTION_SYSTEM, VALUE_INI_TEXTURE_RES, std::max (2 - texture_red, 0));
 	ini.Put_Int (W3D_SECTION_SYSTEM, VALUE_INI_SURFACE_EFFECT, surface_effect);
 	ini.Put_Int (W3D_SECTION_SYSTEM, VALUE_INI_PARTICLE_DETAIL, particle_detail);
-	ini.Save(W3D_CONF_FILE);
+	OpenW3D::Save_Config(ini);
 
 	return ;
 }
@@ -1134,7 +1134,7 @@ void AutoConfigSettings()
 	}
 
 	d3d->Release();
-	ini.Save(W3D_CONF_FILE);
+	OpenW3D::Save_Config(ini);
 }
 
 
@@ -1257,4 +1257,3 @@ PerformanceConfigDialogClass::OnShowWindow(BOOL bShow, UINT nStatus)
 
 	return ;
 }
-

--- a/Code/Tools/WWConfig/WWConfig.cpp
+++ b/Code/Tools/WWConfig/WWConfig.cpp
@@ -22,9 +22,9 @@
 #include "StdAfx.h"
 #include "WWConfig.h"
 #include "WWConfigDlg.h"
-#include "argv.h"
 #include "ffactory.h"
 #include "locale_api.h"
+#include "openw3d.h"
 #include "wwconfig_ids.h"
 
 
@@ -84,24 +84,31 @@ BOOL CWWConfigApp::InitInstance()
 	//-------------------------------------------------------------------------
 	// Get the Command line parameters.
 	//-------------------------------------------------------------------------
-	CString cmd(m_lpCmdLine);
+	const char *cmd = m_lpCmdLine != NULL ? m_lpCmdLine : "";
+
+	if (!OpenW3D::Set_Config_File_Path_From_Command_Line(cmd)) {
+		::MessageBoxA(NULL, "Missing value for --ini.", "WWConfig", MB_ICONERROR | MB_OK);
+		return false;
+	}
+
+	OpenW3D::Get_Config_File_Path();
 
 	//=========================================================================
 	// Init the strings.
 	//=========================================================================
 	int language = -1;
 
-	if( cmd.Find( "-French") !=-1 ) {
+	if (OpenW3D::Command_Line_Has_Arg(cmd, "-French")) {
 		language = 	IDL_FRENCH;
-	} else if( cmd.Find( "-German") !=-1 ) {
+	} else if (OpenW3D::Command_Line_Has_Arg(cmd, "-German")) {
 		language = 	IDL_GERMAN;
-	} else if( cmd.Find( "-Japanese") !=-1 ) {
+	} else if (OpenW3D::Command_Line_Has_Arg(cmd, "-Japanese")) {
 		language = 	IDL_JAPANESE;
-	} else if( cmd.Find( "-Korean") !=-1 ) {
+	} else if (OpenW3D::Command_Line_Has_Arg(cmd, "-Korean")) {
 		language = 	IDL_KOREAN;
-	} else if( cmd.Find( "-Chinese") !=-1 ) {
+	} else if (OpenW3D::Command_Line_Has_Arg(cmd, "-Chinese")) {
 		language = 	IDL_CHINESE;
-	} else if( cmd.Find( "-English") !=-1 ) {
+	} else if (OpenW3D::Command_Line_Has_Arg(cmd, "-English")) {
 		language = 	IDL_ENGLISH;
 	}
 
@@ -115,10 +122,10 @@ BOOL CWWConfigApp::InitInstance()
 	//
 	//
 	//
-	if (cmd.Find("-autoconfig")!=-1) {
+	if (OpenW3D::Command_Line_Has_Arg(cmd, "-autoconfig")) {
 		AutoConfigSettings();
 	}
-	else if (cmd.Find("-driverversion")!=-1) {
+	else if (OpenW3D::Command_Line_Has_Arg(cmd, "-driverversion")) {
 		CheckDriverVersion();
 	}
 	else {

--- a/Code/WWAudio/WWAudio.cpp
+++ b/Code/WWAudio/WWAudio.cpp
@@ -1536,7 +1536,7 @@ WWAudioClass::Save_To_Registry
 	ini.Put_Float (W3D_SECTION_SOUND, VALUE_INI_DIALOG_VOL,			dialog_volume);
 	ini.Put_Float (W3D_SECTION_SOUND, VALUE_INI_CINEMATIC_VOL,		cinematic_volume);
 	ini.Put_Int (W3D_SECTION_SOUND, VALUE_INI_SPEAKER_TYPE,		speaker_type);
-	retval = ini.Save(W3D_CONF_FILE) != 0;
+	retval = OpenW3D::Save_Config(ini);
 
 	return retval;
 }

--- a/Code/ww3d2/dx8wrapper.cpp
+++ b/Code/ww3d2/dx8wrapper.cpp
@@ -1087,7 +1087,7 @@ bool DX8Wrapper::Registry_Save_Render_Device( const char */*sub_key*/, int devic
 	ini.Put_Bool(W3D_SECTION_RENDER, VALUE_INI_RENDER_DEVICE_WINDOWED, windowed != 0);
 	ini.Put_Int(W3D_SECTION_RENDER, VALUE_INI_RENDER_DEVICE_TEXTURE_DEPTH, texture_depth);
 
-	return ini.Save(W3D_CONF_FILE) != 0;
+	return OpenW3D::Save_Config(ini);
 }
 
 bool DX8Wrapper::Registry_Load_Render_Device( const char * sub_key, bool resize_window )

--- a/Code/wwlib/CMakeLists.txt
+++ b/Code/wwlib/CMakeLists.txt
@@ -29,6 +29,7 @@ set(WWLIB_SRC
     multilist.cpp
     mutex.cpp
     nstrdup.cpp
+    openw3d.cpp
     pipe.cpp
     pk.cpp
     ramfile.cpp

--- a/Code/wwlib/ffactory.cpp
+++ b/Code/wwlib/ffactory.cpp
@@ -222,6 +222,9 @@ Is_Full_Path (const char *path)
 
 		// Check for network path
 		retval |= bool((path[0] == '\\') && (path[1] == '\\'));
+
+		// Check for POSIX-style absolute paths.
+		retval |= bool(path[0] == '/');
 	}
 
 	return retval;
@@ -306,5 +309,4 @@ void SimpleFileFactoryClass::Return_File( FileClass *file )
 {
 	delete file;
 }
-
 

--- a/Code/wwlib/openw3d.cpp
+++ b/Code/wwlib/openw3d.cpp
@@ -1,0 +1,319 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 OpenW3D Contributors.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "openw3d.h"
+
+#include "ini.h"
+#include "wwstring.h"
+
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <shlobj.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace
+{
+	std::string g_config_file_path;
+	bool g_config_file_path_initialized = false;
+	bool g_config_file_path_override = false;
+
+	std::vector<std::string> Tokenize_Command_Line(const char *command_line)
+	{
+		std::vector<std::string> args;
+
+		if (command_line == NULL) {
+			return args;
+		}
+
+		const char *current = command_line;
+		while (*current != '\0') {
+			while (*current != '\0' && std::isspace(static_cast<unsigned char>(*current))) {
+				++current;
+			}
+
+			if (*current == '\0') {
+				break;
+			}
+
+			std::string arg;
+			bool in_quotes = false;
+			while (*current != '\0') {
+				if (*current == '"') {
+					in_quotes = !in_quotes;
+					++current;
+					continue;
+				}
+
+				if (!in_quotes && std::isspace(static_cast<unsigned char>(*current))) {
+					break;
+				}
+
+				arg.push_back(*current);
+				++current;
+			}
+
+			args.push_back(arg);
+		}
+
+		return args;
+	}
+
+	std::filesystem::path Get_Current_Directory()
+	{
+		std::error_code error;
+		std::filesystem::path current_dir = std::filesystem::current_path(error);
+		if (!error) {
+			return current_dir;
+		}
+
+#ifdef _WIN32
+		char path[MAX_PATH] = { 0 };
+		DWORD length = GetCurrentDirectoryA(ARRAY_SIZE(path), path);
+		if (length > 0 && length < ARRAY_SIZE(path)) {
+			return std::filesystem::path(path);
+		}
+#else
+		char path[4096] = { 0 };
+		if (getcwd(path, sizeof(path)) != NULL) {
+			return std::filesystem::path(path);
+		}
+#endif
+
+		return std::filesystem::path();
+	}
+
+	std::filesystem::path Make_Absolute_Path(const char *path)
+	{
+		if (path == NULL || path[0] == '\0') {
+			return std::filesystem::path();
+		}
+
+		std::filesystem::path resolved(path);
+		if (!resolved.is_absolute()) {
+			resolved = Get_Current_Directory() / resolved;
+		}
+
+		return resolved.lexically_normal();
+	}
+
+	std::filesystem::path Get_Executable_Directory()
+	{
+#ifdef _WIN32
+		char path[32768] = { 0 };
+		DWORD length = GetModuleFileNameA(NULL, path, ARRAY_SIZE(path));
+		if (length > 0 && length < ARRAY_SIZE(path)) {
+			return std::filesystem::path(path).parent_path();
+		}
+#else
+		char path[4096] = { 0 };
+		const ssize_t length = readlink("/proc/self/exe", path, sizeof(path) - 1);
+		if (length > 0) {
+			path[length] = '\0';
+			return std::filesystem::path(path).parent_path();
+		}
+#endif
+
+		return Get_Current_Directory();
+	}
+
+	std::filesystem::path Get_Windows_AppData_Directory()
+	{
+		const char *appdata = std::getenv("APPDATA");
+		if (appdata != NULL && appdata[0] != '\0') {
+			return Make_Absolute_Path(appdata);
+		}
+
+#ifdef _WIN32
+		std::filesystem::path appdata_path;
+		HMODULE shfolder = LoadLibraryA("shfolder.dll");
+		if (shfolder != NULL) {
+			typedef HRESULT(__stdcall *SHGetFolderPathAType)(HWND, int, HANDLE, DWORD, LPSTR);
+			SHGetFolderPathAType get_folder_path =
+				(SHGetFolderPathAType)GetProcAddress(shfolder, "SHGetFolderPathA");
+			if (get_folder_path != NULL) {
+				char path[MAX_PATH] = { 0 };
+				if (get_folder_path(NULL, CSIDL_APPDATA, NULL, 0, path) == S_OK) {
+					appdata_path = std::filesystem::path(path);
+				}
+			}
+			FreeLibrary(shfolder);
+		}
+
+		return appdata_path;
+#else
+		return std::filesystem::path();
+#endif
+	}
+
+	std::filesystem::path Get_Default_Config_File_Path()
+	{
+		const char *config_override = std::getenv("OPENW3D_CONFIG_INI");
+		if (config_override == NULL || config_override[0] == '\0') {
+			config_override = std::getenv("RENEGADE_CONFIG_INI");
+		}
+		if (config_override != NULL && config_override[0] != '\0') {
+			return Make_Absolute_Path(config_override);
+		}
+
+		const std::filesystem::path executable_dir = Get_Executable_Directory();
+		const std::filesystem::path portable_config = executable_dir / W3D_CONF_FILENAME;
+		std::error_code error;
+		if (std::filesystem::exists(portable_config, error) && !error) {
+			return portable_config;
+		}
+
+#ifdef _WIN32
+		std::filesystem::path config_dir = Get_Windows_AppData_Directory();
+		if (!config_dir.empty()) {
+			return config_dir / "OpenW3D" / W3D_CONF_FILENAME;
+		}
+#else
+		const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
+		if (xdg_config_home != NULL && xdg_config_home[0] != '\0') {
+			return Make_Absolute_Path(xdg_config_home) / "OpenW3D" / W3D_CONF_FILENAME;
+		}
+
+		const char *home = std::getenv("HOME");
+		if (home != NULL && home[0] != '\0') {
+			return Make_Absolute_Path(home) / ".config" / "OpenW3D" / W3D_CONF_FILENAME;
+		}
+#endif
+
+		return portable_config;
+	}
+
+	bool Ensure_Config_Directory_Exists(const std::filesystem::path &config_path)
+	{
+		const std::filesystem::path parent_path = config_path.parent_path();
+		if (parent_path.empty()) {
+			return true;
+		}
+
+		std::error_code error;
+		std::filesystem::create_directories(parent_path, error);
+		return !error;
+	}
+
+	void Store_Config_File_Path(const std::filesystem::path &path, bool is_override)
+	{
+		const std::filesystem::path resolved_path = path.empty() ? std::filesystem::path(W3D_CONF_FILENAME) : path;
+		g_config_file_path = resolved_path.string();
+		g_config_file_path_initialized = true;
+		g_config_file_path_override = is_override;
+	}
+}
+
+void OpenW3D::Set_Config_File_Path_Override(const char *path)
+{
+	Store_Config_File_Path(Make_Absolute_Path(path), true);
+}
+
+bool OpenW3D::Set_Config_File_Path_From_Command_Line(int argc, char *argv[])
+{
+	for (int index = 1; index < argc; ++index) {
+		if (std::strcmp(argv[index], "--ini") != 0) {
+			continue;
+		}
+
+		++index;
+		if (index >= argc || argv[index] == NULL || argv[index][0] == '\0') {
+			return false;
+		}
+
+		Set_Config_File_Path_Override(argv[index]);
+	}
+
+	return true;
+}
+
+bool OpenW3D::Set_Config_File_Path_From_Command_Line(const char *command_line)
+{
+	const std::vector<std::string> args = Tokenize_Command_Line(command_line);
+	for (size_t index = 0; index < args.size(); ++index) {
+		if (args[index] != "--ini") {
+			continue;
+		}
+
+		++index;
+		if (index >= args.size() || args[index].empty()) {
+			return false;
+		}
+
+		Set_Config_File_Path_Override(args[index].c_str());
+	}
+
+	return true;
+}
+
+const char *OpenW3D::Get_Config_File_Path()
+{
+	if (!g_config_file_path_initialized) {
+		Store_Config_File_Path(Get_Default_Config_File_Path(), false);
+	}
+
+	return g_config_file_path.c_str();
+}
+
+bool OpenW3D::Has_Config_File_Path_Override()
+{
+	return g_config_file_path_override;
+}
+
+bool OpenW3D::Command_Line_Has_Arg(const char *command_line, const char *arg)
+{
+	const std::vector<std::string> args = Tokenize_Command_Line(command_line);
+	for (const std::string &current : args) {
+		if (current == arg) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void OpenW3D::Append_Config_File_Arg(StringClass &command_line)
+{
+	if (!Has_Config_File_Path_Override()) {
+		return;
+	}
+
+	command_line += " --ini \"";
+	command_line += Get_Config_File_Path();
+	command_line += "\"";
+}
+
+bool OpenW3D::Save_Config(const INIClass &ini)
+{
+	const std::filesystem::path config_path = Get_Config_File_Path();
+	if (!Ensure_Config_Directory_Exists(config_path)) {
+		return false;
+	}
+
+	const std::string native_path = config_path.string();
+	return ini.Save(native_path.c_str()) != 0;
+}

--- a/Code/wwlib/openw3d.cpp
+++ b/Code/wwlib/openw3d.cpp
@@ -29,11 +29,11 @@
 #include <system_error>
 #include <vector>
 
-#ifdef _WIN32
+#if defined(OPENW3D_WIN32)
 #include <windows.h>
 #include <shlobj.h>
-#else
-#include <unistd.h>
+#elif defined(OPENW3D_SDL3)
+#include <SDL3/SDL_filesystem.h>
 #endif
 
 namespace
@@ -87,24 +87,7 @@ namespace
 	{
 		std::error_code error;
 		std::filesystem::path current_dir = std::filesystem::current_path(error);
-		if (!error) {
-			return current_dir;
-		}
-
-#ifdef _WIN32
-		char path[MAX_PATH] = { 0 };
-		DWORD length = GetCurrentDirectoryA(ARRAY_SIZE(path), path);
-		if (length > 0 && length < ARRAY_SIZE(path)) {
-			return std::filesystem::path(path);
-		}
-#else
-		char path[4096] = { 0 };
-		if (getcwd(path, sizeof(path)) != NULL) {
-			return std::filesystem::path(path);
-		}
-#endif
-
-		return std::filesystem::path();
+		return error ? std::filesystem::path() : current_dir;
 	}
 
 	std::filesystem::path Make_Absolute_Path(const char *path)
@@ -123,32 +106,30 @@ namespace
 
 	std::filesystem::path Get_Executable_Directory()
 	{
-#ifdef _WIN32
+#if defined(OPENW3D_WIN32)
 		char path[32768] = { 0 };
 		DWORD length = GetModuleFileNameA(NULL, path, ARRAY_SIZE(path));
 		if (length > 0 && length < ARRAY_SIZE(path)) {
 			return std::filesystem::path(path).parent_path();
 		}
-#else
-		char path[4096] = { 0 };
-		const ssize_t length = readlink("/proc/self/exe", path, sizeof(path) - 1);
-		if (length > 0) {
-			path[length] = '\0';
-			return std::filesystem::path(path).parent_path();
+#elif defined(OPENW3D_SDL3)
+		const char *base_path = SDL_GetBasePath();
+		if (base_path != NULL && base_path[0] != '\0') {
+			return std::filesystem::path(base_path);
 		}
 #endif
 
 		return Get_Current_Directory();
 	}
 
-	std::filesystem::path Get_Windows_AppData_Directory()
+	std::filesystem::path Get_User_Config_Directory()
 	{
+#if defined(OPENW3D_WIN32)
 		const char *appdata = std::getenv("APPDATA");
 		if (appdata != NULL && appdata[0] != '\0') {
-			return Make_Absolute_Path(appdata);
+			return Make_Absolute_Path(appdata) / "OpenW3D";
 		}
 
-#ifdef _WIN32
 		std::filesystem::path appdata_path;
 		HMODULE shfolder = LoadLibraryA("shfolder.dll");
 		if (shfolder != NULL) {
@@ -164,10 +145,18 @@ namespace
 			FreeLibrary(shfolder);
 		}
 
-		return appdata_path;
-#else
-		return std::filesystem::path();
+		return appdata_path.empty() ? std::filesystem::path() : appdata_path / "OpenW3D";
+#elif defined(OPENW3D_SDL3)
+		char *pref_path = SDL_GetPrefPath("OpenW3D", "OpenW3D");
+		if (pref_path != NULL && pref_path[0] != '\0') {
+			const std::filesystem::path config_path(pref_path);
+			SDL_free(pref_path);
+			return config_path;
+		}
+		SDL_free(pref_path);
 #endif
+
+		return std::filesystem::path();
 	}
 
 	std::filesystem::path Get_Default_Config_File_Path()
@@ -187,20 +176,10 @@ namespace
 			return portable_config;
 		}
 
-#ifdef _WIN32
-		std::filesystem::path config_dir = Get_Windows_AppData_Directory();
+#if defined(OPENW3D_WIN32) || defined(OPENW3D_SDL3)
+		std::filesystem::path config_dir = Get_User_Config_Directory();
 		if (!config_dir.empty()) {
-			return config_dir / "OpenW3D" / W3D_CONF_FILENAME;
-		}
-#else
-		const char *xdg_config_home = std::getenv("XDG_CONFIG_HOME");
-		if (xdg_config_home != NULL && xdg_config_home[0] != '\0') {
-			return Make_Absolute_Path(xdg_config_home) / "OpenW3D" / W3D_CONF_FILENAME;
-		}
-
-		const char *home = std::getenv("HOME");
-		if (home != NULL && home[0] != '\0') {
-			return Make_Absolute_Path(home) / ".config" / "OpenW3D" / W3D_CONF_FILENAME;
+			return config_dir / W3D_CONF_FILENAME;
 		}
 #endif
 

--- a/Code/wwlib/openw3d.cpp
+++ b/Code/wwlib/openw3d.cpp
@@ -38,8 +38,8 @@
 
 namespace
 {
-	constexpr char kConfigOrganization[] = "W3DHub";
-	constexpr char kConfigApplication[] = "OpenW3D";
+	constexpr char CONFIG_ORGANIZATION[] = "W3DHub";
+	constexpr char CONFIG_APPLICATION[] = "OpenW3D";
 
 	std::string g_config_file_path;
 	bool g_config_file_path_initialized = false;
@@ -127,10 +127,10 @@ namespace
 
 	std::filesystem::path Get_User_Config_Directory()
 	{
-	#if defined(OPENW3D_WIN32)
+#if defined(OPENW3D_WIN32)
 		const char *appdata = std::getenv("APPDATA");
 		if (appdata != NULL && appdata[0] != '\0') {
-			return Make_Absolute_Path(appdata) / kConfigOrganization / kConfigApplication;
+			return Make_Absolute_Path(appdata) / CONFIG_ORGANIZATION / CONFIG_APPLICATION;
 		}
 
 		std::filesystem::path appdata_path;
@@ -148,9 +148,9 @@ namespace
 			FreeLibrary(shfolder);
 		}
 
-		return appdata_path.empty() ? std::filesystem::path() : appdata_path / kConfigOrganization / kConfigApplication;
-	#elif defined(OPENW3D_SDL3)
-		char *pref_path = SDL_GetPrefPath(kConfigOrganization, kConfigApplication);
+		return appdata_path.empty() ? std::filesystem::path() : appdata_path / CONFIG_ORGANIZATION / CONFIG_APPLICATION;
+#elif defined(OPENW3D_SDL3)
+		char *pref_path = SDL_GetPrefPath(CONFIG_ORGANIZATION, CONFIG_APPLICATION);
 		if (pref_path != NULL && pref_path[0] != '\0') {
 			const std::filesystem::path config_path(pref_path);
 			SDL_free(pref_path);

--- a/Code/wwlib/openw3d.cpp
+++ b/Code/wwlib/openw3d.cpp
@@ -38,6 +38,9 @@
 
 namespace
 {
+	constexpr char kConfigOrganization[] = "W3DHub";
+	constexpr char kConfigApplication[] = "OpenW3D";
+
 	std::string g_config_file_path;
 	bool g_config_file_path_initialized = false;
 	bool g_config_file_path_override = false;
@@ -124,10 +127,10 @@ namespace
 
 	std::filesystem::path Get_User_Config_Directory()
 	{
-#if defined(OPENW3D_WIN32)
+	#if defined(OPENW3D_WIN32)
 		const char *appdata = std::getenv("APPDATA");
 		if (appdata != NULL && appdata[0] != '\0') {
-			return Make_Absolute_Path(appdata) / "OpenW3D";
+			return Make_Absolute_Path(appdata) / kConfigOrganization / kConfigApplication;
 		}
 
 		std::filesystem::path appdata_path;
@@ -145,9 +148,9 @@ namespace
 			FreeLibrary(shfolder);
 		}
 
-		return appdata_path.empty() ? std::filesystem::path() : appdata_path / "OpenW3D";
-#elif defined(OPENW3D_SDL3)
-		char *pref_path = SDL_GetPrefPath("OpenW3D", "OpenW3D");
+		return appdata_path.empty() ? std::filesystem::path() : appdata_path / kConfigOrganization / kConfigApplication;
+	#elif defined(OPENW3D_SDL3)
+		char *pref_path = SDL_GetPrefPath(kConfigOrganization, kConfigApplication);
 		if (pref_path != NULL && pref_path[0] != '\0') {
 			const std::filesystem::path config_path(pref_path);
 			SDL_free(pref_path);

--- a/Code/wwlib/openw3d.h
+++ b/Code/wwlib/openw3d.h
@@ -17,8 +17,24 @@
 */
 #pragma once
 
+class INIClass;
+class StringClass;
+
+namespace OpenW3D
+{
+	void Set_Config_File_Path_Override(const char *path);
+	bool Set_Config_File_Path_From_Command_Line(int argc, char *argv[]);
+	bool Set_Config_File_Path_From_Command_Line(const char *command_line);
+	const char *Get_Config_File_Path();
+	bool Has_Config_File_Path_Override();
+	bool Command_Line_Has_Arg(const char *command_line, const char *arg);
+	void Append_Config_File_Arg(StringClass &command_line);
+	bool Save_Config(const INIClass &ini);
+}
+
 // Some defines for moving game config to ini files rather than registry.
-#define W3D_CONF_FILE "openw3d.conf"
+#define W3D_CONF_FILENAME "openw3d.conf"
+#define W3D_CONF_FILE OpenW3D::Get_Config_File_Path()
 #define W3D_SECTION_RENDER "RenderDevice"
 #define W3D_SECTION_SOUND "Sound"
 #define W3D_SECTION_SYSTEM "System"


### PR DESCRIPTION
This follows up the INI-backed config work by moving `openw3d.conf` path
resolution into shared `wwlib` code and by teaching the game and legacy
`wwconfig` entry points to honor an explicit `--ini PATH` override.

What this changes:
- adds a shared config-path resolver in `wwlib`
- supports `--ini PATH` in `renegade` and `wwconfig`
- resolves config in this order:
  1. explicit `--ini PATH`
  2. `OPENW3D_CONFIG_INI` / `RENEGADE_CONFIG_INI`
  3. portable `openw3d.conf` next to the executable if it already exists
  4. standard per-user config path
- resolves the `--ini` path before any `--gamedir` handling can change the working directory
- creates parent directories before saving to per-user config locations
- forwards the explicit config path when `renegade` launches `wwconfig.exe`
- treats POSIX-style absolute paths as absolute in the shared file factory
