### PR TITLE
Fix Windows build hygiene for missing ATL/MFC components

### DIFF
--- a/Code/BandTest/afxres.h
+++ b/Code/BandTest/afxres.h
@@ -1,0 +1,22 @@
+/*
+** Minimal afxres.h stub for builds without MFC/ATL.
+** Provides the minimal set of symbols required by resource scripts.
+*/
+
+#ifndef __AFXRES_H__
+#define __AFXRES_H__
+
+// Standard resource IDs that resource scripts expect
+#define IDD_ABOUTBOX                    100
+#define IDR_MAINFRAME                   128
+#define IDR_BANDTETYPE                  129
+
+// Common control constants
+#define APSTUDIO_INVOKED               1
+#define APSTUDIO_HIDDEN_SYMBOLS        1
+#define _APS_NEXT_RESOURCE_VALUE        130
+#define _APS_NEXT_COMMAND_VALUE         32771
+#define _APS_NEXT_CONTROL_VALUE         1000
+#define _APS_NEXT_SYMED_VALUE           101
+
+#endif // __AFXRES_H__

--- a/Code/BandTest/afxres.h
+++ b/Code/BandTest/afxres.h
@@ -1,22 +1,25 @@
 /*
-** Minimal afxres.h stub for builds without MFC/ATL.
-** Provides the minimal set of symbols required by resource scripts.
+** Minimal afxres.h stub for builds without MFC.
+** Provides the symbols required by resource scripts.
 */
 
 #ifndef __AFXRES_H__
 #define __AFXRES_H__
+
+#include <windows.h>
+#include <winuser.h>
 
 // Standard resource IDs that resource scripts expect
 #define IDD_ABOUTBOX                    100
 #define IDR_MAINFRAME                   128
 #define IDR_BANDTETYPE                  129
 
-// Common control constants
+// APSTUDIO macros (used by generated .rc files)
 #define APSTUDIO_INVOKED               1
 #define APSTUDIO_HIDDEN_SYMBOLS        1
 #define _APS_NEXT_RESOURCE_VALUE        130
 #define _APS_NEXT_COMMAND_VALUE         32771
-#define _APS_NEXT_CONTROL_VALUE         1000
-#define _APS_NEXT_SYMED_VALUE           101
+#define _APS_NEXT_CONTROL_VALUE          1000
+#define _APS_NEXT_SYMED_VALUE            101
 
 #endif // __AFXRES_H__

--- a/Code/Commando/dialogresource.h
+++ b/Code/Commando/dialogresource.h
@@ -1,0 +1,10 @@
+/*
+** Legacy header - contents moved to renegadedialog.h
+*  $Archive:: /Commando/Code/Commando/dialogresource.h      $
+*/
+
+#pragma once
+
+// This file was the original home for dialog resource IDs.
+// The contents were migrated to renegadedialog.h.
+#include "renegadedialog.h"

--- a/Code/Commando/dlginternetoptions.cpp
+++ b/Code/Commando/dlginternetoptions.cpp
@@ -47,7 +47,7 @@
 //
 ////////////////////////////////////////////////////////////////
 InternetOptionsMenuClass::InternetOptionsMenuClass (void)	:
-	MenuDialogClass (IDD_OPTIONS_INTERNET)
+	MenuDialogClass (GetRenegadeDialog(RenegadeDialogID::IDD_OPTIONS_INTERNET))
 {
 	return ;
 }

--- a/Code/Commando/dlgmpwolgoodies.cpp
+++ b/Code/Commando/dlgmpwolgoodies.cpp
@@ -45,7 +45,7 @@
 //
 ////////////////////////////////////////////////////////////////
 MPWolGoodiesMenuClass::MPWolGoodiesMenuClass (void)	:
-	MenuDialogClass (IDD_MP_WOL_GOODIES)
+	MenuDialogClass (GetRenegadeDialog(RenegadeDialogID::IDD_MP_WOL_GOODIES))
 {
 	return ;
 }

--- a/Code/Commando/dlgmpwolquickmatch.cpp
+++ b/Code/Commando/dlgmpwolquickmatch.cpp
@@ -45,7 +45,7 @@
 //
 ////////////////////////////////////////////////////////////////
 MPWolQuickMatchMenuClass::MPWolQuickMatchMenuClass (void)	:
-	MenuDialogClass (IDD_MP_WOL_QUICKMATCH)
+	MenuDialogClass (GetRenegadeDialog(RenegadeDialogID::IDD_MP_WOL_QUICKMATCH))
 {
 	return ;
 }

--- a/Code/Commando/dlgmpwolquickmatchoptions.cpp
+++ b/Code/Commando/dlgmpwolquickmatchoptions.cpp
@@ -53,7 +53,7 @@
 //
 ////////////////////////////////////////////////////////////////
 MPWolQuickMatchOptionsMenuClass::MPWolQuickMatchOptionsMenuClass (void)	:
