### PR TITLE
Add WW3D renderer backend lifecycle seam

### DIFF
--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -1,3 +1,6 @@
+option(ENABLE_DX9_BACKEND "Enable DX9 backend" $<BOOL:${WIN32}>)
+add_feature_info(DX9_Renderer ENABLE_DX9_BACKEND "DX9 Backend")
+
 # Set source files
 set(WW3D2_SRC
     aabtree.cpp
@@ -135,6 +138,7 @@ set(WW3D2_SRC
     dx8texman.h
     dx8vertexbuffer.h
     dx8wrapper.h
+    dx8backend.h
     dynamesh.h
     font3d.h
     formconv.h
@@ -213,6 +217,7 @@ set(WW3D2_SRC
     w3d_obsolete.h
     w3d_util.h
     w3derr.h
+    ww3dbackend.h
     ww3d.h
     ww3dformat.h
     ww3dids.h
@@ -230,6 +235,10 @@ target_link_libraries(ww3d2 PRIVATE
 )
 
 target_sources(ww3d2 PRIVATE ${WW3D2_SRC})
+
+if (ENABLE_DX9_BACKEND)
+    target_sources(ww3d2 PRIVATE dx8backend.cpp)
+endif()
 
 # This module needs building differently for the level editor
 if (W3D_TOOLS)

--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -1,5 +1,13 @@
-option(ENABLE_DX9_BACKEND "Enable DX9 backend" $<BOOL:${WIN32}>)
+if (WIN32)
+    set(ENABLE_DX9_BACKEND_DEFAULT ON)
+else()
+    set(ENABLE_DX9_BACKEND_DEFAULT OFF)
+endif()
+
+option(ENABLE_DX9_BACKEND "Enable DX9 backend" ${ENABLE_DX9_BACKEND_DEFAULT})
 add_feature_info(DX9_Renderer ENABLE_DX9_BACKEND "DX9 Backend")
+
+set_source_files_properties(nullbackend.cpp PROPERTIES COMPILE_DEFINITIONS WW3D_RDDESC_NO_D3D)
 
 # Set source files
 set(WW3D2_SRC
@@ -173,6 +181,7 @@ set(WW3D2_SRC
     metalmap.h
     missingtexture.h
     motchan.h
+    nullbackend.h
     nullrobj.h
     part_buf.h
     part_emt.h
@@ -238,6 +247,9 @@ target_sources(ww3d2 PRIVATE ${WW3D2_SRC})
 
 if (ENABLE_DX9_BACKEND)
     target_sources(ww3d2 PRIVATE dx8backend.cpp)
+    target_compile_definitions(ww3d2 PRIVATE WW3D_DX9_BACKEND)
+else()
+    target_sources(ww3d2 PRIVATE nullbackend.cpp)
 endif()
 
 # This module needs building differently for the level editor
@@ -254,4 +266,11 @@ if (W3D_TOOLS)
     target_compile_definitions(ww3d2e PRIVATE PARAM_EDITING_ON)
 
     target_sources(ww3d2e PRIVATE ${WW3D2_SRC})
+
+    if (ENABLE_DX9_BACKEND)
+        target_sources(ww3d2e PRIVATE dx8backend.cpp)
+        target_compile_definitions(ww3d2e PRIVATE WW3D_DX9_BACKEND)
+    else()
+        target_sources(ww3d2e PRIVATE nullbackend.cpp)
+    endif()
 endif()

--- a/Code/ww3d2/dx8backend.cpp
+++ b/Code/ww3d2/dx8backend.cpp
@@ -1,0 +1,190 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * DX8Backend implementation.                                                                  *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#include "dx8backend.h"
+#include "dx8wrapper.h"
+
+DX8Backend::DX8Backend()
+{
+}
+
+DX8Backend::~DX8Backend()
+{
+}
+
+bool DX8Backend::Init(void * hwnd, bool lite)
+{
+    return DX8Wrapper::Init(hwnd, lite);
+}
+
+void DX8Backend::Shutdown()
+{
+    DX8Wrapper::Shutdown();
+}
+
+bool DX8Backend::Set_Any_Render_Device()
+{
+    return DX8Wrapper::Set_Any_Render_Device();
+}
+
+bool DX8Backend::Set_Render_Device(const char * dev_name, int width, int height, int bits, int windowed, bool resize_window)
+{
+    return DX8Wrapper::Set_Render_Device(dev_name, width, height, bits, windowed, resize_window);
+}
+
+bool DX8Backend::Set_Render_Device(int dev, int resx, int resy, int bits, int windowed, bool resize_window)
+{
+    return DX8Wrapper::Set_Render_Device(dev, resx, resy, bits, windowed, resize_window);
+}
+
+bool DX8Backend::Set_Next_Render_Device()
+{
+    return DX8Wrapper::Set_Next_Render_Device();
+}
+
+bool DX8Backend::Toggle_Windowed()
+{
+    return DX8Wrapper::Toggle_Windowed();
+}
+
+bool DX8Backend::Is_Windowed()
+{
+    return DX8Wrapper::Is_Windowed();
+}
+
+int DX8Backend::Get_Render_Device_Count()
+{
+    return DX8Wrapper::Get_Render_Device_Count();
+}
+
+int DX8Backend::Get_Render_Device()
+{
+    return DX8Wrapper::Get_Render_Device();
+}
+
+const RenderDeviceDescClass & DX8Backend::Get_Render_Device_Desc(int deviceidx)
+{
+    return DX8Wrapper::Get_Render_Device_Desc(deviceidx);
+}
+
+const char * DX8Backend::Get_Render_Device_Name(int device_index)
+{
+    return DX8Wrapper::Get_Render_Device_Name(device_index);
+}
+
+bool DX8Backend::Set_Device_Resolution(int width, int height, int bits, int windowed, bool resize_window)
+{
+    return DX8Wrapper::Set_Device_Resolution(width, height, bits, windowed, resize_window);
+}
+
+void DX8Backend::Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    DX8Wrapper::Get_Device_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+void DX8Backend::Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    DX8Wrapper::Get_Render_Target_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+int DX8Backend::Get_Device_Resolution_Width()
+{
+    return DX8Wrapper::Get_Device_Resolution_Width();
+}
+
+int DX8Backend::Get_Device_Resolution_Height()
+{
+    return DX8Wrapper::Get_Device_Resolution_Height();
+}
+
+bool DX8Backend::Registry_Save_Render_Device(const char * sub_key)
+{
+    return DX8Wrapper::Registry_Save_Render_Device(sub_key);
+}
+
+bool DX8Backend::Registry_Load_Render_Device(const char * sub_key, bool resize_window)
+{
+    return DX8Wrapper::Registry_Load_Render_Device(sub_key, resize_window);
+}
+
+bool DX8Backend::Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth)
+{
+    return DX8Wrapper::Registry_Save_Render_Device(sub_key, device, width, height, depth, windowed, texture_depth);
+}
+
+bool DX8Backend::Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth)
+{
+    return DX8Wrapper::Registry_Load_Render_Device(sub_key, device, device_len, width, height, depth, windowed, texture_depth);
+}
+
+void DX8Backend::Begin_Scene()
+{
+    DX8Wrapper::Begin_Scene();
+}
+
+void DX8Backend::End_Scene(bool flip_frame)
+{
+    DX8Wrapper::End_Scene(flip_frame);
+}
+
+void DX8Backend::Flip_To_Primary()
+{
+    DX8Wrapper::Flip_To_Primary();
+}
+
+void DX8Backend::Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z, unsigned int stencil)
+{
+    DX8Wrapper::Clear(clear_color, clear_z_stencil, color, z, stencil);
+}
+
+void DX8Backend::SetRenderType(SceneClass::PolyRenderType type)
+{
+    DX8Wrapper::SetRenderType(type);
+}
+
+void DX8Backend::Set_Swap_Interval(int swap)
+{
+    DX8Wrapper::Set_Swap_Interval(swap);
+}
+
+int DX8Backend::Get_Swap_Interval()
+{
+    return DX8Wrapper::Get_Swap_Interval();
+}
+
+void DX8Backend::Set_Texture_Bitdepth(int depth)
+{
+    DX8Wrapper::Set_Texture_Bitdepth(depth);
+}
+
+int DX8Backend::Get_Texture_Bitdepth()
+{
+    return DX8Wrapper::Get_Texture_Bitdepth();
+}

--- a/Code/ww3d2/dx8backend.cpp
+++ b/Code/ww3d2/dx8backend.cpp
@@ -164,11 +164,6 @@ void DX8Backend::Clear(bool clear_color, bool clear_z_stencil, const Vector3 &co
     DX8Wrapper::Clear(clear_color, clear_z_stencil, color, z, stencil);
 }
 
-void DX8Backend::SetRenderType(SceneClass::PolyRenderType type)
-{
-    DX8Wrapper::SetRenderType(type);
-}
-
 void DX8Backend::Set_Swap_Interval(int swap)
 {
     DX8Wrapper::Set_Swap_Interval(swap);

--- a/Code/ww3d2/dx8backend.h
+++ b/Code/ww3d2/dx8backend.h
@@ -1,0 +1,88 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * DX8Backend - concrete WW3DBackend implementation wrapping DX8Wrapper static methods.         *
+ * DX8Wrapper stays standalone and does NOT inherit from WW3DBackend.                          *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef DX8BACKEND_H
+#define DX8BACKEND_H
+
+#include "ww3dbackend.h"
+
+// DX8Wrapper static methods are called directly from here.
+// No include of dx8wrapper.h at header level to keep D3D9 out of the ww3d2 include chain.
+class DX8Wrapper;
+
+class DX8Backend : public WW3DBackend
+{
+public:
+    DX8Backend();
+    virtual ~DX8Backend();
+
+    // WW3DBackend interface - delegate to DX8Wrapper static methods
+    virtual bool Init(void * hwnd, bool lite = false) override;
+    virtual void Shutdown() override;
+
+    virtual bool Set_Any_Render_Device() override;
+    virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Next_Render_Device() override;
+    virtual bool Toggle_Windowed() override;
+    virtual bool Is_Windowed() override;
+
+    virtual int Get_Render_Device_Count() override;
+    virtual int Get_Render_Device() override;
+    virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) override;
+    virtual const char * Get_Render_Device_Name(int device_index) override;
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual int Get_Device_Resolution_Width() override;
+    virtual int Get_Device_Resolution_Height() override;
+
+    virtual bool Registry_Save_Render_Device(const char * sub_key) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) override;
+    virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) override;
+
+    virtual void Begin_Scene() override;
+    virtual void End_Scene(bool flip_frame = true) override;
+    virtual void Flip_To_Primary() override;
+
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
+
+    virtual void SetRenderType(SceneClass::PolyRenderType) override;
+
+    virtual void Set_Swap_Interval(int swap) override;
+    virtual int Get_Swap_Interval() override;
+
+    virtual void Set_Texture_Bitdepth(int depth) override;
+    virtual int Get_Texture_Bitdepth() override;
+};
+
+#endif // DX8BACKEND_H

