### PR TITLE
Add Vulkan and DX12 backend stub compile targets

### DIFF
--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -231,6 +231,54 @@ target_link_libraries(ww3d2 PRIVATE
 
 target_sources(ww3d2 PRIVATE ${WW3D2_SRC})
 
+# Additional backend options (DX8 is always available on Windows via ENABLE_DX9_BACKEND)
+# Vulkan: cross-platform, requires Vulkan SDK headers
+option(ENABLE_VULKAN_BACKEND "Enable Vulkan backend" OFF)
+add_feature_info(Vulkan_Backend ENABLE_VULKAN_BACKEND "Vulkan render backend (cross-platform)")
+
+# DX12: Windows-only, requires Windows 10 SDK
+option(ENABLE_DX12_BACKEND "Enable DirectX 12 backend" OFF)
+add_feature_info(DX12_Backend ENABLE_DX12_BACKEND "DirectX 12 render backend (Windows only)")
+
+# Vulkan backend sources
+if (ENABLE_VULKAN_BACKEND)
+    if (NOT WIN32)
+        find_package(Vulkan QUIET)
+        if (NOT Vulkan_FOUND)
+            message(STATUS "Vulkan not found; Vulkan backend will not be built")
+        endif()
+    else()
+        # On Windows, Vulkan is typically available via the GPU driver
+        find_package(Vulkan QUIET)
+    endif()
+    if (Vulkan_FOUND)
+        target_sources(ww3d2 PRIVATE
+            backends/vulkan/vulkanbackend.cpp
+        )
+        target_include_directories(ww3d2 PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/backends/vulkan
+        )
+        target_link_libraries(ww3d2 PRIVATE Vulkan::Vulkan)
+    else()
+        message(STATUS "Vulkan backend enabled but Vulkan not available — backend stub will be excluded")
+        # Still update cache so the option appears "on" even if unmet
+    endif()
+endif()
+
+# DX12 backend sources (Windows only)
+if (ENABLE_DX12_BACKEND)
+    if (WIN32)
+        target_sources(ww3d2 PRIVATE
+            backends/dx12/dx12backend.cpp
+        )
+        target_include_directories(ww3d2 PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/backends/dx12
+        )
+    else()
+        message(WARNING "ENABLE_DX12_BACKEND is Windows-only; ignoring on ${CMAKE_SYSTEM_NAME}")
+    endif()
+endif()
+
 # This module needs building differently for the level editor
 if (W3D_TOOLS)
     # Targets to build.

--- a/Code/ww3d2/backends/dx12/dx12backend.cpp
+++ b/Code/ww3d2/backends/dx12/dx12backend.cpp
@@ -1,0 +1,83 @@
+/**
+ * DX12Backend — stub DirectX 12 render backend implementation.
+ *
+ * STATUS: Not implemented. All methods return false or no-op.
+ *
+ * This file exists to:
+ * - Establish the DX12 backend's concrete shape matching DX12Backend class
+ * - Provide a compile-valid stub so the CMake plumbing can reference it
+ * - Serve as the implementation entry point when real DX12 work begins
+ *
+ * Build enable: cmake -DENABLE_DX12_BACKEND=ON
+ * Note: requires Windows 10 SDK (d3d12.h, dxgi1_6.h) — not available on Linux
+ */
+
+#include "backends/dx12/dx12backend.h"
+
+DX12Backend::DX12Backend() = default;
+DX12Backend::~DX12Backend() = default;
+
+bool DX12Backend::Init(void * /*hwnd*/, bool /*lite*/)
+{
+    // TODO: create D3D12 device via D3D12CreateDevice()
+    // TODO: create command queue (D3D12_COMMAND_LIST_TYPE_DIRECT)
+    // TODO: create swapchain via CreateSwapChain()
+    // TODO: create descriptor heaps (RTV, DSV, SRV)
+    // TODO: create command allocators and command lists
+    m_initialized = false;
+    return false;
+}
+
+void DX12Backend::Shutdown()
+{
+    // TODO: wait for GPU idle
+    // TODO: release all D3D12 COM objects
+    m_initialized = false;
+}
+
+bool DX12Backend::Set_Any_Render_Device() { return false; }
+bool DX12Backend::Set_Render_Device(const char * /*dev_name*/, int, int, int, int, bool) { return false; }
+bool DX12Backend::Set_Render_Device(int, int, int, int, int, bool) { return false; }
+bool DX12Backend::Set_Next_Render_Device() { return false; }
+bool DX12Backend::Toggle_Windowed() { return false; }
+bool DX12Backend::Is_Windowed() { return false; }
+
+int DX12Backend::Get_Render_Device_Count() { return 0; }
+int DX12Backend::Get_Render_Device() { return -1; }
+
+const RenderDeviceDescClass & DX12Backend::Get_Render_Device_Desc(int /*deviceidx*/)
+{
+    static RenderDeviceDescClass null_desc;
+    return null_desc;
+}
+
+const char * DX12Backend::Get_Render_Device_Name(int /*device_index*/) { return "DX12 (not implemented)"; }
+
+bool DX12Backend::Set_Device_Resolution(int, int, int, int, bool) { return false; }
+void DX12Backend::Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    set_w = set_h = set_bits = 0;
+    set_windowed = false;
+}
+void DX12Backend::Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    set_w = set_h = set_bits = 0;
+    set_windowed = false;
+}
+int DX12Backend::Get_Device_Resolution_Width() { return 0; }
+int DX12Backend::Get_Device_Resolution_Height() { return 0; }
+
+bool DX12Backend::Registry_Save_Render_Device(const char * /*sub_key*/) { return false; }
+bool DX12Backend::Registry_Load_Render_Device(const char * /*sub_key*/, bool) { return false; }
+bool DX12Backend::Registry_Save_Render_Device(const char *, int, int, int, int, bool, int) { return false; }
+bool DX12Backend::Registry_Load_Render_Device(const char *, char *, int, int&, int&, int&, int&, int&) { return false; }
+
+void DX12Backend::Begin_Scene() {}
+void DX12Backend::End_Scene(bool /*flip_frame*/) {}
+void DX12Backend::Flip_To_Primary() {}
+
+void DX12Backend::Clear(bool, bool, const Vector3 &, float, unsigned int) {}
+void DX12Backend::Set_Swap_Interval(int) {}
+int DX12Backend::Get_Swap_Interval() { return 0; }
+void DX12Backend::Set_Texture_Bitdepth(int) {}
+int DX12Backend::Get_Texture_Bitdepth() { return 0; }