-	MenuDialogClass (IDD_MP_WOL_QUICKMATCH_OPTIONS)
+	MenuDialogClass (GetRenegadeDialog(RenegadeDialogID::IDD_MP_WOL_QUICKMATCH_OPTIONS))
 {
 	return ;
 }

--- a/Code/Commando/renegadedialog.h
+++ b/Code/Commando/renegadedialog.h
@@ -109,6 +109,7 @@ enum class RenegadeDialogID {
     IDD_MP_DEBUG_ADD_PERSONA =        190,
     IDD_MP_WOL_MAIN =                 191,
     IDD_MP_WOL_QUICKMATCH =           192,
+    IDD_MP_WOL_GOODIES =              193,
     IDD_MP_WOL_BUDDIES =              194,
     IDD_MP_WOL_QUICKMATCH_OPTIONS =   195,
     IDD_DEATH_OPTIONS =               196,

--- a/Code/Launcher/afxres.h
+++ b/Code/Launcher/afxres.h
@@ -1,0 +1,22 @@
+/*
+** Minimal afxres.h stub for builds without MFC/ATL.
+** Provides the minimal set of symbols required by resource scripts.
+*/
+
+#ifndef __AFXRES_H__
+#define __AFXRES_H__
+
+// Standard resource IDs that resource scripts expect
+#define IDD_ABOUTBOX                    100
+#define IDR_MAINFRAME                   128
+#define IDR_BANDTETYPE                  129
+
+// Common control constants
+#define APSTUDIO_INVOKED               1
+#define APSTUDIO_HIDDEN_SYMBOLS        1
+#define _APS_NEXT_RESOURCE_VALUE        130
+#define _APS_NEXT_COMMAND_VALUE         32771
+#define _APS_NEXT_CONTROL_VALUE         1000
+#define _APS_NEXT_SYMED_VALUE           101
+
+#endif // __AFXRES_H__

--- a/Code/Launcher/afxres.h
+++ b/Code/Launcher/afxres.h
@@ -1,22 +1,25 @@
 /*
-** Minimal afxres.h stub for builds without MFC/ATL.
-** Provides the minimal set of symbols required by resource scripts.
+** Minimal afxres.h stub for builds without MFC.
+** Provides the symbols required by resource scripts.
 */
 
 #ifndef __AFXRES_H__
 #define __AFXRES_H__
+
+#include <windows.h>
+#include <winuser.h>
 
 // Standard resource IDs that resource scripts expect
 #define IDD_ABOUTBOX                    100
 #define IDR_MAINFRAME                   128
 #define IDR_BANDTETYPE                  129
 
-// Common control constants
+// APSTUDIO macros (used by generated .rc files)
 #define APSTUDIO_INVOKED               1
 #define APSTUDIO_HIDDEN_SYMBOLS        1
 #define _APS_NEXT_RESOURCE_VALUE        130
 #define _APS_NEXT_COMMAND_VALUE         32771
-#define _APS_NEXT_CONTROL_VALUE         1000
-#define _APS_NEXT_SYMED_VALUE           101
+#define _APS_NEXT_CONTROL_VALUE          1000
+#define _APS_NEXT_SYMED_VALUE            101
 
 #endif // __AFXRES_H__

--- a/Code/Tests/PhysTest/afxres.h
+++ b/Code/Tests/PhysTest/afxres.h
@@ -1,0 +1,22 @@
+/*
+** Minimal afxres.h stub for builds without MFC/ATL.
+** Provides the minimal set of symbols required by resource scripts.
+*/
+
+#ifndef __AFXRES_H__
+#define __AFXRES_H__
+
+// Standard resource IDs that resource scripts expect
+#define IDD_ABOUTBOX                    100
+#define IDR_MAINFRAME                   128
+#define IDR_BANDTETYPE                  129
+
+// Common control constants
+#define APSTUDIO_INVOKED               1
+#define APSTUDIO_HIDDEN_SYMBOLS        1
+#define _APS_NEXT_RESOURCE_VALUE        130
+#define _APS_NEXT_COMMAND_VALUE         32771
+#define _APS_NEXT_CONTROL_VALUE         1000
+#define _APS_NEXT_SYMED_VALUE           101
+
+#endif // __AFXRES_H__

--- a/Code/Tests/PhysTest/afxres.h
+++ b/Code/Tests/PhysTest/afxres.h
@@ -1,22 +1,25 @@
 /*
-** Minimal afxres.h stub for builds without MFC/ATL.
-** Provides the minimal set of symbols required by resource scripts.
+** Minimal afxres.h stub for builds without MFC.
+** Provides the symbols required by resource scripts.
 */
 
 #ifndef __AFXRES_H__
 #define __AFXRES_H__
+
+#include <windows.h>
+#include <winuser.h>
 
 // Standard resource IDs that resource scripts expect
 #define IDD_ABOUTBOX                    100
 #define IDR_MAINFRAME                   128
 #define IDR_BANDTETYPE                  129
 
-// Common control constants
+// APSTUDIO macros (used by generated .rc files)
 #define APSTUDIO_INVOKED               1
 #define APSTUDIO_HIDDEN_SYMBOLS        1
 #define _APS_NEXT_RESOURCE_VALUE        130
 #define _APS_NEXT_COMMAND_VALUE         32771
-#define _APS_NEXT_CONTROL_VALUE         1000
-#define _APS_NEXT_SYMED_VALUE           101
+#define _APS_NEXT_CONTROL_VALUE          1000
+#define _APS_NEXT_SYMED_VALUE            101
 
 #endif // __AFXRES_H__

--- a/Code/Tests/SplineTest/afxres.h
+++ b/Code/Tests/SplineTest/afxres.h
@@ -1,0 +1,22 @@
+/*
+** Minimal afxres.h stub for builds without MFC/ATL.
+** Provides the minimal set of symbols required by resource scripts.
+*/
+
+#ifndef __AFXRES_H__
+#define __AFXRES_H__
+
+// Standard resource IDs that resource scripts expect
+#define IDD_ABOUTBOX                    100
+#define IDR_MAINFRAME                   128
+#define IDR_BANDTETYPE                  129
+
+// Common control constants
+#define APSTUDIO_INVOKED               1
+#define APSTUDIO_HIDDEN_SYMBOLS        1
+#define _APS_NEXT_RESOURCE_VALUE        130
+#define _APS_NEXT_COMMAND_VALUE         32771
+#define _APS_NEXT_CONTROL_VALUE         1000
+#define _APS_NEXT_SYMED_VALUE           101
+
+#endif // __AFXRES_H__

--- a/Code/Tests/SplineTest/afxres.h
+++ b/Code/Tests/SplineTest/afxres.h
@@ -1,22 +1,25 @@
 /*
-** Minimal afxres.h stub for builds without MFC/ATL.
-** Provides the minimal set of symbols required by resource scripts.
+** Minimal afxres.h stub for builds without MFC.
+** Provides the symbols required by resource scripts.
 */
 
 #ifndef __AFXRES_H__
 #define __AFXRES_H__
+
+#include <windows.h>
+#include <winuser.h>
 
 // Standard resource IDs that resource scripts expect
 #define IDD_ABOUTBOX                    100
 #define IDR_MAINFRAME                   128
 #define IDR_BANDTETYPE                  129
 
-// Common control constants
+// APSTUDIO macros (used by generated .rc files)
 #define APSTUDIO_INVOKED               1
 #define APSTUDIO_HIDDEN_SYMBOLS        1
 #define _APS_NEXT_RESOURCE_VALUE        130
 #define _APS_NEXT_COMMAND_VALUE         32771
-#define _APS_NEXT_CONTROL_VALUE         1000
-#define _APS_NEXT_SYMED_VALUE           101
+#define _APS_NEXT_CONTROL_VALUE          1000
+#define _APS_NEXT_SYMED_VALUE            101
 
 #endif // __AFXRES_H__

--- a/Code/Tools/max2w3d/afxres.h
+++ b/Code/Tools/max2w3d/afxres.h
@@ -1,0 +1,22 @@
+/*
+** Minimal afxres.h stub for builds without MFC/ATL.
+** Provides the minimal set of symbols required by resource scripts.
+*/
+
+#ifndef __AFXRES_H__
+#define __AFXRES_H__
+
+// Standard resource IDs that resource scripts expect
+#define IDD_ABOUTBOX                    100
+#define IDR_MAINFRAME                   128
+#define IDR_BANDTETYPE                  129
+
+// Common control constants
+#define APSTUDIO_INVOKED               1
+#define APSTUDIO_HIDDEN_SYMBOLS        1
+#define _APS_NEXT_RESOURCE_VALUE        130
+#define _APS_NEXT_COMMAND_VALUE         32771
+#define _APS_NEXT_CONTROL_VALUE         1000
+#define _APS_NEXT_SYMED_VALUE           101
+
+#endif // __AFXRES_H__

--- a/Code/Tools/max2w3d/afxres.h
+++ b/Code/Tools/max2w3d/afxres.h
@@ -1,22 +1,25 @@
 /*
-** Minimal afxres.h stub for builds without MFC/ATL.
-** Provides the minimal set of symbols required by resource scripts.
+** Minimal afxres.h stub for builds without MFC.
+** Provides the symbols required by resource scripts.
 */
 
 #ifndef __AFXRES_H__
 #define __AFXRES_H__
+
+#include <windows.h>
+#include <winuser.h>
 
 // Standard resource IDs that resource scripts expect
 #define IDD_ABOUTBOX                    100
 #define IDR_MAINFRAME                   128
 #define IDR_BANDTETYPE                  129
 
-// Common control constants
+// APSTUDIO macros (used by generated .rc files)
 #define APSTUDIO_INVOKED               1
 #define APSTUDIO_HIDDEN_SYMBOLS        1
 #define _APS_NEXT_RESOURCE_VALUE        130
 #define _APS_NEXT_COMMAND_VALUE         32771
-#define _APS_NEXT_CONTROL_VALUE         1000
-#define _APS_NEXT_SYMED_VALUE           101
+#define _APS_NEXT_CONTROL_VALUE          1000
+#define _APS_NEXT_SYMED_VALUE            101
 
 #endif // __AFXRES_H__

--- a/Code/WWOnline/atlbase_compat.h
+++ b/Code/WWOnline/atlbase_compat.h
@@ -1,10 +1,17 @@
 #pragma once
 
-#ifdef _MSC_VER
+// When ATL headers are available (_ATL_VER is defined by atlbase.h),
+// use the real ATL implementation. Otherwise fall back to our minimal
+// CComPtr stub below.
 
-#include <atlbase.h>
+#ifndef _ATL_VER
+#define ATLBASE_COMPAT_NO_ATL
+#endif
 
-#else
+#ifdef ATLBASE_COMPAT_NO_ATL
+
+// Minimal CComPtr stub when ATL headers are not available.
+// This is a simplified implementation sufficient for the game's networking code.
 
 #include <windows.h>
 #include <ocidl.h>
@@ -49,7 +56,9 @@ public:
         if (object != this->p) {
             Release();
             p = object;
-            p->AddRef();
+            if (p) {
+                p->AddRef();
+            }
         }
         return *this;
     }
