### PR TITLE
Add DX8Backend implementing WW3DBackend interface

### DIFF
--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -29,6 +29,7 @@ set(WW3D2_SRC
     dx8texman.cpp
     dx8vertexbuffer.cpp
     dx8wrapper.cpp
+    dx8backend.cpp
     dynamesh.cpp
     font3d.cpp
     formconv.cpp
@@ -135,6 +136,7 @@ set(WW3D2_SRC
     dx8texman.h
     dx8vertexbuffer.h
     dx8wrapper.h
+    dx8backend.h
     dynamesh.h
     font3d.h
     formconv.h

--- a/Code/ww3d2/dx8backend.cpp
+++ b/Code/ww3d2/dx8backend.cpp
@@ -1,0 +1,334 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "dx8backend.h"
+#include "dx8wrapper.h"
+#include "rddesc.h"
+
+/*
+** Include dx8wrapper inline implementation for dx8backend's use of
+** DX8Wrapper static methods.
+** This pulls in the full DX8 implementation chain.
+*/
+#include "dx8wrapper_impl.h"
+
+// Disable warning about unused parameters in this file
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4100)
+#endif
+
+DX8Backend::DX8Backend()
+    : m_Initialized(false)
+    , m_IsWindowed(true)
+    , m_VSync(1)
+{
+}
+
+DX8Backend::~DX8Backend()
+{
+}
+
+//==========================================================================
+// Device enumeration
+//==========================================================================
+
+int DX8Backend::Enumerate_Devices(BackendDeviceCapabilities* devices, int max_devices)
+{
+    // Populate the DX8 internal device list first
+    DX8Wrapper::Enumerate_Devices();
+
+    int count = DX8Wrapper::Get_Render_Device_Count();
+    int count_to_report = (count < max_devices) ? count : max_devices;
+
+    for (int i = 0; i < count_to_report; i++) {
+        const RenderDeviceDescClass& desc = DX8Wrapper::Get_Render_Device_Desc(i);
+
+        BackendDeviceCapabilities& dev = devices[i];
+
+        dev.AdapterIndex = i;
+        dev.IsHardware = true; // DX8/DX9 adapters are physical GPUs
+        dev.IsExternal = false;
+        dev.DedicatedVideoMemory = -1; // DX8 doesn't expose VRAM at this level
+        dev.DedicatedSystemMemory = -1;
+        dev.SharedSystemMemory = -1;
+
+        // Device name
+        const char* name = desc.Get_Device_Name();
+        if (name) {
+            strncpy(dev.DeviceName, name, sizeof(dev.DeviceName) - 1);
+            dev.DeviceName[sizeof(dev.DeviceName) - 1] = '\0';
+        } else {
+            dev.DeviceName[0] = '\0';
+        }
+
+        // Driver name
+        strncpy(dev.DriverName, desc.DriverName, sizeof(dev.DriverName) - 1);
+        dev.DriverName[sizeof(dev.DriverName) - 1] = '\0';
+
+        // Driver version from D3DADAPTER_IDENTIFIER9
+        const D3DADAPTER_IDENTIFIER9& id = desc.Get_Adapter_Identifier();
+        snprintf(dev.DriverVersion, sizeof(dev.DriverVersion), "%d.%d.%d.%d",
+            HIWORD(id.DriverVersion.HighPart),
+            LOWORD(id.DriverVersion.HighPart),
+            HIWORD(id.DriverVersion.LowPart),
+            LOWORD(id.DriverVersion.LowPart));
+
+        dev.VendorId = static_cast<int>(id.VendorId);
+        dev.DeviceId = static_cast<int>(id.DeviceId);
+        dev.SubSystemId = static_cast<int>(id.SubSysId);
+        dev.RevisionId = static_cast<int>(id.Revision);
+    }
+
+    return count_to_report;
+}
+
+//==========================================================================
+// Initialization
+//==========================================================================
+
+bool DX8Backend::Init(void* hwnd, bool lite)
+{
+    // DX8Wrapper handles its own init — just record that we're initialized
+    // The actual Init call goes through DX8Wrapper directly for now
+    m_Initialized = true;
+    return true;
+}
+
+void DX8Backend::Shutdown()
+{
+    m_Initialized = false;
+}
+
+//==========================================================================
+// Device selection
+//==========================================================================
+
+bool DX8Backend::Set_Any_Render_Device()
+{
+    return DX8Wrapper::Set_Any_Render_Device() != WW3D_OK ? false : true;
+}
+
+bool DX8Backend::Set_Render_Device(const char* dev_name)
+{
+    return DX8Wrapper::Set_Render_Device(dev_name) != WW3D_OK ? false : true;
+}
+
+bool DX8Backend::Set_Render_Device(int adapter_index)
+{
+    return DX8Wrapper::Set_Render_Device(adapter_index) != WW3D_OK ? false : true;
+}
+
+bool DX8Backend::Set_Next_Render_Device()
+{
+    return DX8Wrapper::Set_Next_Render_Device() != WW3D_OK ? false : true;
+}
+
+bool DX8Backend::Toggle_Windowed()
+{
+    return DX8Wrapper::Toggle_Windowed() != WW3D_OK ? false : true;
+}
+
+bool DX8Backend::Is_Windowed()
+{
+    return DX8Wrapper::Is_Windowed();
+}
+
+//==========================================================================
+// Device properties
+//==========================================================================
+
+int DX8Backend::Get_Render_Device_Count()
+{
+    return DX8Wrapper::Get_Render_Device_Count();
+}
+
+int DX8Backend::Get_Render_Device()
+{
+    return DX8Wrapper::Get_Render_Device();
+}
+
+const BackendDeviceCapabilities& DX8Backend::Get_Render_Device_Desc(int adapter_index)
+{
+    // DX8Wrapper doesn't have a way to get cached desc without re-fetching,
+    // so we use a static temp. Caller should call Enumerate_Devices() first
+    // to populate the DX8 internal list.
+    static BackendDeviceCapabilities dev;
+    if (adapter_index < 0 || adapter_index >= DX8Wrapper::Get_Render_Device_Count()) {
+        dev = BackendDeviceCapabilities();
+        return dev;
+    }
+
+    const RenderDeviceDescClass& desc = DX8Wrapper::Get_Render_Device_Desc(adapter_index);
+    dev.AdapterIndex = adapter_index;
+    dev.IsHardware = true;
+    dev.IsExternal = false;
+    dev.DedicatedVideoMemory = -1;
+    dev.DedicatedSystemMemory = -1;
+    dev.SharedSystemMemory = -1;
+
+    const char* name = desc.Get_Device_Name();
+    if (name) {
+        strncpy(dev.DeviceName, name, sizeof(dev.DeviceName) - 1);
+        dev.DeviceName[sizeof(dev.DeviceName) - 1] = '\0';
+    } else {
+        dev.DeviceName[0] = '\0';
+    }
+
+    strncpy(dev.DriverName, desc.DriverName, sizeof(dev.DriverName) - 1);
+    dev.DriverName[sizeof(dev.DriverName) - 1] = '\0';
+
+    const D3DADAPTER_IDENTIFIER9& id = desc.Get_Adapter_Identifier();
+    snprintf(dev.DriverVersion, sizeof(dev.DriverVersion), "%d.%d.%d.%d",
+        HIWORD(id.DriverVersion.HighPart),
+        LOWORD(id.DriverVersion.HighPart),
+        HIWORD(id.DriverVersion.LowPart),
+        LOWORD(id.DriverVersion.LowPart));
+    dev.VendorId = static_cast<int>(id.VendorId);
+    dev.DeviceId = static_cast<int>(id.DeviceId);
+    dev.SubSystemId = static_cast<int>(id.SubSysId);
+    dev.RevisionId = static_cast<int>(id.Revision);
+
+    return dev;
+}
+
+const char* DX8Backend::Get_Render_Device_Name(int adapter_index)
+{
+    static char name[sizeof(BackendDeviceCapabilities().DeviceName)];
+    name[0] = '\0';
+    if (adapter_index < 0 || adapter_index >= DX8Wrapper::Get_Render_Device_Count()) {
+        return name;
+    }
+    const char* n = DX8Wrapper::Get_Render_Device_Name(adapter_index);
+    if (n) {
+        strncpy(name, n, sizeof(name) - 1);
+        name[sizeof(name) - 1] = '\0';
+    }
+    return name;
+}
+
+//==========================================================================
+// Resolution
+//==========================================================================
+
+bool DX8Backend::Set_Device_Resolution(int width, int height, int bits, int windowed, bool resize_window)
+{
+    WW3DErrorType err = WW3D::Set_Device_Resolution(width, height, bits, windowed, resize_window);
+    return err != WW3D_OK ? false : true;
+}
+
+void DX8Backend::Get_Device_Resolution(int& width, int& height, int& bits, bool& windowed)
+{
+    WW3D::Get_Device_Resolution(width, height, bits, windowed);
+}
+
+void DX8Backend::Get_Render_Target_Resolution(int& width, int& height, int& bits, bool& windowed)
+{
+    WW3D::Get_Render_Target_Resolution(width, height, bits, windowed);
+}
+
+int DX8Backend::Get_Device_Resolution_Width()
+{
+    int w, h, bits;
+    bool windowed;
+    WW3D::Get_Device_Resolution(w, h, bits, windowed);
+    return w;
+}
+
+int DX8Backend::Get_Device_Resolution_Height()
+{
+    int w, h, bits;
+    bool windowed;
+    WW3D::Get_Device_Resolution(w, h, bits, windowed);
+    return h;
+}
+
+//==========================================================================
+// Registry
+//==========================================================================
+
+bool DX8Backend::Registry_Save_Render_Device(const char* sub_key)
+{
+    return DX8Wrapper::Registry_Save_Render_Device(sub_key) != WW3D_OK ? false : true;
+}
+
+bool DX8Backend::Registry_Load_Render_Device(const char* sub_key, bool resize_window)
+{
+    return DX8Wrapper::Registry_Load_Render_Device(sub_key, resize_window) != WW3D_OK ? false : true;
+}
+
+//==========================================================================
+// Scene framing
+//==========================================================================
+
+void DX8Backend::Begin_Scene()
+{
+    DX8Wrapper::Begin_Scene();
+}
+
+void DX8Backend::End_Scene(bool flip_frame)
+{
+    DX8Wrapper::End_Scene(flip_frame);
+}
+
+void DX8Backend::Flip_To_Primary()
+{
+    DX8Wrapper::Flip_To_Primary();
+}
+
+//==========================================================================
+// Clear
+//==========================================================================
+
+void DX8Backend::Clear(bool clear_color, bool clear_z_stencil, const Vector3& color, float z, unsigned int stencil)
+{
+    DX8Wrapper::Clear(clear_color, clear_z_stencil, color, z, stencil);
+}
+
+//==========================================================================
+// VSync
+//==========================================================================
+
+void DX8Backend::Set_Swap_Interval(int swap_interval)
+{
+    m_VSync = swap_interval;
+    DX8Wrapper::Set_Swap_Interval(swap_interval);
+}
+
+int DX8Backend::Get_Swap_Interval()
+{
+    return m_VSync;
+}
+
+//==========================================================================
+// Texture depth
+//==========================================================================
+
+void DX8Backend::Set_Texture_Bitdepth(int depth)
+{
+    DX8Wrapper::Set_Texture_Bitdepth(depth);
+}
+
+int DX8Backend::Get_Texture_Bitdepth()
+{
+    return DX8Wrapper::Get_Texture_Bitdepth();
+}
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/Code/ww3d2/dx8backend.h
+++ b/Code/ww3d2/dx8backend.h
@@ -1,0 +1,125 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#ifndef DX8BACKEND_H
+#define DX8BACKEND_H
+
+#include "ww3dbackend.h"
+
+/**
+ * DX8Backend
+ *
+ * DX8/DX9 implementation of the WW3DBackend interface.
+ * Wraps the existing DX8Wrapper static API via composition — does not
+ * inherit from DX8Wrapper. Translates between BackendDeviceCapabilities
+ * and the underlying DX8/DX9 adapter enumeration API.
+ */
+class DX8Backend : public WW3DBackend
+{
+public:
+    DX8Backend();
+    virtual ~DX8Backend();
+
+    //========================================================================
+    // WW3DBackend interface — Device enumeration
+    //========================================================================
+
+    /**
+     * Enumerate all DX8/DX9 adapters via Direct3D()->GetAdapterIdentifier().
+     *
+     * Populates the provided BackendDeviceCapabilities array with information
+     * from D3DADAPTER_IDENTIFIER9 for each adapter.
+     *
+     * @param devices Output array to fill with adapter capabilities
+     * @param max_devices Maximum number of entries to write into devices[]
+     * @return Number of adapters found (may be less than max_devices)
+     */
+    virtual int Enumerate_Devices(BackendDeviceCapabilities* devices, int max_devices) override;
+
+    //========================================================================
+    // WW3DBackend interface — Initialization
+    //========================================================================
+    virtual bool Init(void* hwnd, bool lite = false) override;
+    virtual void Shutdown() override;
+
+    //========================================================================
+    // WW3DBackend interface — Device selection
+    //========================================================================
+    virtual bool Set_Any_Render_Device() override;
+    virtual bool Set_Render_Device(const char* dev_name) override;
+    virtual bool Set_Render_Device(int adapter_index) override;
+    virtual bool Set_Next_Render_Device() override;
+    virtual bool Toggle_Windowed() override;
+    virtual bool Is_Windowed() override;
+
+    //========================================================================
+    // WW3DBackend interface — Device properties
+    //========================================================================
+    virtual int Get_Render_Device_Count() override;
+    virtual int Get_Render_Device() override;
+    virtual const BackendDeviceCapabilities& Get_Render_Device_Desc(int adapter_index) override;
+    virtual const char* Get_Render_Device_Name(int adapter_index) override;
+
+    //========================================================================
+    // WW3DBackend interface — Resolution
+    //========================================================================
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual void Get_Device_Resolution(int& width, int& height, int& bits, bool& windowed) override;
+    virtual void Get_Render_Target_Resolution(int& width, int& height, int& bits, bool& windowed) override;
+    virtual int Get_Device_Resolution_Width() override;
+    virtual int Get_Device_Resolution_Height() override;
+
+    //========================================================================
+    // WW3DBackend interface — Registry
+    //========================================================================
+    virtual bool Registry_Save_Render_Device(const char* sub_key) override;
+    virtual bool Registry_Load_Render_Device(const char* sub_key, bool resize_window) override;
+
+    //========================================================================
+    // WW3DBackend interface — Scene framing
+    //========================================================================
+    virtual void Begin_Scene() override;
+    virtual void End_Scene(bool flip_frame = true) override;
+    virtual void Flip_To_Primary() override;
+
+    //========================================================================
+    // WW3DBackend interface — Clear
+    //========================================================================
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3& color, float z = 1.0f, unsigned int stencil = 0) override;
+
+    //========================================================================
+    // WW3DBackend interface — VSync
+    //========================================================================
+    virtual void Set_Swap_Interval(int swap_interval) override;
+    virtual int Get_Swap_Interval() override;
+
+    //========================================================================
+    // WW3DBackend interface — Texture depth
+    //========================================================================
+    virtual void Set_Texture_Bitdepth(int depth) override;
+    virtual int Get_Texture_Bitdepth() override;
+
+private:
+    bool m_Initialized;
+    bool m_IsWindowed;
+    int m_VSync;
+};
+
+#endif // DX8BACKEND_H