--- a/Code/ww3d2/backends/dx12/dx12backend.h
+++ b/Code/ww3d2/backends/dx12/dx12backend.h
@@ -1,0 +1,87 @@
+#pragma once
+
+/**
+ * DX12Backend — stub DirectX 12 render backend for OpenW3D.
+ *
+ * STATUS: Not implemented. This is a compile-time skeleton that declares
+ * the backend interface shape without providing any rendering logic.
+ *
+ * TODO:
+ * - Implement D3D12 device creation and command queue setup
+ * - Implement swapchain / present queue management
+ * - Implement scene begin/end and frame presentation
+ * - Wire into WW3DBackend lifecycle
+ *
+ * Compilation requires:
+ * - Windows 10 SDK (d3d12.h, dxgi1_6.h)
+ * - D3D12 SDK layers and debug layer support
+ *
+ * Build enable: cmake -DENABLE_DX12_BACKEND=ON
+ */
+
+#include "ww3dbackend.h"
+
+class DX12Backend : public WW3DBackend
+{
+public:
+    DX12Backend();
+    virtual ~DX12Backend();
+
+    // Initialization
+    // Creates D3D12 device and command queues for the given window.
+    virtual bool Init(void * hwnd, bool lite = false) override;
+    virtual void Shutdown() override;
+
+    // Device enumeration — enumerates D3D12-capable adapters
+    virtual bool Set_Any_Render_Device() override;
+    virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Next_Render_Device() override;
+    virtual bool Toggle_Windowed() override;
+    virtual bool Is_Windowed() override;
+
+    virtual int Get_Render_Device_Count() override;
+    virtual int Get_Render_Device() override;
+    virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) override;
+    virtual const char * Get_Render_Device_Name(int device_index) override;
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual int Get_Device_Resolution_Width() override;
+    virtual int Get_Device_Resolution_Height() override;
+
+    // Registry persistence
+    virtual bool Registry_Save_Render_Device(const char * sub_key) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) override;
+    virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) override;
+
+    // Scene
+    virtual void Begin_Scene() override;
+    virtual void End_Scene(bool flip_frame = true) override;
+    virtual void Flip_To_Primary() override;
+
+    // Clear
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
+
+    // VSync
+    virtual void Set_Swap_Interval(int swap) override;
+    virtual int Get_Swap_Interval() override;
+
+    // Texture depth
+    virtual void Set_Texture_Bitdepth(int depth) override;
+    virtual int Get_Texture_Bitdepth() override;
+
+private:
+    // D3D12 internals — TODO: implement
+    // ID3D12Device * m_device = nullptr;
+    // IDXGISwapChain3 * m_swapchain = nullptr;
+    // ID3D12CommandQueue * m_command_queue = nullptr;
+    // ID3D12GraphicsCommandList * m_command_list = nullptr;
+    //
+    // std::vector<IDXGIAdapter1 *> m_adapters;
+    // int m_active_adapter = 0;
+    // int m_vsync = 1;
+
+    bool m_initialized = false;
+};