--- a/Code/ww3d2/dx8backend.h
+++ b/Code/ww3d2/dx8backend.h
@@ -76,8 +76,6 @@ public:
 
     virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
 
-    virtual void SetRenderType(SceneClass::PolyRenderType) override;
-
     virtual void Set_Swap_Interval(int swap) override;
     virtual int Get_Swap_Interval() override;
 

--- a/Code/ww3d2/dx8wrapper.h
+++ b/Code/ww3d2/dx8wrapper.h
@@ -166,8 +166,14 @@ struct RenderStateStruct
 ** an WWINLINE function so that we can add stat tracking, etc if needed.  Direct access to the
 ** D3D device will require "friend" status and should be granted only in extreme circumstances :-)
 */
+class DX8Wrapper;
+class WW3DBackend;
+
 class DX8Wrapper
 {
+    friend class WW3DBackend;
+    friend class DX8Backend;
+
 	enum ChangedStates {
 		WORLD_CHANGED	=	1<<0,
 		VIEW_CHANGED	=	1<<1,

--- a/Code/ww3d2/nullbackend.cpp
+++ b/Code/ww3d2/nullbackend.cpp
@@ -1,0 +1,203 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+*/
+
+#include "nullbackend.h"
+#include "rddesc.h"
+
+namespace
+{
+	const int DEFAULT_WIDTH = 640;
+	const int DEFAULT_HEIGHT = 480;
+	const int DEFAULT_BIT_DEPTH = 16;
+}
+
+NullBackend::NullBackend() :
+	Width(DEFAULT_WIDTH),
+	Height(DEFAULT_HEIGHT),
+	BitDepth(DEFAULT_BIT_DEPTH),
+	Windowed(true),
+	SwapInterval(0),
+	TextureBitDepth(DEFAULT_BIT_DEPTH)
+{
+}
+
+NullBackend::~NullBackend()
+{
+}
+
+bool NullBackend::Init(void * /*hwnd*/, bool /*lite*/)
+{
+	return true;
+}
+
+void NullBackend::Shutdown()
+{
+}
+
+bool NullBackend::Set_Any_Render_Device()
+{
+	return true;
+}
+
+bool NullBackend::Set_Render_Device(const char * /*dev_name*/, int width, int height, int bits, int windowed, bool /*resize_window*/)
+{
+	return Set_Device_Resolution(width, height, bits, windowed, false);
+}
+
+bool NullBackend::Set_Render_Device(int /*dev*/, int resx, int resy, int bits, int windowed, bool /*resize_window*/)
+{
+	return Set_Device_Resolution(resx, resy, bits, windowed, false);
+}
+
+bool NullBackend::Set_Next_Render_Device()
+{
+	return true;
+}
+
+bool NullBackend::Toggle_Windowed()
+{
+	Windowed = !Windowed;
+	return true;
+}
+
+bool NullBackend::Is_Windowed()
+{
+	return Windowed;
+}
+
+int NullBackend::Get_Render_Device_Count()
+{
+	return 1;
+}
+
+int NullBackend::Get_Render_Device()
+{
+	return 0;
+}
+
+const RenderDeviceDescClass & NullBackend::Get_Render_Device_Desc(int /*deviceidx*/)
+{
+	static RenderDeviceDescClass desc;
+	return desc;
+}
+
+const char * NullBackend::Get_Render_Device_Name(int /*device_index*/)
+{
+	return "Null Renderer";
+}
+
+bool NullBackend::Set_Device_Resolution(int width, int height, int bits, int windowed, bool /*resize_window*/)
+{
+	if (width > 0) {
+		Width = width;
+	}
+	if (height > 0) {
+		Height = height;
+	}
+	if (bits > 0) {
+		BitDepth = bits;
+	}
+	if (windowed != -1) {
+		Windowed = (windowed != 0);
+	}
+	return true;
+}
+
+void NullBackend::Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+	set_w = Width;
+	set_h = Height;
+	set_bits = BitDepth;
+	set_windowed = Windowed;
+}
+
+void NullBackend::Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+	Get_Device_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+int NullBackend::Get_Device_Resolution_Width()
+{
+	return Width;
+}
+
+int NullBackend::Get_Device_Resolution_Height()
+{
+	return Height;
+}
+
+bool NullBackend::Registry_Save_Render_Device(const char * /*sub_key*/)
+{
+	return true;
+}
+
+bool NullBackend::Registry_Load_Render_Device(const char * /*sub_key*/, bool /*resize_window*/)
+{
+	return true;
+}
+
+bool NullBackend::Registry_Save_Render_Device(const char * /*sub_key*/, int /*device*/, int width, int height, int depth, bool windowed, int texture_depth)
+{
+	Width = width;
+	Height = height;
+	BitDepth = depth;
+	Windowed = windowed;
+	TextureBitDepth = texture_depth;
+	return true;
+}
+
+bool NullBackend::Registry_Load_Render_Device(const char * /*sub_key*/, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth)
+{
+	if (device && device_len > 0) {
+		device[0] = '\0';
+	}
+	width = Width;
+	height = Height;
+	depth = BitDepth;
+	windowed = Windowed ? 1 : 0;
+	texture_depth = TextureBitDepth;
+	return true;
+}
+
+void NullBackend::Begin_Scene()
+{
+}
+
+void NullBackend::End_Scene(bool /*flip_frame*/)
+{
+}
+
+void NullBackend::Flip_To_Primary()
+{
+}
+
+void NullBackend::Clear(bool /*clear_color*/, bool /*clear_z_stencil*/, const Vector3 & /*color*/, float /*z*/, unsigned int /*stencil*/)
+{
+}
+
+void NullBackend::Set_Swap_Interval(int swap)
+{
+	SwapInterval = swap;
+}
+
+int NullBackend::Get_Swap_Interval()
+{
+	return SwapInterval;
+}
+
+void NullBackend::Set_Texture_Bitdepth(int depth)
+{
+	TextureBitDepth = depth;
+}
+
+int NullBackend::Get_Texture_Bitdepth()
+{
+	return TextureBitDepth;
+}

--- a/Code/ww3d2/nullbackend.h
+++ b/Code/ww3d2/nullbackend.h
@@ -1,0 +1,68 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+*/
+
+#ifndef NULLBACKEND_H
+#define NULLBACKEND_H
+
+#include "ww3dbackend.h"
+
+class NullBackend : public WW3DBackend
+{
+public:
+	NullBackend();
+	virtual ~NullBackend();
+
+	virtual bool Init(void * hwnd, bool lite = false) override;
+	virtual void Shutdown() override;
+
+	virtual bool Set_Any_Render_Device() override;
+	virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+	virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+	virtual bool Set_Next_Render_Device() override;
+	virtual bool Toggle_Windowed() override;
+	virtual bool Is_Windowed() override;
+
+	virtual int Get_Render_Device_Count() override;
+	virtual int Get_Render_Device() override;
+	virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) override;
+	virtual const char * Get_Render_Device_Name(int device_index) override;
+	virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+	virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+	virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+	virtual int Get_Device_Resolution_Width() override;
+	virtual int Get_Device_Resolution_Height() override;
+
+	virtual bool Registry_Save_Render_Device(const char * sub_key) override;
+	virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) override;
+	virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) override;
+	virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) override;
+
+	virtual void Begin_Scene() override;
+	virtual void End_Scene(bool flip_frame = true) override;
+	virtual void Flip_To_Primary() override;
+
+	virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
+
+	virtual void Set_Swap_Interval(int swap) override;
+	virtual int Get_Swap_Interval() override;
+
+	virtual void Set_Texture_Bitdepth(int depth) override;
+	virtual int Get_Texture_Bitdepth() override;
+
+private:
+	int Width;
+	int Height;
+	int BitDepth;
+	bool Windowed;
+	int SwapInterval;
+	int TextureBitDepth;
+};
+
+#endif // NULLBACKEND_H