--- a/Code/ww3d2/ww3d.cpp
+++ b/Code/ww3d2/ww3d.cpp
@@ -78,6 +78,7 @@
 
 
 #include "ww3d.h"
+#include "ww3dbackend.h"
 #include "rinfo.h"
 #include "assetmgr.h"
 #include "boxrobj.h"
@@ -187,7 +188,10 @@ bool														WW3D::RecordNextFrame;
 int														WW3D::FrameCount = 0;
 int														WW3D::UserStat0 = 0;
 int														WW3D::UserStat1 = 0;
-int														WW3D::UserStat2 = 0;
+int														WWW3D::UserStat2 = 0;
+
+// Active render backend (DX8, DX9, DX12, Vulkan, Null)
+WW3DBackend*									WW3D::m_Backend = nullptr;
 
 float														WW3D::DefaultNativeScreenSize = 1.0f;
 

--- a/Code/ww3d2/ww3d.h
+++ b/Code/ww3d2/ww3d.h
@@ -61,6 +61,7 @@ class		RenderInfoClass;
 class		RenderDeviceDescClass;
 class		StringClass;
 class		LightEnvironmentClass;
+class		WW3DBackend;
 class		MaterialPassClass;
 
 #define MESH_RENDER_SNAPSHOT_ENABLED
