### PR TITLE
Guard DXVK wrapper headers behind #ifdef _WIN32 with non-Windows stubs

### DIFF
--- a/Code/dxvk_wrapper/d3d9.h
+++ b/Code/dxvk_wrapper/d3d9.h
@@ -2,4 +2,6 @@
 
 #include "dxvk_wrapper_compat.h"
 
+#ifdef _WIN32
 #include <dxvk/d3d9.h>
+#endif

--- a/Code/dxvk_wrapper/d3dx9.h
+++ b/Code/dxvk_wrapper/d3dx9.h
@@ -2,4 +2,6 @@
 
 #include "dxvk_wrapper_compat.h"
 
+#ifdef _WIN32
 #include <dxvk/d3d9.h>
+#endif

--- a/Code/dxvk_wrapper/d3dx9core.h
+++ b/Code/dxvk_wrapper/d3dx9core.h
@@ -2,4 +2,6 @@
 
 #include "dxvk_wrapper_compat.h"
 
+#ifdef _WIN32
 #include <dxvk/d3dx9core.h>
+#endif

--- a/Code/dxvk_wrapper/dxvk_wrapper_compat.h
+++ b/Code/dxvk_wrapper/dxvk_wrapper_compat.h
@@ -1,15 +1,14 @@
 #pragma once
 
-#ifdef ZeroMemory
-#undef ZeroMemory
-#endif
-
+#ifdef _WIN32
 #include <windows_base.h>
 #include <windows.h>
+#endif
 
 #define LF_FACESIZE 32
 #define EXTERN_C extern "C"
 
+#ifdef _WIN32
 typedef struct GLYPHMETRICSFLOAT GLYPHMETRICSFLOAT;
 typedef GUID *LPGUID;
 typedef GUID CLSID;
@@ -18,10 +17,23 @@ typedef struct IStream IStream;
 typedef struct HFONT HFONT;
 typedef struct TEXTMETRICA TEXTMETRICA;
 typedef struct TEXTMETRICW TEXTMETRICW;
-
 typedef double DOUBLE;
-
 #define STDAPI HRESULT WINAPI
+typedef long HRESULT;
+#else
+// Stub types for non-Windows builds.
+// The dxvk_wrapper provides D3D9 type shims only; actual rendering
+// requires a platform-specific backend implementation.
+typedef void *LPGUID;
+typedef long HRESULT;
+#define STDAPI HRESULT
+#define DECLSPEC_UUID(X)
+typedef void *HFONT;
+typedef void *HBITMAP;
+typedef void *HDC;
+typedef void *HANDLE;
+typedef struct { void *lpVtbl; } IStream;
+#endif
 
 #define HIWORD(W) (((W) & 0xffff) >> 8)
 #define LOWORD(W) ((W) & 0xff)

--- a/Code/dxvk_wrapper/ocidl.h
+++ b/Code/dxvk_wrapper/ocidl.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include "windows.h"
+
+#ifdef _WIN32
 #include <dxvk/ocidl.h>
+#endif
 
 struct IConnectionPoint : public IUnknown {
 	virtual HRESULT Advise(IUnknown *pUnkSink, DWORD *dwCookie) = 0;

--- a/Code/dxvk_wrapper/rpc.h
+++ b/Code/dxvk_wrapper/rpc.h
@@ -4,7 +4,9 @@
 
 #define __RPCNDR_H_VERSION__
 
+#ifdef _WIN32
 #include <dxvk/rpc.h>
+#endif
 
 #define __RPC_FAR
 #define __RPC_USER

--- a/Code/dxvk_wrapper/windows.h
+++ b/Code/dxvk_wrapper/windows.h
@@ -2,4 +2,6 @@
 
 #include "dxvk_wrapper_compat.h"
 
+#ifdef _WIN32
 #include <dxvk/windows.h>
+#endif

--- a/cmake/dx9-headers.cmake
+++ b/cmake/dx9-headers.cmake
@@ -1,0 +1,11 @@
+# Use the same headers that dxvk uses
+FetchContent_Declare(
+    dx9
+    GIT_REPOSITORY https://github.com/misyltoad/mingw-directx-headers.git
+    GIT_TAG        9df86f2341616ef1888ae59919feaa6d4fad693d
+)
+
+FetchContent_MakeAvailable(dx9)
+
+add_library(d3d9lib INTERFACE)
+target_include_directories(d3d9lib INTERFACE "${dx9_SOURCE_DIR}")


### PR DESCRIPTION
## Summary

This PR guards the DXVK-provided DX9 header includes behind `#ifdef _WIN32` and adds minimal non-Windows type stubs so the `dxvk_wrapper` layer doesn't break Linux/Unix builds that don't have `dxvk` headers available.

It also adds the `cmake/dx9-headers.cmake` fetch helper (from `rm5248/OpenW3D`'s `dxvk-testing` branch) for platforms that want to use DXVK's header set, without including the full DXVK native library download.

## Changes

### `Code/dxvk_wrapper/` — guard DX9 header includes

- `d3d9.h`, `d3dx9.h`, `d3dx9core.h`, `ocidl.h`, `rpc.h`, `windows.h`:
  wrap `#include <dxvk/...>` in `#ifdef _WIN32` blocks
- `dxvk_wrapper_compat.h`:
  - guard `<windows_base.h>`/`<windows.h>` behind `#ifdef _WIN32`
  - remove unused `#undef ZeroMemory` guard
  - add minimal non-Windows stubs: `LPGUID`, `HFONT`, `HBITMAP`, `HDC`, `HANDLE`, `IStream`, `HRESULT`, `STDAPI`, `DECLSPEC_UUID`

### `cmake/dx9-headers.cmake` — add DX9 header fetch

- Mirrors the header-fetch approach from `rm5248/OpenW3D/dxvk-testing`
- Fetches DX9 headers from `misyltoad/mingw-directx-headers`
- Exposes an `d3d9lib` interface target for backends that want it

### Explicitly not included

- `cmake/dxvk.cmake` (DXVK native library download) — not ready for upstream; only useful on Steam Runtime/Linux and requires external tarball verification
- Any changes to actual rendering code

## Validation

- `git diff --check` passed
- Files modified are all within `dxvk_wrapper/` and `cmake/` — no ww3d2 core or rendering code touched
- The guard approach mirrors how the codebase already handles `WIN32`-only includes elsewhere

## AI assistance disclosure

This PR was generated with AI assistance through OpenClaw. Implementation prepared by Orbit using OpenAI Codex GPT-5.5 via OpenClaw. Changes are minimal and self-contained.