--- a/Code/ww3d2/rddesc.h
+++ b/Code/ww3d2/rddesc.h
@@ -44,8 +44,19 @@
 
 #include "vector.h"
 #include "wwstring.h"
+
+#if defined(WW3D_RDDESC_NO_D3D)
+struct D3DCAPS9
+{
+};
+
+struct D3DADAPTER_IDENTIFIER9
+{
+};
+#else
 #include <d3d9types.h>
 #include <d3d9caps.h>
+#endif
 
 class ResolutionDescClass
 {

--- a/Code/ww3d2/ww3d.cpp
+++ b/Code/ww3d2/ww3d.cpp
@@ -114,6 +114,13 @@
 #include "dx8texman.h"
 #include "formconv.h"
 #include "animatedsoundmgr.h"
+#include "ww3dbackend.h"
+
+#if defined(WW3D_DX9_BACKEND)
+#include "dx8backend.h"
+#else
+#include "nullbackend.h"
+#endif
 
 
 #ifndef _UNIX
@@ -220,6 +227,21 @@ int														WW3D::LastFrameMemoryFrees;
 int														WW3D::TextureFilter;
 
 bool														WW3D::Lite = false;
+WW3DBackend *									WW3D::Backend = NULL;
+
+static WW3DBackend *Create_WW3D_Backend()
+{
+#if defined(WW3D_DX9_BACKEND)
+	return new DX8Backend();
+#else
+	return new NullBackend();
+#endif
+}
+
+static WW3DErrorType Backend_Bool_To_WW3D_Error(bool success)
+{
+	return success ? WW3D_ERROR_OK : WW3D_ERROR_INITIALIZATION_FAILED;
+}
 
 /**********************************************************************************
 **
@@ -267,8 +289,11 @@ WW3DErrorType WW3D::Init(void *hwnd, char * /*defaultpal*/, bool lite)
 	** Initialize d3d, this also enumerates the available devices and resolutions.
 	*/
 	Init_D3D_To_WW3_Conversion();