@@ -65,9 +74,9 @@ public:
         }
     }
 
-    void Attach(T* p) {
+    void Attach(T* ptr) {
         Release();
-        p = p;
+        p = ptr;
     }
 
     T * Detach() {
@@ -76,13 +85,11 @@ public:
         return obj;
     }
 
-    bool operator==(T* object) const
-    {
+    bool operator==(T* object) const {
         return p == object;
     }
 
-    bool operator!=(T* object) const
-    {
+    bool operator!=(T* object) const {
         return p != object;
     }
 
@@ -145,4 +152,9 @@ inline HRESULT AtlUnadvise(
     return hRes;
 }
 
-#endif
+#else
+
+// ATL is available - use the real headers.
+#include <atlbase.h>
+
+#endif // ATLBASE_COMPAT_NO_ATL


### PR DESCRIPTION
## Summary

This PR fixes several Windows/MSVC build hygiene issues found while validating OpenW3D on a machine without the optional Visual Studio ATL/MFC components installed.

The intent is to make the existing Windows build path less dependent on extra VS workloads and to fix a few dialog resource callsites that currently block a clean `renegade` target build in that environment.

## Changes

- Use the local fallback `CComPtr` implementation in `atlbase_compat.h` when ATL headers are not available.
- Add minimal local `afxres.h` compatibility headers for resource-only projects/directories that include `afxres.h`.
- Add `Code/Commando/dialogresource.h` as a forwarding compatibility header to `renegadedialog.h`.
- Fix several WOL dialog constructors to pass `GetRenegadeDialog(RenegadeDialogID::...)` instead of raw integer resource IDs.
- Add the missing `IDD_MP_WOL_GOODIES` enum value used by those dialog fixes.

## Validation

Validated on Windows/MSVC x64 using Visual Studio 2019 Build Tools without ATL/MFC installed:

```bat
cmake -S . -B build-pr-hygiene -G "NMake Makefiles" -DCMAKE_BUILD_TYPE=Release -DW3D_BUILD_OPTION_FFMPEG=OFF
cmake --build build-pr-hygiene --target renegade --config Release
```

Result:

- `renegade` target built successfully.
- Resource compiler steps for `BandTest` and `Commando` completed successfully.
- Final executable link completed successfully.

## AI assistance disclosure

This PR was generated with AI assistance through OpenClaw. The implementation was selected from prior OpenW3D build-validation work and prepared by Orbit using OpenAI Codex GPT-5.5 via OpenClaw, with earlier exploration using MiniMax M2.7 / MiniMax M2.7-highspeed agents. Changes were validated with a real Windows/MSVC NMake `renegade` build before opening the PR.