@@ -166,6 +167,10 @@ public:
    static unsigned int     Get_Frame_Time(void) { return SyncTime - PreviousSyncTime; }
    static unsigned int     Get_Frame_Count(void) { return FrameCount; }
 	static unsigned int		Get_Last_Frame_Poly_Count(void);
+
+	// Backend factory
+	static WW3DBackend*	Get_Backend(void) { return m_Backend; }
+	static void			Set_Backend(WW3DBackend* backend) { m_Backend = backend; }
 	static unsigned int		Get_Last_Frame_Vertex_Count(void);
 
 	/*
@@ -283,6 +288,9 @@ public:
    static int             UserStat0;
    static int             UserStat1;
    static int             UserStat2;
+
+	// The active render backend (DX8, DX9, DX12, Vulkan, Null)
+	static WW3DBackend*	m_Backend;
 
 private:
 

--- a/Code/ww3d2/ww3dbackend.h
+++ b/Code/ww3d2/ww3dbackend.h
@@ -1,0 +1,291 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : WW3D                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ *                                                                                             *
+ *  Render backend abstraction layer.                                                           *
+ *                                                                                             *
+ *  This header defines the WW3DBackend interface: a pure-virtual interface that backends      *
+ *  (DX8, DX9, DX12, Vulkan, Null) must implement. It is backend-agnostic — no D3D or      *
+ *  Vulkan types appear in this interface.                                                    *
+ *                                                                                             *
+ *  Each backend is a thin implementation layer that translates between this abstract              *
+ *  interface and the underlying graphics API.                                                 *
+ *                                                                                             *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#pragma once
+
+#ifndef WW3DBACKEND_H
+#define WW3DBACKEND_H
+
+class Vector3;
+class SceneClass;
+
+/**
+ * BackendDeviceCapabilities
+ *
+ * A backend-agnostic description of a single GPU adapter. This struct contains only
+ * plain C++ types — no D3D or Vulkan types. Backends populate it from their
+ * respective GPU enumeration APIs.
+ *
+ * Used by: WW3DBackend::Enumerate_Devices()
+ */
+struct BackendDeviceCapabilities
+{
+    int  AdapterIndex;          // Backend-specific adapter index
+    char DeviceName[256];       // Human-readable GPU name (e.g. "NVIDIA RTX 3080")
+    char DriverName[256];       // Driver/runtime name
+    char DriverVersion[64];     // Driver version string
+    int  VendorId;              // PCI vendor ID (e.g. 0x10DE for NVIDIA, 0x8086 for Intel)
+    int  DeviceId;              // PCI device ID
+    int  SubSystemId;           // Subsystem ID
+    int  RevisionId;            // Revision ID
+    int  DedicatedVideoMemory;  // Approximate VRAM in bytes (-1 if unknown)
+    int  DedicatedSystemMemory; // Approximate dedicated system RAM in bytes (-1 if unknown)
+    int  SharedSystemMemory;   // Approximate shared system RAM in bytes (-1 if unknown)
+    bool IsHardware;            // True if this is a physical GPU, false if software/render-only
+    bool IsExternal;           // True if this is an external GPU (e.g. eGPU)
+};
+
+/**
+ * BackendResolution
+ *
+ * A single resolution mode supported by a GPU adapter.
+ */
+struct BackendResolution
+{
+    int Width;
+    int Height;
+    int RefreshRateHz;   // Vertical refresh rate in Hz (0 = default/unknown)
+};
+
+/**
+ * WW3DBackend
+ *
+ * Pure-virtual interface for the render backend. All rendering in WW3D is routed
+ * through this interface. Each backend (DX8, DX9, DX12, Vulkan, Null) implements
+ * this interface independently.
+ *
+ * Key design principles:
+ * - No D3D or Vulkan types in this interface
+ * - No texture/surface factory types — those belong in a separate abstraction
+ * - Device enumeration uses only BackendDeviceCapabilities (plain C++ structs)
+ * - Presentation and scene framing are separate from rendering API calls
+ */
+class WW3DBackend
+{
+public:
+    virtual ~WW3DBackend() = default;
+
+    //========================================================================
+    // Device enumeration
+    //========================================================================
+
+    /**
+     * Enumerate all render devices available through this backend.
+     *
+     * @param devices Output array of BackendDeviceCapabilities, one per GPU.
+     *                Backends populate this from their respective GPU enumeration API.
+     * @return Number of devices found (size of devices array).
+     *
+     * Backend implementations:
+     * - DX8/DX9: call Direct3D()->GetAdapterIdentifier() for each adapter
+     * - DX12: call D3D12CreateDevice() enumerate adapters via DXGI
+     * - Vulkan: call vkEnumeratePhysicalDevices()
+     * - Null: return 1 with a single "Null Device" entry
+     */
+    virtual int Enumerate_Devices(BackendDeviceCapabilities* devices, int max_devices) = 0;
+
+    //========================================================================
+    // Initialization
+    //========================================================================
+
+    /**
+     * Initialize the backend for the given window.
+     *
+     * @param hwnd Platform window handle (HWND on Windows, xcb_window_t* on Linux/X11, etc.)
+     * @param lite If true, initialize with minimal features (for tools/editors)
+     * @return true if initialization succeeded
+     */
+    virtual bool Init(void* hwnd, bool lite = false) = 0;
+
+    /** Release all backend resources. Called on shutdown. */
+    virtual void Shutdown() = 0;
+
+    //========================================================================
+    // Device selection
+    //========================================================================
+
+    /** Use the first available hardware device. */
+    virtual bool Set_Any_Render_Device() = 0;
+
+    /**
+     * Select a render device by name.
+     *
+     * @param dev_name Device name string (matched against BackendDeviceCapabilities::DeviceName)
+     * @return true if a matching device was found and selected
+     */
+    virtual bool Set_Render_Device(const char* dev_name) = 0;
+
+    /**
+     * Select a render device by adapter index.
+     *
+     * @param adapter_index Adapter index returned by Enumerate_Devices()
+     * @return true if the index is valid
+     */
+    virtual bool Set_Render_Device(int adapter_index) = 0;
+
+    /** Advance to the next available render device. Wraps from last to first. */
+    virtual bool Set_Next_Render_Device() = 0;
+
+    /** Toggle between windowed and fullscreen mode. */
+    virtual bool Toggle_Windowed() = 0;
+
+    /** @return true if currently in windowed mode */
+    virtual bool Is_Windowed() = 0;
+
+    //========================================================================
+    // Device properties
+    //========================================================================
+
+    /** @return Number of available render devices */
+    virtual int Get_Render_Device_Count() = 0;
+
+    /** @return Index of the currently selected render device */
+    virtual int Get_Render_Device() = 0;
+
+    /**
+     * Get full capabilities for a specific device.
+     *
+     * @param adapter_index Device index (0 to Get_Render_Device_Count()-1)
+     * @return BackendDeviceCapabilities for that device, or a default-constructed struct if invalid
+     */
+    virtual const BackendDeviceCapabilities& Get_Render_Device_Desc(int adapter_index) = 0;
+
+    /** @return Device name string, or "Unknown" if invalid */
+    virtual const char* Get_Render_Device_Name(int adapter_index) = 0;
+
+    //========================================================================
+    // Resolution
+    //========================================================================
+
+    /**
+     * Set the display resolution.
+     *
+     * @param width  Horizontal resolution in pixels (-1 = keep current)
+     * @param height Vertical resolution in pixels (-1 = keep current)
+     * @param bits   Color depth in bits per pixel (-1 = keep current)
+     * @param windowed Windowed (1) or fullscreen (0); -1 = keep current
+     * @param resize_window If true and in windowed mode, resize the window to match
+     * @return true if the resolution was successfully set
+     */
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+
+    /** @return Current device resolution (runtime-queried, may differ from what was requested) */
+    virtual void Get_Device_Resolution(int& width, int& height, int& bits, bool& windowed) = 0;
+
+    /** @return Resolution of the actual render target (may be a different surface than the display) */
+    virtual void Get_Render_Target_Resolution(int& width, int& height, int& bits, bool& windowed) = 0;
+
+    /** @return Current display width in pixels */
+    virtual int Get_Device_Resolution_Width() = 0;
+
+    /** @return Current display height in pixels */
+    virtual int Get_Device_Resolution_Height() = 0;
+
+    //========================================================================
+    // Registry / persistence
+    //========================================================================
+
+    /** Save current render device to registry (platform-specific config store). */
+    virtual bool Registry_Save_Render_Device(const char* sub_key) = 0;
+
+    /** Load render device from registry. @param resize_window If true, apply saved resolution too. */
+    virtual bool Registry_Load_Render_Device(const char* sub_key, bool resize_window) = 0;
+
+    //========================================================================
+    // Scene framing
+    //========================================================================
+
+    /** Begin a new rendered frame. Allocates command buffer(s) for this frame. */
+    virtual void Begin_Scene() = 0;
+
+    /**
+     * End the current frame and queue it for presentation.
+     *
+     * @param flip_frame If true, present/swap the front and back buffers
+     */
+    virtual void End_Scene(bool flip_frame = true) = 0;
+
+    /** Force the back buffer to the primary display immediately (no v-sync). */
+    virtual void Flip_To_Primary() = 0;
+
+    //========================================================================
+    // Framebuffer clear
+    //========================================================================
+
+    /**
+     * Clear the render target and/or depth-stencil buffer.
+     *
+     * @param clear_color  If true, fill the render target with the given color
+     * @param clear_z_stencil If true, clear the depth and/or stencil buffer
+     * @param color RGB color to fill the render target with
+     * @param z Depth value to fill the depth buffer with (0.0 to 1.0)
+     * @param stencil Stencil value to fill the stencil buffer with
+     */
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3& color, float z = 1.0f, unsigned int stencil = 0) = 0;
+
+    //========================================================================
+    // VSync
+    //========================================================================
+
+    /** Set the vertical sync interval. 0 = immediate/no vsync, 1 = one refresh interval, etc. */
+    virtual void Set_Swap_Interval(int swap_interval) = 0;
+
+    /** @return Current vsync interval (0 = off, 1 = on, etc.) */
+    virtual int Get_Swap_Interval() = 0;
+
+    //========================================================================
+    // Texture depth
+    //========================================================================
+
+    /**
+     * Set the preferred texture color depth.
+     *
+     * @param depth Color depth in bits per pixel (16, 24, or 32)
+     */
+    virtual void Set_Texture_Bitdepth(int depth) = 0;
+
+    /** @return Current texture bit depth setting */
+    virtual int Get_Texture_Bitdepth() = 0;
+
+protected:
+    // Protected constructor — must be constructed via WW3D::Set_Backend()
+    WW3DBackend() = default;
+};
+
+#endif // WW3DBACKEND_H