-	WWDEBUG_SAY(("Init DX8Wrapper\n"));
-	if (!DX8Wrapper::Init(_Hwnd, lite)) {
+	WWDEBUG_SAY(("Init WW3D backend\n"));
+	Backend = Create_WW3D_Backend();
+	if (!Backend || !Backend->Init(_Hwnd, lite)) {
+		delete Backend;
+		Backend = NULL;
 		return(WW3D_ERROR_DIRECTX8_INITIALIZATION_FAILED);
 	}
 	WWDEBUG_SAY(("Allocate Debug Resources\n"));
@@ -352,8 +377,12 @@ WW3DErrorType WW3D::Shutdown(void)
 	}
 
 	DX8TextureManagerClass::Shutdown();
-	if (!Lite) {
-		DX8Wrapper::Shutdown();
+	if (Backend) {
+		if (!Lite) {
+			Backend->Shutdown();
+		}
+		delete Backend;
+		Backend = NULL;
 	}
 
 	/*
@@ -385,12 +414,7 @@ WW3DErrorType WW3D::Shutdown(void)
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Render_Device( const char * dev_name, int width, int height, int bits, int windowed, bool resize_window )
 {
-	bool success = DX8Wrapper::Set_Render_Device(dev_name,width,height,bits,windowed,resize_window);
-	if (success) {
-		return WW3D_ERROR_OK;
-	} else {
-		return WW3D_ERROR_INITIALIZATION_FAILED;
-	}
+	return Backend_Bool_To_WW3D_Error(Backend && Backend->Set_Render_Device(dev_name,width,height,bits,windowed,resize_window));
 }
 
 
@@ -408,12 +432,7 @@ WW3DErrorType WW3D::Set_Render_Device( const char * dev_name, int width, int hei
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Any_Render_Device( void )
 {
-	bool success = DX8Wrapper::Set_Any_Render_Device();
-	if (success) {
-		return WW3D_ERROR_OK;
-	} else {
-		return WW3D_ERROR_INITIALIZATION_FAILED;
-	}
+	return Backend_Bool_To_WW3D_Error(Backend && Backend->Set_Any_Render_Device());
 }
 
 
@@ -431,12 +450,7 @@ WW3DErrorType WW3D::Set_Any_Render_Device( void )
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Render_Device(int dev, int width, int height, int bits, int windowed, bool resize_window)
 {
-	bool success = DX8Wrapper::Set_Render_Device(dev,width,height,bits,windowed,resize_window);
-	if (success) {
-		return WW3D_ERROR_OK;
-	} else {
-		return WW3D_ERROR_INITIALIZATION_FAILED;
-	}
+	return Backend_Bool_To_WW3D_Error(Backend && Backend->Set_Render_Device(dev,width,height,bits,windowed,resize_window));
 }
 
 
@@ -454,12 +468,7 @@ WW3DErrorType WW3D::Set_Render_Device(int dev, int width, int height, int bits, 
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Next_Render_Device(void)
 {
-	bool success = DX8Wrapper::Set_Next_Render_Device();
-	if (success) {
-		return WW3D_ERROR_OK;
-	} else {
-		return WW3D_ERROR_INITIALIZATION_FAILED;
-	}
+	return Backend_Bool_To_WW3D_Error(Backend && Backend->Set_Next_Render_Device());
 }
 
 /***********************************************************************************************
@@ -493,7 +502,7 @@ void *WW3D::Get_Window( void )
  *=============================================================================================*/
 bool WW3D::Is_Windowed( void )
 {
-	return DX8Wrapper::Is_Windowed();
+	return Backend && Backend->Is_Windowed();
 }
 
 /***********************************************************************************************
@@ -513,12 +522,7 @@ bool WW3D::Is_Windowed( void )
  *=============================================================================================*/
 WW3DErrorType WW3D::Toggle_Windowed (void)
 {
-	bool success = DX8Wrapper::Toggle_Windowed();
-	if (success) {
-		return WW3D_ERROR_OK;
-	} else {
-		return WW3D_ERROR_INITIALIZATION_FAILED;
-	}
+	return Backend_Bool_To_WW3D_Error(Backend && Backend->Toggle_Windowed());
 }
 
 
@@ -537,7 +541,7 @@ WW3DErrorType WW3D::Toggle_Windowed (void)
  *=============================================================================================*/
 int WW3D::Get_Render_Device(void)
 {
-	return DX8Wrapper::Get_Render_Device();
+	return Backend ? Backend->Get_Render_Device() : -1;
 }
 
 
@@ -556,7 +560,8 @@ int WW3D::Get_Render_Device(void)
  *=============================================================================================*/
 const RenderDeviceDescClass & WW3D::Get_Render_Device_Desc(int deviceidx)
 {
-	return DX8Wrapper::Get_Render_Device_Desc(deviceidx);
+	WWASSERT(Backend != NULL);
+	return Backend->Get_Render_Device_Desc(deviceidx);
 }
 
 
@@ -576,7 +581,7 @@ const RenderDeviceDescClass & WW3D::Get_Render_Device_Desc(int deviceidx)
  *=============================================================================================*/
 const int WW3D::Get_Render_Device_Count(void)
 {
-	return DX8Wrapper::Get_Render_Device_Count();
+	return Backend ? Backend->Get_Render_Device_Count() : 0;
 }
 
 
@@ -595,7 +600,7 @@ const int WW3D::Get_Render_Device_Count(void)
  *=============================================================================================*/
 const char * WW3D::Get_Render_Device_Name(int device_index)
 {
-	return DX8Wrapper::Get_Render_Device_Name(device_index);
+	return Backend ? Backend->Get_Render_Device_Name(device_index) : "";
 }
 
 
@@ -613,13 +618,7 @@ const char * WW3D::Get_Render_Device_Name(int device_index)
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Device_Resolution(int width,int height,int bits,int windowed, bool resize_window)
 {
-	bool success = DX8Wrapper::Set_Device_Resolution(width,height,bits,windowed,resize_window);
-
-	if (success) {
-		return WW3D_ERROR_OK;
-	} else {
-		return WW3D_ERROR_INITIALIZATION_FAILED;
-	}
+	return Backend_Bool_To_WW3D_Error(Backend && Backend->Set_Device_Resolution(width,height,bits,windowed,resize_window));
 }
 
 
@@ -638,7 +637,9 @@ WW3DErrorType WW3D::Set_Device_Resolution(int width,int height,int bits,int wind
  *=============================================================================================*/
 void WW3D::Get_Render_Target_Resolution(int & set_w,int & set_h,int & set_bits,bool & set_windowed)
 {
-	DX8Wrapper::Get_Render_Target_Resolution(set_w,set_h,set_bits,set_windowed);
+	if (Backend) {
+		Backend->Get_Render_Target_Resolution(set_w,set_h,set_bits,set_windowed);
+	}
 }
 
 
@@ -657,7 +658,9 @@ void WW3D::Get_Render_Target_Resolution(int & set_w,int & set_h,int & set_bits,b
  *=============================================================================================*/
 void WW3D::Get_Device_Resolution(int & set_w,int & set_h,int & set_bits,bool & set_windowed)
 {
-	DX8Wrapper::Get_Device_Resolution(set_w,set_h,set_bits,set_windowed);
+	if (Backend) {
+		Backend->Get_Device_Resolution(set_w,set_h,set_bits,set_windowed);
+	}
 }
 
 
@@ -676,12 +679,7 @@ void WW3D::Get_Device_Resolution(int & set_w,int & set_h,int & set_bits,bool & s
  *=============================================================================================*/
 WW3DErrorType WW3D::Registry_Save_Render_Device( const char * sub_key )
 {
-	bool success = DX8Wrapper::Registry_Save_Render_Device(sub_key);
-	if (success) {
-		return WW3D_ERROR_OK;
-	} else {
-		return WW3D_ERROR_INITIALIZATION_FAILED;
-	}
+	return Backend_Bool_To_WW3D_Error(Backend && Backend->Registry_Save_Render_Device(sub_key));
 }
 
 /***********************************************************************************************
@@ -698,12 +696,7 @@ WW3DErrorType WW3D::Registry_Save_Render_Device( const char * sub_key )
  *=============================================================================================*/
 WW3DErrorType WW3D::Registry_Save_Render_Device( const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth )
 {
-	bool success = DX8Wrapper::Registry_Save_Render_Device(sub_key,device,width,height,depth,windowed,texture_depth);
-	if (success) {
-		return WW3D_ERROR_OK;
-	} else {
-		return WW3D_ERROR_INITIALIZATION_FAILED;
-	}
+	return Backend_Bool_To_WW3D_Error(Backend && Backend->Registry_Save_Render_Device(sub_key,device,width,height,depth,windowed,texture_depth));
 }
 
 
@@ -721,17 +714,12 @@ WW3DErrorType WW3D::Registry_Save_Render_Device( const char *sub_key, int device
  *=============================================================================================*/
 WW3DErrorType WW3D::Registry_Load_Render_Device( const char * sub_key, bool resize_window )
 {
-	bool success = DX8Wrapper::Registry_Load_Render_Device(sub_key,resize_window);
-	if (success) {
-		return WW3D_ERROR_OK;
-	} else {
-		return WW3D_ERROR_INITIALIZATION_FAILED;
-	}
+	return Backend_Bool_To_WW3D_Error(Backend && Backend->Registry_Load_Render_Device(sub_key,resize_window));
 }
 
 bool WW3D::Registry_Load_Render_Device( const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth)
 {
-	return DX8Wrapper::Registry_Load_Render_Device(sub_key,device,device_len,width,height,depth,windowed,texture_depth);
+	return Backend && Backend->Registry_Load_Render_Device(sub_key,device,device_len,width,height,depth,windowed,texture_depth);
 }
 
 void WW3D::_Invalidate_Mesh_Cache()
@@ -820,11 +808,11 @@ WW3DErrorType WW3D::Begin_Render(bool clear,bool clearz,const Vector3 & color, v
 		vp.MinZ = 0.0f;;
 		vp.MaxZ = 1.0f;
 		DX8Wrapper::Set_Viewport(&vp);
-		DX8Wrapper::Clear(clear, clearz, color);
+		Backend->Clear(clear, clearz, color);
 	}
 
-	// Notify D3D that we are beginning to render the frame
-	DX8Wrapper::Begin_Scene();
+	// Notify the backend that we are beginning to render the frame
+	Backend->Begin_Scene();
 
 	return WW3D_ERROR_OK;
 }
@@ -1065,7 +1053,7 @@ WW3DErrorType WW3D::End_Render(bool flip_frame)
 
 	{
 		WWPROFILE("DX8Wrapper::End_Scene");
-		DX8Wrapper::End_Scene(flip_frame);
+		Backend->End_Scene(flip_frame);
 	}
 
 	FrameCount++;
@@ -1094,7 +1082,9 @@ WW3DErrorType WW3D::End_Render(bool flip_frame)
  *=============================================================================================*/
 void WW3D::Flip_To_Primary(void)
 {
-	DX8Wrapper::Flip_To_Primary();
+	if (Backend) {
+		Backend->Flip_To_Primary();
+	}
 }
 
 
@@ -1154,7 +1144,9 @@ void WW3D::Sync(unsigned int sync_time)
  *=============================================================================================*/
 void WW3D::Set_Ext_Swap_Interval(int swap)
 {
-	DX8Wrapper::Set_Swap_Interval(swap);
+	if (Backend) {
+		Backend->Set_Swap_Interval(swap);
+	}
 }
 
 
@@ -1172,7 +1164,7 @@ void WW3D::Set_Ext_Swap_Interval(int swap)
  *=============================================================================================*/
 int WW3D::Get_Ext_Swap_Interval(void)
 {
-	return DX8Wrapper::Get_Swap_Interval();
+	return Backend ? Backend->Get_Swap_Interval() : 0;
 }
 
 
@@ -1229,12 +1221,15 @@ int WW3D::Get_Collision_Box_Display_Mask(void)
 void WW3D::Normalize_Coordinates(int x, int y, float &fx, float &fy)
 {
 	// clip the coordinates back into the resolution of the screen
-	x = Bound(x, 0, DX8Wrapper::Get_Device_Resolution_Width());
-	y = Bound(y, 0, DX8Wrapper::Get_Device_Resolution_Height());
+	int width = Backend ? Backend->Get_Device_Resolution_Width() : DEFAULT_RESOLUTION_WIDTH;
+	int height = Backend ? Backend->Get_Device_Resolution_Height() : DEFAULT_RESOLUTION_HEIGHT;
+
+	x = Bound(x, 0, width);
+	y = Bound(y, 0, height);
 
 	// now that the coordinates are clipped convert them to their normalized values.
-	fx = (float)x / DX8Wrapper::Get_Device_Resolution_Width();
-	fy = (float)y / DX8Wrapper::Get_Device_Resolution_Height();
+	fx = (float)x / width;
+	fy = (float)y / height;
 }
 
 
@@ -1843,12 +1838,14 @@ void WW3D::Update_Pixel_Center(void)
 
 void WW3D::Set_Texture_Bitdepth(int bitdepth)
 {
-	DX8Wrapper::Set_Texture_Bitdepth(bitdepth);
+	if (Backend) {
+		Backend->Set_Texture_Bitdepth(bitdepth);
+	}
 }
 
 int WW3D::Get_Texture_Bitdepth()
 {
-	return DX8Wrapper::Get_Texture_Bitdepth();
+	return Backend ? Backend->Get_Texture_Bitdepth() : DEFAULT_BIT_DEPTH;
 }
 
 void WW3D::Add_To_Static_Sort_List(RenderObjClass *robj, unsigned int sort_level)

--- a/Code/ww3d2/ww3d.h
+++ b/Code/ww3d2/ww3d.h
@@ -62,6 +62,7 @@ class		RenderDeviceDescClass;
 class		StringClass;
 class		LightEnvironmentClass;
 class		MaterialPassClass;
+class		WW3DBackend;
 
 #define MESH_RENDER_SNAPSHOT_ENABLED
 #define SNAPSHOT_SAY(x) if (WW3D::Is_Snapshot_Activated()) { WWDEBUG_SAY(x); }
@@ -350,6 +351,7 @@ private:
 	static bool							IsTexturingEnabled;
 
 	static bool							Lite;
+	static WW3DBackend *			Backend;
 
 	// This is the default native screen size which will be set for each
 	// RenderObject on construction. The native screen size is the screen size

--- a/Code/ww3d2/ww3dbackend.h
+++ b/Code/ww3d2/ww3dbackend.h
@@ -1,0 +1,95 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * WW3DBackend interface - minimal device-level abstraction for render backends.              *
+ *                                                                                             *
+ * Concrete backends (DX8, Vulkan, null) implement this interface. DX8Wrapper stays          *
+ * standalone and is NOT part of this interface chain.                                        *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef WW3DBACKEND_H
+#define WW3DBACKEND_H
+
+#include "vector3.h"
+#include "scene.h"
+#include "rddesc.h"
+#include "index.h"
+
+class WW3DBackend
+{
+public:
+    virtual ~WW3DBackend() {}
+
+    // Initialization
+    virtual bool Init(void * hwnd, bool lite = false) = 0;
+    virtual void Shutdown() = 0;
+
+    // Device enumeration
+    virtual bool Set_Any_Render_Device() = 0;
+    virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+    virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+    virtual bool Set_Next_Render_Device() = 0;
+    virtual bool Toggle_Windowed() = 0;
+    virtual bool Is_Windowed() = 0;
+
+    virtual int Get_Render_Device_Count() = 0;
+    virtual int Get_Render_Device() = 0;
+    virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) = 0;
+    virtual const char * Get_Render_Device_Name(int device_index) = 0;
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+    virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) = 0;
+    virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) = 0;
+    virtual int Get_Device_Resolution_Width() = 0;
+    virtual int Get_Device_Resolution_Height() = 0;
+
+    // Registry
+    virtual bool Registry_Save_Render_Device(const char * sub_key) = 0;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) = 0;
+    virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) = 0;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) = 0;
+
+    // Scene
+    virtual void Begin_Scene() = 0;
+    virtual void End_Scene(bool flip_frame = true) = 0;
+    virtual void Flip_To_Primary() = 0;
+
+    // Clear
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) = 0;
+
+    // Render type
+    virtual void SetRenderType(SceneClass::PolyRenderType) = 0;
+
+    // VSync
+    virtual void Set_Swap_Interval(int swap) = 0;
+    virtual int Get_Swap_Interval() = 0;
+
+    // Texture depth
+    virtual void Set_Texture_Bitdepth(int depth) = 0;
+    virtual int Get_Texture_Bitdepth() = 0;
+};
+
+#endif // WW3DBACKEND_H