--- a/Code/ww3d2/backends/vulkan/vulkanbackend.cpp
+++ b/Code/ww3d2/backends/vulkan/vulkanbackend.cpp
@@ -1,0 +1,82 @@
+/**
+ * VulkanBackend — stub Vulkan render backend implementation.
+ *
+ * STATUS: Not implemented. All methods return false or no-op.
+ *
+ * This file exists to:
+ * - Establish the Vulkan backend's concrete shape matching VulkanBackend class
+ * - Provide a compile-valid stub so the CMake plumbing can reference it
+ * - Serve as the implementation entry point when real Vulkan work begins
+ *
+ * Build enable: cmake -DENABLE_VULKAN_BACKEND=ON
+ */
+
+#include "backends/vulkan/vulkanbackend.h"
+
+VulkanBackend::VulkanBackend() = default;
+VulkanBackend::~VulkanBackend() = default;
+
+bool VulkanBackend::Init(void * /*hwnd*/, bool /*lite*/)
+{
+    // TODO: create VkInstance with required extensions (VK_KHR_surface, etc.)
+    // TODO: enumerate physical devices and select GPU
+    // TODO: create VkDevice with queues and extensions
+    // TODO: create window surface (VkSurfaceKHR from hwnd)
+    // TODO: create swapchain
+    m_initialized = false;
+    return false;
+}
+
+void VulkanBackend::Shutdown()
+{
+    // TODO: wait for device idle
+    // TODO: destroy swapchain, surface, device, instance
+    m_initialized = false;
+}
+
+bool VulkanBackend::Set_Any_Render_Device() { return false; }
+bool VulkanBackend::Set_Render_Device(const char * /*dev_name*/, int, int, int, int, bool) { return false; }
+bool VulkanBackend::Set_Render_Device(int, int, int, int, int, bool) { return false; }
+bool VulkanBackend::Set_Next_Render_Device() { return false; }
+bool VulkanBackend::Toggle_Windowed() { return false; }
+bool VulkanBackend::Is_Windowed() { return false; }
+
+int VulkanBackend::Get_Render_Device_Count() { return 0; }
+int VulkanBackend::Get_Render_Device() { return -1; }
+
+const RenderDeviceDescClass & VulkanBackend::Get_Render_Device_Desc(int /*deviceidx*/)
+{
+    static RenderDeviceDescClass null_desc;
+    return null_desc;
+}
+
+const char * VulkanBackend::Get_Render_Device_Name(int /*device_index*/) { return "Vulkan (not implemented)"; }
+
+bool VulkanBackend::Set_Device_Resolution(int, int, int, int, bool) { return false; }
+void VulkanBackend::Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    set_w = set_h = set_bits = 0;
+    set_windowed = false;
+}
+void VulkanBackend::Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    set_w = set_h = set_bits = 0;
+    set_windowed = false;
+}
+int VulkanBackend::Get_Device_Resolution_Width() { return 0; }
+int VulkanBackend::Get_Device_Resolution_Height() { return 0; }
+
+bool VulkanBackend::Registry_Save_Render_Device(const char * /*sub_key*/) { return false; }
+bool VulkanBackend::Registry_Load_Render_Device(const char * /*sub_key*/, bool) { return false; }
+bool VulkanBackend::Registry_Save_Render_Device(const char *, int, int, int, int, bool, int) { return false; }
+bool VulkanBackend::Registry_Load_Render_Device(const char *, char *, int, int&, int&, int&, int&, int&) { return false; }
+
+void VulkanBackend::Begin_Scene() {}
+void VulkanBackend::End_Scene(bool /*flip_frame*/) {}
+void VulkanBackend::Flip_To_Primary() {}
+
+void VulkanBackend::Clear(bool, bool, const Vector3 &, float, unsigned int) {}
+void VulkanBackend::Set_Swap_Interval(int) {}
+int VulkanBackend::Get_Swap_Interval() { return 0; }
+void VulkanBackend::Set_Texture_Bitdepth(int) {}
+int VulkanBackend::Get_Texture_Bitdepth() { return 0; }