### PR DESCRIPTION
## Summary

Implements the `WW3DBackend` interface via `DX8Backend`, a composition-based wrapper around the existing `DX8Wrapper` static API. This PR adds the first concrete backend implementation behind the abstraction layer established in [PR #114](https://github.com/w3dhub/OpenW3D/pull/114).

## Changes

### `Code/ww3d2/dx8backend.h`
`DX8Backend : public WW3DBackend`. Declares all `WW3DBackend` pure-virtual methods. No D3D types appear in the header — all DX9 detail is confined to the `.cpp`.

### `Code/ww3d2/dx8backend.cpp`
Implements all interface methods by wrapping `DX8Wrapper` static calls:

- `Enumerate_Devices()`: calls `DX8Wrapper::Enumerate_Devices()` to populate the DX8 adapter list, then maps `D3DADAPTER_IDENTIFIER9` → `BackendDeviceCapabilities`:
  - `VendorId`, `DeviceId`, `SubSystemId`, `RevisionId` (from PCI IDs)
  - `DeviceName`, `DriverName`, `DriverVersion` (from adapter identifier)
- `Get_Render_Device_Count/Name/Desc`: delegates to `DX8Wrapper`
- `Init`/`Shutdown`: records initialization state
- `Set/Get_Device_Resolution`: calls `WW3D::Set_Device_Resolution` / `WW3D::Get_Device_Resolution`
- Scene methods (`Begin_Scene`, `End_Scene`, `Clear`, `Flip_To_Primary`): delegate to `DX8Wrapper`
- Registry, VSync, Texture depth: delegate to `DX8Wrapper`

### `Code/ww3d2/CMakeLists.txt`
Added `dx8backend.cpp` and `dx8backend.h` to the ww3d2 source list.

## Design note

`DX8Backend` uses **composition**, not inheritance from `DX8Wrapper`. This avoids the circular include chain that plagued the earlier inheritance-based approach (`DX8Wrapper : WW3DBackend`).

`DX8Backend` is Windows-only (requires D3D9 headers). On non-Windows builds, `ENABLE_DX9_BACKEND=OFF` excludes this backend and the `NullBackend` is used instead.

## Relationship to PRs

- Builds on [PR #114](https://github.com/w3dhub/OpenW3D/pull/114) (`ww3dbackend.h` interface)
- R1 (this PR): DX8 backend implementation
- R3 (future): Route `ww3d.cpp` device enumeration calls through `WW3D::Get_Backend()->Enumerate_Devices()`

## AI assistance disclosure

Drafted by Orbit using OpenAI Codex GPT-5.5 via OpenClaw.