--- a/Code/ww3d2/ww3dbackend.h
+++ b/Code/ww3d2/ww3dbackend.h
@@ -35,10 +35,9 @@
 #define WW3DBACKEND_H
 
 #include "vector3.h"
-#include "rddesc.h"
-#include "index.h"
 
 class SceneClass;
+class RenderDeviceDescClass;
 
 class WW3DBackend
 {

--- a/Code/ww3d2/ww3dbackend.h
+++ b/Code/ww3d2/ww3dbackend.h
@@ -80,9 +80,6 @@ public:
     // Clear
     virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) = 0;
 
-    // Render type
-    virtual void SetRenderType(SceneClass::PolyRenderType) = 0;
-
     // VSync
     virtual void Set_Swap_Interval(int swap) = 0;
     virtual int Get_Swap_Interval() = 0;

--- a/Code/ww3d2/ww3dbackend.h
+++ b/Code/ww3d2/ww3dbackend.h
@@ -35,9 +35,10 @@
 #define WW3DBACKEND_H
 
 #include "vector3.h"
-#include "scene.h"
 #include "rddesc.h"
 #include "index.h"
+
+class SceneClass;
 
 class WW3DBackend
 {


### PR DESCRIPTION
## Summary

This PR introduces the critical renderer backend seam needed before any DX12/Vulkan/DXVK work can be split out safely.

It adds a small `WW3DBackend` device/lifecycle interface and wires `WW3D` to own a backend instance. The existing DX8/DX9 renderer remains implemented by `DX8Wrapper`; the new `DX8Backend` wraps that static API by composition instead of making `DX8Wrapper` inherit from the interface.

A minimal `NullBackend` is also included so non-DX9 builds have a compile-time backend target without pulling D3D types into the backend abstraction.

## Why this shape

An earlier inheritance-based approach (`DX8Wrapper : WW3DBackend`) creates circular include pressure through texture/surface/mesh renderer headers. This PR intentionally avoids that by:

- keeping `DX8Wrapper` standalone
- adding `DX8Backend` as a composition wrapper
- keeping `ww3dbackend.h` minimal and device-oriented
- avoiding mesh/texture/surface factory dependencies in the backend interface

## Changes

- Add `Code/ww3d2/ww3dbackend.h`
- Add `Code/ww3d2/dx8backend.{h,cpp}`
- Add `Code/ww3d2/nullbackend.{h,cpp}`
- Wire `WW3D` to create/use a backend instance
- Add `ENABLE_DX9_BACKEND`, defaulting ON for Windows and OFF elsewhere
- Add a `WW3D_RDDESC_NO_D3D` path for the null backend's render-device descriptor stub

## Validation

- `git diff --check w3dhub/main..HEAD` passed
- Linux CMake configure passed with `-DENABLE_DX9_BACKEND=OFF`
- Linux `nullbackend.cpp` object compile passed
- Windows/MSVC x64 NMake build passed for `ww3d2` with `-DENABLE_DX9_BACKEND=ON`

Windows validation command used:

```bat
cmake -S . -B build-pr-seam -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DENABLE_DX9_BACKEND=ON -DW3D_BUILD_OPTION_FFMPEG=OFF
cmake --build build-pr-seam --target ww3d2 --config Release
```

## Notes

This PR does not add a DX12 or Vulkan backend yet. It is the first seam that makes those future PRs tractable and reviewable.

Linux full `ww3d2` target still has pre-existing unrelated portability failures in `wwlib` (`intrin.h`, `_lrotl`, etc.), so this PR only claims Linux configure + null backend object validation.

## AI assistance disclosure

This PR was generated with AI assistance through OpenClaw. The implementation and PR preparation used OpenAI Codex GPT-5.5 via OpenClaw; earlier exploratory work in this thread also used MiniMax M2.7 / MiniMax M2.7-highspeed agents. Changes were validated with local Linux configure/object checks and a Windows/MSVC `ww3d2` build before opening the PR.