--- a/Code/ww3d2/backends/vulkan/vulkanbackend.h
+++ b/Code/ww3d2/backends/vulkan/vulkanbackend.h
@@ -1,0 +1,89 @@
+#pragma once
+
+/**
+ * VulkanBackend — stub Vulkan render backend for OpenW3D.
+ *
+ * STATUS: Not implemented. This is a compile-time skeleton that declares
+ * the backend interface shape without providing any rendering logic.
+ *
+ * TODO:
+ * - Implement Vulkan instance/device creation and destruction
+ * - Implement VK_KHR_surface swapchain management
+ * - Implement scene begin/end and frame submission
+ * - Wire into WW3DBackend lifecycle
+ *
+ * Compilation requires:
+ * - Vulkan SDK (vulkan-1, vulkan-headers)
+ * - Graphics pipeline state objects for our draw calls
+ * - Shader compilation pipeline (SPIR-V or GLSL)
+ *
+ * Build enable: cmake -DENABLE_VULKAN_BACKEND=ON
+ */
+
+#include "ww3dbackend.h"
+
+class VulkanBackend : public WW3DBackend
+{
+public:
+    VulkanBackend();
+    virtual ~VulkanBackend();
+
+    // Initialization
+    // Creates VkInstance and device with requested GPU/extensions.
+    virtual bool Init(void * hwnd, bool lite = false) override;
+    virtual void Shutdown() override;
+
+    // Device enumeration — enumerates Vulkan-capable GPUs
+    virtual bool Set_Any_Render_Device() override;
+    virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Next_Render_Device() override;
+    virtual bool Toggle_Windowed() override;
+    virtual bool Is_Windowed() override;
+
+    virtual int Get_Render_Device_Count() override;
+    virtual int Get_Render_Device() override;
+    virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) override;
+    virtual const char * Get_Render_Device_Name(int device_index) override;
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual int Get_Device_Resolution_Width() override;
+    virtual int Get_Device_Resolution_Height() override;
+
+    // Registry persistence
+    virtual bool Registry_Save_Render_Device(const char * sub_key) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) override;
+    virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) override;
+
+    // Scene
+    virtual void Begin_Scene() override;
+    virtual void End_Scene(bool flip_frame = true) override;
+    virtual void Flip_To_Primary() override;
+
+    // Clear
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
+
+    // VSync
+    virtual void Set_Swap_Interval(int swap) override;
+    virtual int Get_Swap_Interval() override;
+
+    // Texture depth
+    virtual void Set_Texture_Bitdepth(int depth) override;
+    virtual int Get_Texture_Bitdepth() override;
+
+private:
+    // Vulkan internals — TODO: implement
+    // VkInstance m_instance = VK_NULL_HANDLE;
+    // VkPhysicalDevice m_physical_device = VK_NULL_HANDLE;
+    // VkDevice m_device = VK_NULL_HANDLE;
+    // VkSurfaceKHR m_surface = VK_NULL_HANDLE;
+    // VkSwapchainKHR m_swapchain = VK_NULL_HANDLE;
+    //
+    // std::vector<VkPhysicalDevice> m_devices;
+    // int m_active_device = 0;
+    // int m_vsync = 1;
+
+    bool m_initialized = false;
+};


### PR DESCRIPTION
## Summary

This PR adds stub compile targets for Vulkan and DirectX 12 render backends, establishing the backend slot structure for future implementation work.

Each stub:
- Declares the full `WW3DBackend` interface (`VulkanBackend` / `DX12Backend`)
- Provides a compile-valid `.cpp` with all methods returning false/no-op
- Is CMake-plumbed behind its own `ENABLE_*_BACKEND` option (default OFF)
- Documents TODO items and required SDKs in the header

## Why this shape

This PR does **not** claim to implement rendering. It provides the structural slot — a place for real Vulkan or DX12 work to be plugged in without reshaping the CMake or header structure later. It's intentionally small and honest about what it does and doesn't do.

## Changes

### New files

- `Code/ww3d2/backends/vulkan/vulkanbackend.h` — stub Vulkan backend class
- `Code/ww3d2/backends/vulkan/vulkanbackend.cpp` — stub implementation
- `Code/ww3d2/backends/dx12/dx12backend.h` — stub DX12 backend class
- `Code/ww3d2/backends/dx12/dx12backend.cpp` — stub implementation

### CMake

- `Code/ww3d2/CMakeLists.txt` — added `ENABLE_VULKAN_BACKEND` (OFF by default) and `ENABLE_DX12_BACKEND` (OFF by default) with `add_feature_info`
- Vulkan sources are only added if `Vulkan_FOUND` at configure time
- DX12 sources are Windows-only; on other platforms a warning is emitted

### Build options

```cmake
cmake -S . -B build -DENABLE_VULKAN_BACKEND=ON   # enable Vulkan stub
cmake -S . -B build -DENABLE_DX12_BACKEND=ON     # enable DX12 stub (Windows only)
```

### What this does NOT include

- No actual rendering code
- No swapchain/presentation implementation
- No shader compilation pipeline
- No DXVK integration (see PR #110 for DXVK header guards)

## Validation

- `git diff --check` passed
- CMake configure passed with `-DENABLE_VULKAN_BACKEND=ON`
- Feature flags appear in CMake configure summary
- Build fails in `wwlib` due to pre-existing Linux portability issues (`intrin.h`, etc.) — unrelated to this PR, blocks full ww3d2 build on Linux in this environment

## AI assistance disclosure

This PR was generated with AI assistance through OpenClaw. Implementation prepared by Orbit using OpenAI Codex GPT-5.5 via OpenClaw.