### PR TITLE
wwconfig-qt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,9 @@ add_feature_info(BrowserBuild W3D_BUILD_OPTION_WEBBROWSER "Build OpenW3D with we
 option(W3D_BUILD_OPTION_FFMPEG "Build with ffmpeg." OFF)
 add_feature_info(FFMpegBuild W3D_BUILD_OPTION_FFMPEG "Build OpenW3D with FFMpeg")
 
+option(W3D_BUILD_QT_TOOLS "Build Qt-based GUI tools." OFF)
+add_feature_info(QtTools W3D_BUILD_QT_TOOLS "Build Qt front-end tools")
+
 if(NOT WIN32)
     add_compile_definitions(__cdecl=)
     add_compile_definitions(__stdcall=)
@@ -76,6 +79,16 @@ else()
 endif()
 
 add_compile_definitions(-DWEBBROWSER_ENABLED=$<BOOL:${W3D_BUILD_OPTION_WEBBROWSER}>)
+
+if(W3D_BUILD_QT_TOOLS)
+    if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+        message(FATAL_ERROR "Qt tooling is only supported for 64-bit builds. Configure with a 64-bit generator or set W3D_BUILD_QT_TOOLS=OFF.")
+    endif()
+    set(CMAKE_AUTOMOC ON)
+    set(CMAKE_AUTOUIC ON)
+    set(CMAKE_AUTORCC ON)
+    include(qt_tools)
+endif()
 
 if(WIN32)
     # Do we want to build with bink for video decoding?

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -26,6 +26,53 @@
             "cacheVariables": {
                 "W3D_COMPILER_FLAGS": "/W3"
             }
+        },
+        {
+            "name": "windows-qt",
+            "inherits": "win",
+            "displayName": "Windows + Qt (x64)",
+            "binaryDir": "C:/build/openw3d/${presetName}",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            },
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+                "VCPKG_TARGET_TRIPLET": "x64-windows",
+                "VCPKG_INSTALLED_DIR": "C:/vcpkg.installed",
+                "W3D_BUILD_QT_TOOLS": "ON"
+            }
+        },
+        {
+            "name": "windows-qt-tools",
+            "inherits": "windows-qt",
+            "displayName": "Windows + Qt (Tools only)",
+            "cacheVariables": {
+                "RENEGADE_CLIENT": "OFF",
+                "RENEGADE_FDS": "OFF",
+                "RENEGADE_TOOLS": "ON"
+            }
+        },
+        {
+            "name": "linux",
+            "inherits": "default",
+            "displayName": "Linux builds",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            }
+        },
+        {
+            "name": "linux-qt",
+            "inherits": "linux",
+            "displayName": "Linux + Qt (x64)",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+                "VCPKG_TARGET_TRIPLET": "x64-linux",
+                "W3D_BUILD_QT_TOOLS": "ON"
+            }
         }
     ],
     "buildPresets": [
@@ -34,6 +81,27 @@
             "configurePreset": "win",
             "displayName": "Build Windows build",
             "description": "Build Windows build",
+            "configuration": "Release"
+        },
+        {
+            "name": "windows-qt",
+            "configurePreset": "windows-qt",
+            "displayName": "Build Windows + Qt",
+            "description": "Build Qt-enabled Windows binaries",
+            "configuration": "Release"
+        },
+        {
+            "name": "windows-qt-tools",
+            "configurePreset": "windows-qt-tools",
+            "displayName": "Build Windows + Qt (Tools only)",
+            "description": "Build Qt-enabled tools only",
+            "configuration": "Release"
+        },
+        {
+            "name": "linux-qt",
+            "configurePreset": "linux-qt",
+            "displayName": "Build Linux + Qt",
+            "description": "Build Qt-enabled Linux binaries",
             "configuration": "Release"
         }
     ],
@@ -48,6 +116,45 @@
                 {
                     "type": "build",
                     "name": "win"
+                }
+            ]
+        },
+        {
+            "name": "windows-qt",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "windows-qt"
+                },
+                {
+                    "type": "build",
+                    "name": "windows-qt"
+                }
+            ]
+        },
+        {
+            "name": "windows-qt-tools",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "windows-qt-tools"
+                },
+                {
+                    "type": "build",
+                    "name": "windows-qt-tools"
+                }
+            ]
+        },
+        {
+            "name": "linux-qt",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "linux-qt"
+                },
+                {
+                    "type": "build",
+                    "name": "linux-qt"
                 }
             ]
         }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -49,9 +49,9 @@
             "inherits": "windows-qt",
             "displayName": "Windows + Qt (Tools only)",
             "cacheVariables": {
-                "RENEGADE_CLIENT": "OFF",
-                "RENEGADE_FDS": "OFF",
-                "RENEGADE_TOOLS": "ON"
+                "W3D_CLIENT": "OFF",
+                "W3D_FDS": "OFF",
+                "W3D_TOOLS": "ON"
             }
         },
         {

--- a/Code/Tools/CMakeLists.txt
+++ b/Code/Tools/CMakeLists.txt
@@ -6,3 +6,7 @@ add_subdirectory(MixViewer)
 add_subdirectory(W3DView)
 add_subdirectory(LevelEdit)
 add_subdirectory(WWConfig)
+
+if(W3D_BUILD_QT_TOOLS)
+    add_subdirectory(WWConfigQt)
+endif()

--- a/Code/Tools/WWConfig/CMakeLists.txt
+++ b/Code/Tools/WWConfig/CMakeLists.txt
@@ -2,13 +2,23 @@
 set(WWCONFIG_CORE_SRC
     EZGIMEX.cpp
     locale.cpp
-    Locale_API.cpp
     gimex.h
     locale.h
     Locale_API.h
-    WWConfigSettings.cpp
     WWConfigSettings.h
 )
+
+if(WIN32)
+    list(APPEND WWCONFIG_CORE_SRC
+        Locale_API.cpp
+        WWConfigSettings.cpp
+    )
+else()
+    list(APPEND WWCONFIG_CORE_SRC
+        Locale_API_NonWin.cpp
+        WWConfigSettings_NonWin.cpp
+    )
+endif()
 
 add_library(wwconfig_core STATIC)
 
@@ -24,50 +34,55 @@ target_link_libraries(wwconfig_core
     PUBLIC
         wwcommon
         wwlib
+)
+
+if(WIN32)
+    target_link_libraries(wwconfig_core PUBLIC ww3d2)
+endif()
+
+if(WIN32)
+    set(WWCONFIG_SRC
+        AudioConfigDialog.cpp
+        DriverVersionWarning.cpp
+        PerformanceConfigDialog.cpp
+        StdAfx.cpp
+        VideoConfigDialog.cpp
+        WWConfig.cpp
+        WWConfigDlg.cpp
+        AudioConfigDialog.h
+        DriverVersionWarning.h
+        PerformanceConfigDialog.h
+        Resource.h
+        StdAfx.h
+        VideoConfigDialog.h
+        WWConfig.h
+        WWConfigDlg.h
+        WWConfig.rc
+    )
+
+    # Targets to build.
+    add_executable(wwconfig WIN32)
+
+    target_compile_definitions(wwconfig PRIVATE
+        _AFXDLL
+    )
+
+    target_link_libraries(wwconfig PRIVATE
+        version
+        winmm
+        wwconfig_core
+        wwcommon
+        wwdebug
+        wwmath
+        wwphys
+        wwsaveload
         ww3d2
-)
+        wwaudio
+    )
 
-set(WWCONFIG_SRC
-    AudioConfigDialog.cpp
-    DriverVersionWarning.cpp
-    PerformanceConfigDialog.cpp
-    StdAfx.cpp
-    VideoConfigDialog.cpp
-    WWConfig.cpp
-    WWConfigDlg.cpp
-    AudioConfigDialog.h
-    DriverVersionWarning.h
-    PerformanceConfigDialog.h
-    Resource.h
-    StdAfx.h
-    VideoConfigDialog.h
-    WWConfig.h
-    WWConfigDlg.h
-    WWConfig.rc
-)
+    target_sources(wwconfig PRIVATE ${WWCONFIG_SRC})
 
-# Targets to build.
-add_executable(wwconfig WIN32)
-
-target_compile_definitions(wwconfig PRIVATE
-    _AFXDLL
-)
-
-target_link_libraries(wwconfig PRIVATE
-    version
-    winmm
-    wwconfig_core
-    wwcommon
-    wwdebug
-    wwmath
-    wwphys
-    wwsaveload
-    ww3d2
-    wwaudio
-)
-
-target_sources(wwconfig PRIVATE ${WWCONFIG_SRC})
-
-if(MSVC)
-    target_link_options(wwconfig PRIVATE "/NODEFAULTLIB:libci.lib")
+    if(MSVC)
+        target_link_options(wwconfig PRIVATE "/NODEFAULTLIB:libci.lib")
+    endif()
 endif()

--- a/Code/Tools/WWConfig/CMakeLists.txt
+++ b/Code/Tools/WWConfig/CMakeLists.txt
@@ -1,9 +1,35 @@
-set(WWCONFIG_SRC
-    AudioConfigDialog.cpp
-    DriverVersionWarning.cpp
+# Core locale/IO helpers shared with both UIs.
+set(WWCONFIG_CORE_SRC
     EZGIMEX.cpp
     locale.cpp
     Locale_API.cpp
+    gimex.h
+    locale.h
+    Locale_API.h
+    WWConfigSettings.cpp
+    WWConfigSettings.h
+)
+
+add_library(wwconfig_core STATIC)
+
+target_sources(wwconfig_core PRIVATE ${WWCONFIG_CORE_SRC})
+
+target_include_directories(wwconfig_core
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/Code/wwlib
+)
+
+target_link_libraries(wwconfig_core
+    PUBLIC
+        wwcommon
+        wwlib
+        ww3d2
+)
+
+set(WWCONFIG_SRC
+    AudioConfigDialog.cpp
+    DriverVersionWarning.cpp
     PerformanceConfigDialog.cpp
     StdAfx.cpp
     VideoConfigDialog.cpp
@@ -11,9 +37,6 @@ set(WWCONFIG_SRC
     WWConfigDlg.cpp
     AudioConfigDialog.h
     DriverVersionWarning.h
-    gimex.h
-    locale.h
-    Locale_API.h
     PerformanceConfigDialog.h
     Resource.h
     StdAfx.h
@@ -33,9 +56,9 @@ target_compile_definitions(wwconfig PRIVATE
 target_link_libraries(wwconfig PRIVATE
     version
     winmm
+    wwconfig_core
     wwcommon
     wwdebug
-    wwlib
     wwmath
     wwphys
     wwsaveload

--- a/Code/Tools/WWConfig/Locale_API.h
+++ b/Code/Tools/WWConfig/Locale_API.h
@@ -37,24 +37,25 @@
 #ifndef  LOCALE_API_H
 #define  LOCALE_API_H
 
-#include <STDLIB.H>
+#include <stdlib.h>
+#include <wchar.h>
 
 /****************************************************************************/
 /* GLOBAL VARIABLES                                                         */
 /****************************************************************************/
-extern	int		CodePage;
-extern	void *	LocaleFile;
-extern	int		LanguageID;
-extern	CHAR	LanguageFile[];
+extern int   CodePage;
+extern void *LocaleFile;
+extern int   LanguageID;
+extern char  LanguageFile[];
 
 /****************************************************************************/
 /* LOCALE API                                                               */
 /****************************************************************************/
-int				Locale_Init	( int language, const CHAR *file );
+int             Locale_Init(int language, const char *file);
 void			Locale_Restore ( void );
-const CHAR	*	Locale_GetString( int StringID, CHAR *String );
-const wchar_t	*	Locale_GetString( int StringID, wchar_t *String );
-const wchar_t	*	Locale_GetString( int StringID );
+const char     *Locale_GetString(int StringID, char *String);
+const wchar_t  *Locale_GetString(int StringID, wchar_t *String);
+const wchar_t  *Locale_GetString(int StringID);
 bool			Locale_Use_Multi_Language_Files	( void );
 
 #endif

--- a/Code/Tools/WWConfig/Locale_API_NonWin.cpp
+++ b/Code/Tools/WWConfig/Locale_API_NonWin.cpp
@@ -1,0 +1,202 @@
+#include "Locale_API.h"
+
+#include "locale.h"
+#include "wwconfig_ids.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <cwchar>
+
+namespace
+{
+constexpr size_t kMaxLocalePath = 260;
+
+bool g_localeInitialized = false;
+
+int DefaultLanguageFromLocale()
+{
+    const char *locale = std::getenv("LC_ALL");
+    if (!locale || locale[0] == '\0') {
+        locale = std::getenv("LC_MESSAGES");
+    }
+    if (!locale || locale[0] == '\0') {
+        locale = std::getenv("LANG");
+    }
+    if (!locale) {
+        return IDL_ENGLISH;
+    }
+
+    if (std::strncmp(locale, "de", 2) == 0) {
+        return IDL_GERMAN;
+    }
+    if (std::strncmp(locale, "fr", 2) == 0) {
+        return IDL_FRENCH;
+    }
+    if (std::strncmp(locale, "ja", 2) == 0) {
+        return IDL_JAPANESE;
+    }
+    if (std::strncmp(locale, "ko", 2) == 0) {
+        return IDL_KOREAN;
+    }
+    if (std::strncmp(locale, "zh", 2) == 0) {
+        return IDL_CHINESE;
+    }
+
+    return IDL_ENGLISH;
+}
+
+wchar_t *Remove_Quotes_Around_String(wchar_t *old_string)
+{
+    if (!old_string || *old_string != L'"') {
+        return old_string;
+    }
+
+    wchar_t wide_buffer[kMaxLocalePath * 3] = {};
+    const wchar_t *letter = old_string + 1;
+    std::wcsncpy(wide_buffer, letter, (kMaxLocalePath * 3) - 1);
+
+    const size_t length = std::wcslen(wide_buffer);
+    if (length > 0 && wide_buffer[length - 1] == L'"') {
+        wide_buffer[length - 1] = L'\0';
+    }
+
+    std::wcsncpy(old_string, wide_buffer, (kMaxLocalePath * 3) - 1);
+    return old_string;
+}
+
+const wchar_t *LookupWideString(int stringId)
+{
+    if (!g_localeInitialized) {
+        return L"";
+    }
+
+    const char *text = LOCALE_getstring(stringId);
+    if (!text) {
+        return L"";
+    }
+
+    return reinterpret_cast<const wchar_t *>(text);
+}
+} // namespace
+
+char LanguageFile[kMaxLocalePath] = {};
+void *LocaleFile = nullptr;
+int CodePage = 65001;
+int LanguageID = IDL_ENGLISH;
+
+bool Locale_Use_Multi_Language_Files(void)
+{
+    return true;
+}
+
+int Locale_Init(int language, const char *file)
+{
+    if (!file || file[0] == '\0') {
+        return 0;
+    }
+
+    if (g_localeInitialized) {
+        Locale_Restore();
+    }
+
+    std::strncpy(LanguageFile, file, sizeof(LanguageFile) - 1);
+    LanguageFile[sizeof(LanguageFile) - 1] = '\0';
+
+    LanguageID = language;
+    if (LanguageID == -1) {
+        LanguageID = DefaultLanguageFromLocale();
+    }
+    if (LanguageID < 0 || LanguageID >= LOCALE_LANGUAGE_COUNT) {
+        LanguageID = IDL_ENGLISH;
+    }
+
+    if (!LOCALE_init()) {
+        return 0;
+    }
+
+    LOCALE_setbank(0);
+    bool loaded = LOCALE_loadtable(LanguageFile, LanguageID) != 0;
+    if (!loaded && LanguageID != IDL_ENGLISH) {
+        LOCALE_restore();
+        if (!LOCALE_init()) {
+            return 0;
+        }
+        LOCALE_setbank(0);
+        loaded = LOCALE_loadtable(LanguageFile, IDL_ENGLISH) != 0;
+        if (loaded) {
+            LanguageID = IDL_ENGLISH;
+        }
+    }
+
+    if (!loaded) {
+        LOCALE_restore();
+        return 0;
+    }
+
+    g_localeInitialized = true;
+    LocaleFile = reinterpret_cast<void *>(1);
+    return 1;
+}
+
+void Locale_Restore(void)
+{
+    if (!g_localeInitialized) {
+        return;
+    }
+
+    LOCALE_freetable();
+    LOCALE_restore();
+    g_localeInitialized = false;
+    LocaleFile = nullptr;
+}
+
+const char *Locale_GetString(int stringId, char *string)
+{
+    static char buffer[kMaxLocalePath] = {};
+    static wchar_t wide_buffer[kMaxLocalePath] = {};
+
+    std::memset(buffer, '\0', sizeof(buffer));
+    std::wmemset(wide_buffer, L'\0', sizeof(wide_buffer) / sizeof(wide_buffer[0]));
+
+    std::wcsncpy(wide_buffer, LookupWideString(stringId), (kMaxLocalePath - 1));
+    Remove_Quotes_Around_String(wide_buffer);
+
+    const size_t converted = std::wcstombs(buffer, wide_buffer, sizeof(buffer) - 1);
+    if (converted == static_cast<size_t>(-1)) {
+        buffer[0] = '\0';
+    }
+
+    if (string) {
+        std::strncpy(string, buffer, kMaxLocalePath - 1);
+        string[kMaxLocalePath - 1] = '\0';
+    }
+
+    return buffer;
+}
+
+const wchar_t *Locale_GetString(int stringId, wchar_t *string)
+{
+    static wchar_t wide_buffer[kMaxLocalePath] = {};
+
+    std::wmemset(wide_buffer, L'\0', sizeof(wide_buffer) / sizeof(wide_buffer[0]));
+    std::wcsncpy(wide_buffer, LookupWideString(stringId), kMaxLocalePath - 1);
+    Remove_Quotes_Around_String(wide_buffer);
+
+    if (string) {
+        std::wcsncpy(string, wide_buffer, kMaxLocalePath - 1);
+        string[kMaxLocalePath - 1] = L'\0';
+    }
+
+    return wide_buffer;
+}
+
+const wchar_t *Locale_GetString(int stringId)
+{
+    static wchar_t wide_buffer[kMaxLocalePath] = {};
+
+    std::wmemset(wide_buffer, L'\0', sizeof(wide_buffer) / sizeof(wide_buffer[0]));
+    std::wcsncpy(wide_buffer, LookupWideString(stringId), kMaxLocalePath - 1);
+    Remove_Quotes_Around_String(wide_buffer);
+
+    return wide_buffer;
+}

--- a/Code/Tools/WWConfig/WWConfigSettings.cpp
+++ b/Code/Tools/WWConfig/WWConfigSettings.cpp
@@ -1,0 +1,458 @@
+#include "WWConfigSettings.h"
+
+#include "registry.h"
+#include "dx8caps.h"
+#include "dx8wrapper.h"
+#include "cpudetect.h"
+#include "formconv.h"
+#include "wwstring.h"
+
+#include "../../Combat/specialbuilds.h"
+
+#include <algorithm>
+#include <d3d9.h>
+
+#ifndef RENEGADE_SUB_KEY_NAME_RENDER
+#if defined(FREEDEDICATEDSERVER)
+#define RENEGADE_SUB_KEY_NAME_RENDER "Software\\Westwood\\RenegadeFDS\\Render"
+#elif defined(MULTIPLAYERDEMO)
+#define RENEGADE_SUB_KEY_NAME_RENDER "Software\\Westwood\\RenegadeMPDemo\\Render"
+#elif defined(BETACLIENT)
+#define RENEGADE_SUB_KEY_NAME_RENDER "Software\\Westwood\\RenegadeBeta\\Render"
+#else
+#define RENEGADE_SUB_KEY_NAME_RENDER "Software\\Westwood\\Renegade\\Render"
+#endif
+#endif
+
+#ifndef RENEGADE_SUB_KEY_NAME_AUDIO
+#if defined(FREEDEDICATEDSERVER)
+#define RENEGADE_SUB_KEY_NAME_AUDIO "Software\\Westwood\\RenegadeFDS\\Sound"
+#elif defined(MULTIPLAYERDEMO)
+#define RENEGADE_SUB_KEY_NAME_AUDIO "Software\\Westwood\\RenegadeMPDemo\\Sound"
+#elif defined(BETACLIENT)
+#define RENEGADE_SUB_KEY_NAME_AUDIO "Software\\Westwood\\RenegadeBeta\\Sound"
+#else
+#define RENEGADE_SUB_KEY_NAME_AUDIO "Software\\Westwood\\Renegade\\Sound"
+#endif
+#endif
+
+namespace
+{
+#if	defined(FREEDEDICATEDSERVER)
+constexpr const char *kKeyNameSettings = "Software\\Westwood\\RenegadeFDS\\System Settings";
+constexpr const char *kKeyNameOptions = "Software\\Westwood\\RenegadeFDS\\Options";
+#elif defined(MULTIPLAYERDEMO)
+constexpr const char *kKeyNameSettings = "Software\\Westwood\\RenegadeMPDemo\\System Settings";
+constexpr const char *kKeyNameOptions = "Software\\Westwood\\RenegadeMPDemo\\Options";
+#elif defined(BETACLIENT)
+constexpr const char *kKeyNameSettings = "Software\\Westwood\\RenegadeBeta\\System Settings";
+constexpr const char *kKeyNameOptions = "Software\\Westwood\\RenegadeBeta\\Options";
+#else
+constexpr const char *kKeyNameSettings = "Software\\Westwood\\Renegade\\System Settings";
+constexpr const char *kKeyNameOptions = "Software\\Westwood\\Renegade\\Options";
+#endif
+
+constexpr const char *kValueNameDynLOD = "Dynamic_LOD_Budget";
+constexpr const char *kValueNameStaticLOD = "Static_LOD_Budget";
+constexpr const char *kValueNameDynShadows = "Dynamic_Projectors";
+constexpr const char *kValueNameTextureFilter = "Texture_Filter_Mode";
+constexpr const char *kValueNamePrelitMode = "Prelit_Mode";
+constexpr const char *kValueNameShadowMode = "Shadow_Mode";
+constexpr const char *kValueNameStaticShadows = "Static_Projectors";
+constexpr const char *kValueNameTextureRes = "Texture_Resolution";
+constexpr const char *kValueNameSurfaceEffect = "Surface_Effect_Detail";
+constexpr const char *kValueNameParticleDetail = "Particle_Detail";
+
+constexpr const char *kValueNameAudioStereo = "stereo";
+constexpr const char *kValueNameAudioBits = "bits";
+constexpr const char *kValueNameAudioHertz = "hertz";
+constexpr const char *kValueNameAudioDevice = "device name";
+constexpr const char *kValueNameAudioMusicEnabled = "music enabled";
+constexpr const char *kValueNameAudioSoundEnabled = "sound enabled";
+constexpr const char *kValueNameAudioDialogEnabled = "dialog enabled";
+constexpr const char *kValueNameAudioCinematicEnabled = "cinematic enabled";
+constexpr const char *kValueNameAudioMusicVolume = "music volume";
+constexpr const char *kValueNameAudioSoundVolume = "sound volume";
+constexpr const char *kValueNameAudioDialogVolume = "dialog volume";
+constexpr const char *kValueNameAudioCinematicVolume = "cinematic volume";
+constexpr const char *kValueNameAudioSpeakerType = "speaker type";
+
+constexpr int kVolumeScale = 100;
+
+}
+
+namespace WWConfig
+{
+bool LoadRenderSettings(RenderSettings &settings)
+{
+    RegistryClass registry(kKeyNameSettings);
+    if (!registry.Is_Valid()) {
+        return false;
+    }
+
+    settings.dynamicLOD = registry.Get_Int(kValueNameDynLOD, settings.dynamicLOD);
+    settings.staticLOD = registry.Get_Int(kValueNameStaticLOD, settings.staticLOD);
+    settings.dynamicShadows = registry.Get_Int(kValueNameDynShadows, settings.dynamicShadows);
+    settings.staticShadows = registry.Get_Int(kValueNameStaticShadows, settings.staticShadows);
+    settings.prelitMode = registry.Get_Int(kValueNamePrelitMode, settings.prelitMode);
+    settings.textureFilter = registry.Get_Int(kValueNameTextureFilter, settings.textureFilter);
+    settings.shadowMode = registry.Get_Int(kValueNameShadowMode, settings.shadowMode);
+    settings.textureResolution = registry.Get_Int(kValueNameTextureRes, settings.textureResolution);
+    settings.surfaceEffect = registry.Get_Int(kValueNameSurfaceEffect, settings.surfaceEffect);
+    settings.particleDetail = registry.Get_Int(kValueNameParticleDetail, settings.particleDetail);
+    settings.lightingMode = registry.Get_Int(kValueNamePrelitMode, settings.lightingMode);
+
+    return true;
+}
+
+bool SaveRenderSettings(const RenderSettings &settings)
+{
+    RegistryClass registry(kKeyNameSettings);
+    if (!registry.Is_Valid()) {
+        return false;
+    }
+
+    registry.Set_Int(kValueNameDynLOD, settings.dynamicLOD);
+    registry.Set_Int(kValueNameStaticLOD, settings.staticLOD);
+    registry.Set_Int(kValueNameDynShadows, settings.dynamicShadows);
+    registry.Set_Int(kValueNameStaticShadows, settings.staticShadows);
+    registry.Set_Int(kValueNamePrelitMode, settings.prelitMode);
+    registry.Set_Int(kValueNameTextureFilter, settings.textureFilter);
+    registry.Set_Int(kValueNameShadowMode, settings.shadowMode);
+    registry.Set_Int(kValueNameTextureRes, settings.textureResolution);
+    registry.Set_Int(kValueNameSurfaceEffect, settings.surfaceEffect);
+    registry.Set_Int(kValueNameParticleDetail, settings.particleDetail);
+
+    return true;
+}
+
+static void InitializeAdapterSelection(IDirect3D9 **outD3D, D3DCAPS9 *outCaps, D3DADAPTER_IDENTIFIER9 *outAdapterId, D3DFORMAT &displayFormat)
+{
+    IDirect3D9 *d3d = Direct3DCreate9(D3D_SDK_VERSION);
+    if (!d3d) {
+        *outD3D = nullptr;
+        return;
+    }
+
+    RegistryClass renderRegistry(RENEGADE_SUB_KEY_NAME_RENDER);
+    renderRegistry.Is_Valid();
+    int currentAdapterIndex = D3DADAPTER_DEFAULT;
+    char deviceName[256] = {0};
+    renderRegistry.Get_String(VALUE_NAME_RENDER_DEVICE_NAME, deviceName, sizeof(deviceName));
+
+    int adapterCount = d3d->GetAdapterCount();
+    for (int adapterIndex = 0; adapterIndex < adapterCount; ++adapterIndex) {
+        D3DADAPTER_IDENTIFIER9 id = {};
+        if (SUCCEEDED(d3d->GetAdapterIdentifier(adapterIndex, 0, &id))) {
+            StringClass name(id.Description, true);
+            if (name == deviceName) {
+                currentAdapterIndex = adapterIndex;
+                break;
+            }
+        }
+    }
+
+    if (FAILED(d3d->GetDeviceCaps(currentAdapterIndex, D3DDEVTYPE_HAL, outCaps))) {
+        d3d->Release();
+        *outD3D = nullptr;
+        return;
+    }
+
+    ZeroMemory(outAdapterId, sizeof(D3DADAPTER_IDENTIFIER9));
+    if (FAILED(d3d->GetAdapterIdentifier(currentAdapterIndex, 0, outAdapterId))) {
+        d3d->Release();
+        *outD3D = nullptr;
+        return;
+    }
+
+    renderRegistry.Set_String(VALUE_NAME_RENDER_DEVICE_NAME, outAdapterId->Description);
+    renderRegistry.Set_Int(VALUE_NAME_RENDER_DEVICE_WIDTH, 800);
+    renderRegistry.Set_Int(VALUE_NAME_RENDER_DEVICE_HEIGHT, 600);
+    renderRegistry.Set_Int(VALUE_NAME_RENDER_DEVICE_DEPTH, 16);
+    renderRegistry.Set_Int(VALUE_NAME_RENDER_DEVICE_WINDOWED, 0);
+    renderRegistry.Set_Int(VALUE_NAME_RENDER_DEVICE_TEXTURE_DEPTH, 16);
+
+    displayFormat = D3DFMT_R5G6B5;
+    *outD3D = d3d;
+}
+
+void AutoConfigRenderSettings()
+{
+    RegistryClass registry(kKeyNameSettings);
+    if (!registry.Is_Valid()) {
+        return;
+    }
+
+    RegistryClass renderRegistry(RENEGADE_SUB_KEY_NAME_RENDER);
+    if (!renderRegistry.Is_Valid()) {
+        return;
+    }
+
+    IDirect3D9 *d3d = nullptr;
+    D3DCAPS9 tmpCaps = {};
+    const D3DCAPS9 *d3dCaps = nullptr;
+    D3DADAPTER_IDENTIFIER9 adapterId = {};
+    D3DFORMAT displayFormat = D3DFMT_R5G6B5;
+
+    InitializeAdapterSelection(&d3d, &tmpCaps, &adapterId, displayFormat);
+    if (!d3d) {
+        return;
+    }
+    d3dCaps = &tmpCaps;
+
+    DX8Caps caps(d3d, *d3dCaps, D3DFormat_To_WW3DFormat(displayFormat), adapterId);
+    bool canDoMultiPass = caps.Can_Do_Multi_Pass();
+    bool highEndProcessor = CPUDetectClass::Has_SSE_Instruction_Set();
+    if (CPUDetectClass::Get_Processor_Manufacturer() == CPUDetectClass::MANUFACTURER_AMD &&
+        CPUDetectClass::Get_AMD_Processor() >= CPUDetectClass::AMD_PROCESSOR_ATHLON_025) {
+        highEndProcessor = true;
+    }
+
+    registry.Set_Int(kValueNameTextureRes, caps.Support_DXTC() ? 0 : 1);
+
+    if (caps.Support_TnL()) {
+        registry.Set_Int(kValueNameDynLOD, 10000);
+        registry.Set_Int(kValueNameStaticLOD, 10000);
+    } else if (highEndProcessor) {
+        registry.Set_Int(kValueNameDynLOD, 5000);
+        registry.Set_Int(kValueNameStaticLOD, 5000);
+    } else {
+        registry.Set_Int(kValueNameDynLOD, 0);
+        registry.Set_Int(kValueNameStaticLOD, 0);
+    }
+
+    if (caps.Support_Render_To_Texture_Format(D3DFormat_To_WW3DFormat(displayFormat))) {
+        if (caps.Support_TnL()) {
+            registry.Set_Int(kValueNameShadowMode, 3);
+            registry.Set_Int(kValueNameStaticShadows, 1);
+        } else {
+            registry.Set_Int(kValueNameShadowMode, 2);
+            registry.Set_Int(kValueNameStaticShadows, 0);
+        }
+    } else {
+        registry.Set_Int(kValueNameStaticShadows, 0);
+        registry.Set_Int(kValueNameShadowMode, highEndProcessor ? 1 : 0);
+    }
+
+    if (caps.Support_TnL()) {
+        registry.Set_Int(kValueNameSurfaceEffect, 2);
+    } else {
+        registry.Set_Int(kValueNameSurfaceEffect, highEndProcessor ? 1 : 0);
+    }
+
+    if (caps.Support_TnL() && highEndProcessor) {
+        registry.Set_Int(kValueNameParticleDetail, 2);
+    } else if (caps.Support_TnL() || highEndProcessor) {
+        registry.Set_Int(kValueNameParticleDetail, 1);
+    } else {
+        registry.Set_Int(kValueNameParticleDetail, 0);
+    }
+
+    if (!canDoMultiPass || CPUDetectClass::Get_Total_Physical_Memory() < 100 * 1024 * 1024) {
+        registry.Set_Int(kValueNamePrelitMode, 0);
+    } else if (caps.Get_Max_Textures_Per_Pass() >= 2) {
+        registry.Set_Int(kValueNamePrelitMode, 2);
+    } else {
+        registry.Set_Int(kValueNamePrelitMode, 1);
+    }
+
+    RegistryClass registryOptions(kKeyNameOptions);
+    if (registryOptions.Is_Valid()) {
+        registryOptions.Set_Int("ScreenUVBias", 1);
+    }
+
+    if (d3d) {
+        d3d->Release();
+    }
+}
+
+bool LoadVideoSettings(VideoSettings &settings)
+{
+    RegistryClass registry(RENEGADE_SUB_KEY_NAME_RENDER);
+    if (!registry.Is_Valid()) {
+        return false;
+    }
+
+    char deviceName[256] = {};
+    registry.Get_String(VALUE_NAME_RENDER_DEVICE_NAME, deviceName, sizeof(deviceName));
+    if (deviceName[0] != '\0') {
+        settings.deviceName = deviceName;
+    }
+
+    const int width = registry.Get_Int(VALUE_NAME_RENDER_DEVICE_WIDTH, -1);
+    const int height = registry.Get_Int(VALUE_NAME_RENDER_DEVICE_HEIGHT, -1);
+    const int bitDepth = registry.Get_Int(VALUE_NAME_RENDER_DEVICE_DEPTH, -1);
+    const int windowed = registry.Get_Int(VALUE_NAME_RENDER_DEVICE_WINDOWED, settings.windowed ? 1 : 0);
+    const int textureDepth = registry.Get_Int(VALUE_NAME_RENDER_DEVICE_TEXTURE_DEPTH, -1);
+
+    if (width > 0) {
+        settings.width = width;
+    }
+    if (height > 0) {
+        settings.height = height;
+    }
+    if (bitDepth > 0) {
+        settings.bitDepth = bitDepth;
+    }
+    settings.windowed = windowed != 0;
+    if (textureDepth > 0) {
+        settings.textureDepth = textureDepth;
+    }
+
+    return true;
+}
+
+bool SaveVideoSettings(const VideoSettings &settings)
+{
+    RegistryClass registry(RENEGADE_SUB_KEY_NAME_RENDER);
+    if (!registry.Is_Valid()) {
+        return false;
+    }
+
+    registry.Set_String(VALUE_NAME_RENDER_DEVICE_NAME, settings.deviceName.c_str());
+    registry.Set_Int(VALUE_NAME_RENDER_DEVICE_WIDTH, settings.width);
+    registry.Set_Int(VALUE_NAME_RENDER_DEVICE_HEIGHT, settings.height);
+    registry.Set_Int(VALUE_NAME_RENDER_DEVICE_DEPTH, settings.bitDepth);
+    registry.Set_Int(VALUE_NAME_RENDER_DEVICE_WINDOWED, settings.windowed ? 1 : 0);
+    registry.Set_Int(VALUE_NAME_RENDER_DEVICE_TEXTURE_DEPTH, settings.textureDepth);
+    return true;
+}
+
+bool LoadAudioSettings(AudioSettings &settings)
+{
+    RegistryClass registry(RENEGADE_SUB_KEY_NAME_AUDIO);
+    if (!registry.Is_Valid()) {
+        return false;
+    }
+
+    char deviceName[256] = {};
+    registry.Get_String(kValueNameAudioDevice, deviceName, sizeof(deviceName));
+    if (deviceName[0] != '\0') {
+        settings.deviceName = deviceName;
+    }
+
+    settings.stereo = registry.Get_Int(kValueNameAudioStereo, settings.stereo ? 1 : 0) != 0;
+    settings.bitDepth = registry.Get_Int(kValueNameAudioBits, settings.bitDepth);
+    settings.sampleRate = registry.Get_Int(kValueNameAudioHertz, settings.sampleRate);
+    settings.musicEnabled = registry.Get_Int(kValueNameAudioMusicEnabled, settings.musicEnabled ? 1 : 0) != 0;
+    settings.soundEnabled = registry.Get_Int(kValueNameAudioSoundEnabled, settings.soundEnabled ? 1 : 0) != 0;
+    settings.dialogEnabled = registry.Get_Int(kValueNameAudioDialogEnabled, settings.dialogEnabled ? 1 : 0) != 0;
+    settings.cinematicEnabled = registry.Get_Int(kValueNameAudioCinematicEnabled, settings.cinematicEnabled ? 1 : 0) != 0;
+    settings.soundVolume = std::clamp(registry.Get_Int(kValueNameAudioSoundVolume, static_cast<int>(settings.soundVolume * kVolumeScale)) / static_cast<float>(kVolumeScale), 0.0f, 1.0f);
+    settings.musicVolume = std::clamp(registry.Get_Int(kValueNameAudioMusicVolume, static_cast<int>(settings.musicVolume * kVolumeScale)) / static_cast<float>(kVolumeScale), 0.0f, 1.0f);
+    settings.dialogVolume = std::clamp(registry.Get_Int(kValueNameAudioDialogVolume, static_cast<int>(settings.dialogVolume * kVolumeScale)) / static_cast<float>(kVolumeScale), 0.0f, 1.0f);
+    settings.cinematicVolume = std::clamp(registry.Get_Int(kValueNameAudioCinematicVolume, static_cast<int>(settings.cinematicVolume * kVolumeScale)) / static_cast<float>(kVolumeScale), 0.0f, 1.0f);
+    settings.speakerType = registry.Get_Int(kValueNameAudioSpeakerType, settings.speakerType);
+
+    return true;
+}
+
+bool SaveAudioSettings(const AudioSettings &settings)
+{
+    RegistryClass registry(RENEGADE_SUB_KEY_NAME_AUDIO);
+    if (!registry.Is_Valid()) {
+        return false;
+    }
+
+    registry.Set_String(kValueNameAudioDevice, settings.deviceName.c_str());
+    registry.Set_Int(kValueNameAudioStereo, settings.stereo ? 1 : 0);
+    registry.Set_Int(kValueNameAudioBits, settings.bitDepth);
+    registry.Set_Int(kValueNameAudioHertz, settings.sampleRate);
+    registry.Set_Int(kValueNameAudioMusicEnabled, settings.musicEnabled ? 1 : 0);
+    registry.Set_Int(kValueNameAudioSoundEnabled, settings.soundEnabled ? 1 : 0);
+    registry.Set_Int(kValueNameAudioDialogEnabled, settings.dialogEnabled ? 1 : 0);
+    registry.Set_Int(kValueNameAudioCinematicEnabled, settings.cinematicEnabled ? 1 : 0);
+    registry.Set_Int(kValueNameAudioSoundVolume, static_cast<int>(std::clamp(settings.soundVolume, 0.0f, 1.0f) * kVolumeScale));
+    registry.Set_Int(kValueNameAudioMusicVolume, static_cast<int>(std::clamp(settings.musicVolume, 0.0f, 1.0f) * kVolumeScale));
+    registry.Set_Int(kValueNameAudioDialogVolume, static_cast<int>(std::clamp(settings.dialogVolume, 0.0f, 1.0f) * kVolumeScale));
+    registry.Set_Int(kValueNameAudioCinematicVolume, static_cast<int>(std::clamp(settings.cinematicVolume, 0.0f, 1.0f) * kVolumeScale));
+    registry.Set_Int(kValueNameAudioSpeakerType, settings.speakerType);
+
+    return true;
+}
+
+bool EnumerateVideoAdapters(std::vector<VideoAdapterInfo> &adapters)
+{
+    adapters.clear();
+
+    IDirect3D9 *d3d = Direct3DCreate9(D3D_SDK_VERSION);
+    if (!d3d) {
+        return false;
+    }
+
+    constexpr D3DFORMAT kFormats[] = {
+        D3DFMT_X8R8G8B8,
+        D3DFMT_A8R8G8B8,
+        D3DFMT_R5G6B5,
+    };
+
+    const UINT adapterCount = d3d->GetAdapterCount();
+    adapters.reserve(adapterCount);
+
+    for (UINT adapterIndex = 0; adapterIndex < adapterCount; ++adapterIndex) {
+        D3DADAPTER_IDENTIFIER9 identifier = {};
+        if (FAILED(d3d->GetAdapterIdentifier(adapterIndex, 0, &identifier))) {
+            continue;
+        }
+
+        VideoAdapterInfo adapterInfo;
+        adapterInfo.deviceName = identifier.Description;
+        adapterInfo.description = identifier.Description;
+
+        for (D3DFORMAT format : kFormats) {
+            const UINT modeCount = d3d->GetAdapterModeCount(adapterIndex, format);
+            for (UINT modeIndex = 0; modeIndex < modeCount; ++modeIndex) {
+                D3DDISPLAYMODE mode = {};
+                if (FAILED(d3d->EnumAdapterModes(adapterIndex, format, modeIndex, &mode))) {
+                    continue;
+                }
+
+                if (mode.Width < 640 || mode.Height < 480) {
+                    continue;
+                }
+
+                VideoResolution resolution;
+                resolution.width = static_cast<int>(mode.Width);
+                resolution.height = static_cast<int>(mode.Height);
+                resolution.bitDepth = (format == D3DFMT_R5G6B5) ? 16 : 32;
+
+                const auto exists = std::find_if(adapterInfo.resolutions.begin(),
+                                                 adapterInfo.resolutions.end(),
+                                                 [&](const VideoResolution &existing) {
+                                                     return existing.width == resolution.width &&
+                                                            existing.height == resolution.height &&
+                                                            existing.bitDepth == resolution.bitDepth;
+                                                 });
+                if (exists == adapterInfo.resolutions.end()) {
+                    adapterInfo.resolutions.push_back(resolution);
+                }
+            }
+        }
+
+        if (adapterInfo.resolutions.empty()) {
+            continue;
+        }
+
+        std::sort(adapterInfo.resolutions.begin(),
+                  adapterInfo.resolutions.end(),
+                  [](const VideoResolution &lhs, const VideoResolution &rhs) {
+                      if (lhs.bitDepth != rhs.bitDepth) {
+                          return lhs.bitDepth < rhs.bitDepth;
+                      }
+                      if (lhs.width != rhs.width) {
+                          return lhs.width < rhs.width;
+                      }
+                      if (lhs.height != rhs.height) {
+                          return lhs.height < rhs.height;
+                      }
+                      return false;
+                  });
+
+        adapters.push_back(std::move(adapterInfo));
+    }
+
+    d3d->Release();
+    return !adapters.empty();
+}
+
+} // namespace WWConfig

--- a/Code/Tools/WWConfig/WWConfigSettings.h
+++ b/Code/Tools/WWConfig/WWConfigSettings.h
@@ -73,4 +73,9 @@ bool LoadAudioSettings(AudioSettings &settings);
 bool SaveAudioSettings(const AudioSettings &settings);
 
 bool EnumerateVideoAdapters(std::vector<VideoAdapterInfo> &adapters);
+
+// Path to the ini used by the Qt port.
+std::string GetConfigFilePath();
+bool IsDriverWarningDisabled();
+void SetDriverWarningDisabled(bool disabled);
 }

--- a/Code/Tools/WWConfig/WWConfigSettings.h
+++ b/Code/Tools/WWConfig/WWConfigSettings.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+struct RenderSettings
+{
+    int dynamicLOD = 3000;
+    int staticLOD = 3000;
+    int dynamicShadows = 1;
+    int staticShadows = 1;
+    int prelitMode = 0;
+    int textureFilter = 0;
+    int shadowMode = 0;
+    int textureResolution = 0;
+    int surfaceEffect = 1;
+    int particleDetail = 1;
+    int lightingMode = 0;
+};
+
+struct VideoSettings
+{
+    std::string deviceName;
+    int width = 800;
+    int height = 600;
+    int bitDepth = 32;
+    bool windowed = false;
+    int textureDepth = 32;
+};
+
+struct AudioSettings
+{
+    std::string deviceName;
+    bool stereo = true;
+    int bitDepth = 16;
+    int sampleRate = 44100;
+    bool soundEnabled = true;
+    bool musicEnabled = true;
+    bool dialogEnabled = true;
+    bool cinematicEnabled = true;
+    float soundVolume = 1.0f;
+    float musicVolume = 1.0f;
+    float dialogVolume = 1.0f;
+    float cinematicVolume = 1.0f;
+    int speakerType = 0;
+};
+
+struct VideoResolution
+{
+    int width = 0;
+    int height = 0;
+    int bitDepth = 0;
+};
+
+struct VideoAdapterInfo
+{
+    std::string deviceName;
+    std::string description;
+    std::vector<VideoResolution> resolutions;
+};
+
+namespace WWConfig
+{
+bool LoadRenderSettings(RenderSettings &settings);
+bool SaveRenderSettings(const RenderSettings &settings);
+void AutoConfigRenderSettings();
+
+bool LoadVideoSettings(VideoSettings &settings);
+bool SaveVideoSettings(const VideoSettings &settings);
+
+bool LoadAudioSettings(AudioSettings &settings);
+bool SaveAudioSettings(const AudioSettings &settings);
+
+bool EnumerateVideoAdapters(std::vector<VideoAdapterInfo> &adapters);
+}

--- a/Code/Tools/WWConfig/WWConfigSettings_NonWin.cpp
+++ b/Code/Tools/WWConfig/WWConfigSettings_NonWin.cpp
@@ -1,0 +1,309 @@
+#include "WWConfigSettings.h"
+
+#include "ini.h"
+#include "openw3d.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <string>
+#include <utility>
+
+namespace
+{
+// Keep these value names aligned with the legacy DirectX wrapper INI schema.
+constexpr const char *kIniRenderDeviceName = "Name";
+constexpr const char *kIniRenderDeviceWidth = "Width";
+constexpr const char *kIniRenderDeviceHeight = "Height";
+constexpr const char *kIniRenderDeviceDepth = "Depth";
+constexpr const char *kIniRenderDeviceWindowed = "Windowed";
+constexpr const char *kIniRenderDeviceTextureDepth = "TextureDepth";
+
+constexpr const char *kIniValueNameDynLOD = "DynamicLODBudget";
+constexpr const char *kIniValueNameStaticLOD = "StaticLODBudget";
+constexpr const char *kIniValueNameDynShadows = "DynamicProjectors";
+constexpr const char *kIniValueNameTextureFilter = "TextureFilterMode";
+constexpr const char *kIniValueNamePrelitMode = "PrelitMode";
+constexpr const char *kIniValueNameShadowMode = "ShadowMode";
+constexpr const char *kIniValueNameStaticShadows = "StaticProjectors";
+constexpr const char *kIniValueNameTextureRes = "TextureResolution";
+constexpr const char *kIniValueNameSurfaceEffect = "SurfaceEffectDetail";
+constexpr const char *kIniValueNameParticleDetail = "ParticleDetail";
+
+constexpr const char *kIniValueNameAudioStereo = "Stereo";
+constexpr const char *kIniValueNameAudioBits = "Bits";
+constexpr const char *kIniValueNameAudioHertz = "Hertz";
+constexpr const char *kIniValueNameAudioDevice = "DeviceName";
+constexpr const char *kIniValueNameAudioMusicEnabled = "MusicEnabled";
+constexpr const char *kIniValueNameAudioSoundEnabled = "SoundEnabled";
+constexpr const char *kIniValueNameAudioDialogEnabled = "DialogEnabled";
+constexpr const char *kIniValueNameAudioCinematicEnabled = "CinematicEnabled";
+constexpr const char *kIniValueNameAudioMusicVolume = "MusicVolume";
+constexpr const char *kIniValueNameAudioSoundVolume = "SoundVolume";
+constexpr const char *kIniValueNameAudioDialogVolume = "DialogVolume";
+constexpr const char *kIniValueNameAudioCinematicVolume = "CinematicVolume";
+constexpr const char *kIniValueNameAudioSpeakerType = "SpeakerType";
+
+constexpr const char *kValueNameDriverWarningDisabled = "DriverVersionCheckDisabled";
+
+bool SaveIni(INIClass &ini)
+{
+    const std::string path = WWConfig::GetConfigFilePath();
+    return ini.Save(path.c_str()) >= 0;
+}
+
+bool LoadRenderSettingsFromIni(INIClass &ini, RenderSettings &settings)
+{
+    if (!ini.Is_Loaded() || !ini.Section_Present(W3D_SECTION_SYSTEM)) {
+        return false;
+    }
+
+    settings.dynamicLOD = ini.Get_Int(W3D_SECTION_SYSTEM, kIniValueNameDynLOD, settings.dynamicLOD);
+    settings.staticLOD = ini.Get_Int(W3D_SECTION_SYSTEM, kIniValueNameStaticLOD, settings.staticLOD);
+    settings.dynamicShadows = ini.Get_Int(W3D_SECTION_SYSTEM, kIniValueNameDynShadows, settings.dynamicShadows);
+    settings.staticShadows = ini.Get_Int(W3D_SECTION_SYSTEM, kIniValueNameStaticShadows, settings.staticShadows);
+    settings.prelitMode = ini.Get_Int(W3D_SECTION_SYSTEM, kIniValueNamePrelitMode, settings.prelitMode);
+    settings.textureFilter = ini.Get_Int(W3D_SECTION_SYSTEM, kIniValueNameTextureFilter, settings.textureFilter);
+    settings.shadowMode = ini.Get_Int(W3D_SECTION_SYSTEM, kIniValueNameShadowMode, settings.shadowMode);
+    settings.textureResolution = ini.Get_Int(W3D_SECTION_SYSTEM, kIniValueNameTextureRes, settings.textureResolution);
+    settings.surfaceEffect = ini.Get_Int(W3D_SECTION_SYSTEM, kIniValueNameSurfaceEffect, settings.surfaceEffect);
+    settings.particleDetail = ini.Get_Int(W3D_SECTION_SYSTEM, kIniValueNameParticleDetail, settings.particleDetail);
+    settings.lightingMode = ini.Get_Int(W3D_SECTION_SYSTEM, kIniValueNamePrelitMode, settings.lightingMode);
+
+    return true;
+}
+
+void SaveRenderSettingsToIni(const RenderSettings &settings, INIClass &ini)
+{
+    ini.Put_Int(W3D_SECTION_SYSTEM, kIniValueNameDynLOD, settings.dynamicLOD);
+    ini.Put_Int(W3D_SECTION_SYSTEM, kIniValueNameStaticLOD, settings.staticLOD);
+    ini.Put_Int(W3D_SECTION_SYSTEM, kIniValueNameDynShadows, settings.dynamicShadows);
+    ini.Put_Int(W3D_SECTION_SYSTEM, kIniValueNameStaticShadows, settings.staticShadows);
+    ini.Put_Int(W3D_SECTION_SYSTEM, kIniValueNamePrelitMode, settings.prelitMode);
+    ini.Put_Int(W3D_SECTION_SYSTEM, kIniValueNameTextureFilter, settings.textureFilter);
+    ini.Put_Int(W3D_SECTION_SYSTEM, kIniValueNameShadowMode, settings.shadowMode);
+    ini.Put_Int(W3D_SECTION_SYSTEM, kIniValueNameTextureRes, settings.textureResolution);
+    ini.Put_Int(W3D_SECTION_SYSTEM, kIniValueNameSurfaceEffect, settings.surfaceEffect);
+    ini.Put_Int(W3D_SECTION_SYSTEM, kIniValueNameParticleDetail, settings.particleDetail);
+}
+
+bool LoadVideoSettingsFromIni(INIClass &ini, VideoSettings &settings)
+{
+    if (!ini.Is_Loaded() || !ini.Section_Present(W3D_SECTION_RENDER)) {
+        return false;
+    }
+
+    char deviceName[256] = {};
+    ini.Get_String(W3D_SECTION_RENDER, kIniRenderDeviceName, "", deviceName, sizeof(deviceName));
+    if (deviceName[0] != '\0') {
+        settings.deviceName = deviceName;
+    }
+
+    const int width = ini.Get_Int(W3D_SECTION_RENDER, kIniRenderDeviceWidth, -1);
+    const int height = ini.Get_Int(W3D_SECTION_RENDER, kIniRenderDeviceHeight, -1);
+    const int bitDepth = ini.Get_Int(W3D_SECTION_RENDER, kIniRenderDeviceDepth, -1);
+    const int windowed = ini.Get_Int(W3D_SECTION_RENDER, kIniRenderDeviceWindowed, settings.windowed ? 1 : 0);
+    const int textureDepth = ini.Get_Int(W3D_SECTION_RENDER, kIniRenderDeviceTextureDepth, -1);
+
+    if (width > 0) {
+        settings.width = width;
+    }
+    if (height > 0) {
+        settings.height = height;
+    }
+    if (bitDepth > 0) {
+        settings.bitDepth = bitDepth;
+    }
+    settings.windowed = windowed != 0;
+    if (textureDepth > 0) {
+        settings.textureDepth = textureDepth;
+    }
+
+    return true;
+}
+
+void SaveVideoSettingsToIni(const VideoSettings &settings, INIClass &ini)
+{
+    ini.Put_String(W3D_SECTION_RENDER, kIniRenderDeviceName, settings.deviceName.c_str());
+    ini.Put_Int(W3D_SECTION_RENDER, kIniRenderDeviceWidth, settings.width);
+    ini.Put_Int(W3D_SECTION_RENDER, kIniRenderDeviceHeight, settings.height);
+    ini.Put_Int(W3D_SECTION_RENDER, kIniRenderDeviceDepth, settings.bitDepth);
+    ini.Put_Int(W3D_SECTION_RENDER, kIniRenderDeviceWindowed, settings.windowed ? 1 : 0);
+    ini.Put_Int(W3D_SECTION_RENDER, kIniRenderDeviceTextureDepth, settings.textureDepth);
+}
+
+bool LoadAudioSettingsFromIni(INIClass &ini, AudioSettings &settings)
+{
+    if (!ini.Is_Loaded() || !ini.Section_Present(W3D_SECTION_SOUND)) {
+        return false;
+    }
+
+    char deviceName[256] = {};
+    ini.Get_String(W3D_SECTION_SOUND, kIniValueNameAudioDevice, "", deviceName, sizeof(deviceName));
+    if (deviceName[0] != '\0') {
+        settings.deviceName = deviceName;
+    }
+
+    settings.stereo = ini.Get_Int(W3D_SECTION_SOUND, kIniValueNameAudioStereo, settings.stereo ? 1 : 0) != 0;
+    settings.bitDepth = ini.Get_Int(W3D_SECTION_SOUND, kIniValueNameAudioBits, settings.bitDepth);
+    settings.sampleRate = ini.Get_Int(W3D_SECTION_SOUND, kIniValueNameAudioHertz, settings.sampleRate);
+    settings.musicEnabled = ini.Get_Int(W3D_SECTION_SOUND, kIniValueNameAudioMusicEnabled, settings.musicEnabled ? 1 : 0) != 0;
+    settings.soundEnabled = ini.Get_Int(W3D_SECTION_SOUND, kIniValueNameAudioSoundEnabled, settings.soundEnabled ? 1 : 0) != 0;
+    settings.dialogEnabled = ini.Get_Int(W3D_SECTION_SOUND, kIniValueNameAudioDialogEnabled, settings.dialogEnabled ? 1 : 0) != 0;
+    settings.cinematicEnabled = ini.Get_Int(W3D_SECTION_SOUND, kIniValueNameAudioCinematicEnabled, settings.cinematicEnabled ? 1 : 0) != 0;
+    settings.soundVolume = std::clamp(ini.Get_Float(W3D_SECTION_SOUND, kIniValueNameAudioSoundVolume, settings.soundVolume), 0.0f, 1.0f);
+    settings.musicVolume = std::clamp(ini.Get_Float(W3D_SECTION_SOUND, kIniValueNameAudioMusicVolume, settings.musicVolume), 0.0f, 1.0f);
+    settings.dialogVolume = std::clamp(ini.Get_Float(W3D_SECTION_SOUND, kIniValueNameAudioDialogVolume, settings.dialogVolume), 0.0f, 1.0f);
+    settings.cinematicVolume = std::clamp(ini.Get_Float(W3D_SECTION_SOUND, kIniValueNameAudioCinematicVolume, settings.cinematicVolume), 0.0f, 1.0f);
+    settings.speakerType = ini.Get_Int(W3D_SECTION_SOUND, kIniValueNameAudioSpeakerType, settings.speakerType);
+
+    return true;
+}
+
+void SaveAudioSettingsToIni(const AudioSettings &settings, INIClass &ini)
+{
+    ini.Put_String(W3D_SECTION_SOUND, kIniValueNameAudioDevice, settings.deviceName.c_str());
+    ini.Put_Int(W3D_SECTION_SOUND, kIniValueNameAudioStereo, settings.stereo ? 1 : 0);
+    ini.Put_Int(W3D_SECTION_SOUND, kIniValueNameAudioBits, settings.bitDepth);
+    ini.Put_Int(W3D_SECTION_SOUND, kIniValueNameAudioHertz, settings.sampleRate);
+    ini.Put_Int(W3D_SECTION_SOUND, kIniValueNameAudioMusicEnabled, settings.musicEnabled ? 1 : 0);
+    ini.Put_Int(W3D_SECTION_SOUND, kIniValueNameAudioSoundEnabled, settings.soundEnabled ? 1 : 0);
+    ini.Put_Int(W3D_SECTION_SOUND, kIniValueNameAudioDialogEnabled, settings.dialogEnabled ? 1 : 0);
+    ini.Put_Int(W3D_SECTION_SOUND, kIniValueNameAudioCinematicEnabled, settings.cinematicEnabled ? 1 : 0);
+    ini.Put_Float(W3D_SECTION_SOUND, kIniValueNameAudioSoundVolume, std::clamp(settings.soundVolume, 0.0f, 1.0f));
+    ini.Put_Float(W3D_SECTION_SOUND, kIniValueNameAudioMusicVolume, std::clamp(settings.musicVolume, 0.0f, 1.0f));
+    ini.Put_Float(W3D_SECTION_SOUND, kIniValueNameAudioDialogVolume, std::clamp(settings.dialogVolume, 0.0f, 1.0f));
+    ini.Put_Float(W3D_SECTION_SOUND, kIniValueNameAudioCinematicVolume, std::clamp(settings.cinematicVolume, 0.0f, 1.0f));
+    ini.Put_Int(W3D_SECTION_SOUND, kIniValueNameAudioSpeakerType, settings.speakerType);
+}
+
+void AppendResolutionModes(VideoAdapterInfo &adapter, int bitDepth)
+{
+    constexpr std::array<std::pair<int, int>, 10> kModes = {
+        std::pair{640, 480},
+        std::pair{800, 600},
+        std::pair{1024, 768},
+        std::pair{1152, 864},
+        std::pair{1280, 720},
+        std::pair{1280, 800},
+        std::pair{1366, 768},
+        std::pair{1440, 900},
+        std::pair{1600, 900},
+        std::pair{1920, 1080},
+    };
+
+    for (const auto &[width, height] : kModes) {
+        VideoResolution mode;
+        mode.width = width;
+        mode.height = height;
+        mode.bitDepth = bitDepth;
+        adapter.resolutions.push_back(mode);
+    }
+}
+} // namespace
+
+namespace WWConfig
+{
+std::string GetConfigFilePath()
+{
+    if (const char *envPath = std::getenv("OPENW3D_CONFIG_INI")) {
+        if (*envPath != '\0') {
+            return std::string(envPath);
+        }
+    }
+
+    if (const char *envPath = std::getenv("RENEGADE_CONFIG_INI")) {
+        if (*envPath != '\0') {
+            return std::string(envPath);
+        }
+    }
+
+    return std::string(W3D_CONF_FILE);
+}
+
+bool LoadRenderSettings(RenderSettings &settings)
+{
+    const std::string iniPath = GetConfigFilePath();
+    INIClass ini(iniPath.c_str());
+    return LoadRenderSettingsFromIni(ini, settings);
+}
+
+bool SaveRenderSettings(const RenderSettings &settings)
+{
+    const std::string iniPath = GetConfigFilePath();
+    INIClass ini(iniPath.c_str());
+    SaveRenderSettingsToIni(settings, ini);
+    return SaveIni(ini);
+}
+
+void AutoConfigRenderSettings()
+{
+    RenderSettings settings;
+    LoadRenderSettings(settings);
+    SaveRenderSettings(settings);
+}
+
+bool LoadVideoSettings(VideoSettings &settings)
+{
+    const std::string iniPath = GetConfigFilePath();
+    INIClass ini(iniPath.c_str());
+    const bool loaded = LoadVideoSettingsFromIni(ini, settings);
+    if (settings.deviceName.empty()) {
+        settings.deviceName = "OpenW3D";
+    }
+    return loaded;
+}
+
+bool SaveVideoSettings(const VideoSettings &settings)
+{
+    const std::string iniPath = GetConfigFilePath();
+    INIClass ini(iniPath.c_str());
+    SaveVideoSettingsToIni(settings, ini);
+    return SaveIni(ini);
+}
+
+bool LoadAudioSettings(AudioSettings &settings)
+{
+    const std::string iniPath = GetConfigFilePath();
+    INIClass ini(iniPath.c_str());
+    return LoadAudioSettingsFromIni(ini, settings);
+}
+
+bool SaveAudioSettings(const AudioSettings &settings)
+{
+    const std::string iniPath = GetConfigFilePath();
+    INIClass ini(iniPath.c_str());
+    SaveAudioSettingsToIni(settings, ini);
+    return SaveIni(ini);
+}
+
+bool IsDriverWarningDisabled()
+{
+    const std::string iniPath = GetConfigFilePath();
+    INIClass ini(iniPath.c_str());
+    const int disabled = ini.Get_Int(W3D_SECTION_RENDER, kValueNameDriverWarningDisabled, 0);
+    return disabled >= 87;
+}
+
+void SetDriverWarningDisabled(bool disabled)
+{
+    const std::string iniPath = GetConfigFilePath();
+    INIClass ini(iniPath.c_str());
+    ini.Put_Int(W3D_SECTION_RENDER, kValueNameDriverWarningDisabled, disabled ? 87 : 0);
+    SaveIni(ini);
+}
+
+bool EnumerateVideoAdapters(std::vector<VideoAdapterInfo> &adapters)
+{
+    adapters.clear();
+
+    VideoAdapterInfo adapter;
+    adapter.deviceName = "OpenW3D";
+    adapter.description = "OpenW3D Default Adapter";
+    AppendResolutionModes(adapter, 16);
+    AppendResolutionModes(adapter, 32);
+
+    adapters.push_back(std::move(adapter));
+    return true;
+}
+} // namespace WWConfig

--- a/Code/Tools/WWConfigQt/AudioPage.cpp
+++ b/Code/Tools/WWConfigQt/AudioPage.cpp
@@ -1,0 +1,139 @@
+#include "AudioPage.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFormLayout>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QSlider>
+#include <QVBoxLayout>
+
+namespace
+{
+QString DeviceDisplayName(const AudioSettings &settings)
+{
+    if (settings.deviceName.empty()) {
+        return QObject::tr("Default Device");
+    }
+    return QString::fromStdString(settings.deviceName);
+}
+
+int RateIndexFromSampleRate(int sampleRate)
+{
+    switch (sampleRate) {
+    case 11025: return 0;
+    case 22050: return 1;
+    default: return 2;
+    }
+}
+} // namespace
+
+AudioPage::AudioPage(WWConfigBackend &backend, QWidget *parent)
+    : QWidget(parent),
+      m_backend(backend)
+{
+    buildUi();
+    refresh();
+}
+
+void AudioPage::buildUi()
+{
+    auto *layout = new QVBoxLayout(this);
+    layout->setSpacing(12);
+
+    auto *deviceGroup = new QGroupBox(tr("Device"), this);
+    auto *deviceLayout = new QFormLayout(deviceGroup);
+
+    m_driverCombo = new QComboBox(deviceGroup);
+    m_driverCombo->setEnabled(false);
+    deviceLayout->addRow(tr("Driver"), m_driverCombo);
+
+    m_stereoCheck = new QCheckBox(tr("Stereo playback"), deviceGroup);
+    m_stereoCheck->setEnabled(false);
+    deviceLayout->addRow(QString(), m_stereoCheck);
+
+    layout->addWidget(deviceGroup);
+
+    auto *playbackGroup = new QGroupBox(tr("Playback"), this);
+    auto *playbackLayout = new QFormLayout(playbackGroup);
+
+    m_qualityCombo = new QComboBox(playbackGroup);
+    m_qualityCombo->addItems({tr("8-bit"), tr("16-bit")});
+    m_qualityCombo->setEnabled(false);
+    playbackLayout->addRow(tr("Quality"), m_qualityCombo);
+
+    m_rateCombo = new QComboBox(playbackGroup);
+    m_rateCombo->addItems({tr("11 kHz"), tr("22 kHz"), tr("44 kHz")});
+    m_rateCombo->setEnabled(false);
+    playbackLayout->addRow(tr("Sample Rate"), m_rateCombo);
+
+    m_speakerCombo = new QComboBox(playbackGroup);
+    m_speakerCombo->addItems({tr("2 Speaker"), tr("Headphones"), tr("Surround"), tr("4 Speaker")});
+    m_speakerCombo->setEnabled(false);
+    playbackLayout->addRow(tr("Speaker Setup"), m_speakerCombo);
+
+    layout->addWidget(playbackGroup);
+
+    auto *volumeGroup = new QGroupBox(tr("Volume"), this);
+    auto *volumeLayout = new QGridLayout(volumeGroup);
+
+    auto createRow = [&](int row, const QString &labelText, QCheckBox *&check, QSlider *&slider) {
+        check = new QCheckBox(labelText, volumeGroup);
+        check->setEnabled(false);
+        slider = new QSlider(Qt::Horizontal, volumeGroup);
+        slider->setRange(0, 100);
+        slider->setEnabled(false);
+        volumeLayout->addWidget(check, row, 0);
+        volumeLayout->addWidget(slider, row, 1);
+    };
+
+    createRow(0, tr("Sound Effects"), m_soundEnableCheck, m_soundSlider);
+    createRow(1, tr("Music"), m_musicEnableCheck, m_musicSlider);
+    createRow(2, tr("Dialog"), m_dialogEnableCheck, m_dialogSlider);
+    createRow(3, tr("Cinematic"), m_cinematicEnableCheck, m_cinematicSlider);
+
+    layout->addWidget(volumeGroup);
+
+    auto *note = new QLabel(tr("Audio controls mirror the original WWConfig layout. They are locked "
+                               "while we finish extracting the backend logic; current registry "
+                               "values are shown so we can verify the data flow."),
+                            this);
+    note->setWordWrap(true);
+    layout->addWidget(note);
+    layout->addStretch();
+}
+
+void AudioPage::refresh()
+{
+    m_settings = m_backend.loadAudioSettings();
+    updateFromSettings();
+}
+
+void AudioPage::updateFromSettings()
+{
+    m_driverCombo->clear();
+    m_driverCombo->addItem(DeviceDisplayName(m_settings));
+    m_driverCombo->setCurrentIndex(0);
+
+    m_stereoCheck->setChecked(m_settings.stereo);
+
+    const int qualityIndex = (m_settings.bitDepth <= 8) ? 0 : 1;
+    m_qualityCombo->setCurrentIndex(qualityIndex);
+    m_rateCombo->setCurrentIndex(RateIndexFromSampleRate(m_settings.sampleRate));
+    m_speakerCombo->setCurrentIndex(std::clamp(m_settings.speakerType, 0, 3));
+
+    setVolumeRow(m_soundSlider, m_soundEnableCheck, m_settings.soundVolume, m_settings.soundEnabled);
+    setVolumeRow(m_musicSlider, m_musicEnableCheck, m_settings.musicVolume, m_settings.musicEnabled);
+    setVolumeRow(m_dialogSlider, m_dialogEnableCheck, m_settings.dialogVolume, m_settings.dialogEnabled);
+    setVolumeRow(m_cinematicSlider, m_cinematicEnableCheck, m_settings.cinematicVolume, m_settings.cinematicEnabled);
+}
+
+void AudioPage::setVolumeRow(QSlider *slider, QCheckBox *check, float value, bool enabled)
+{
+    slider->setValue(static_cast<int>(std::lround(std::clamp(value, 0.0f, 1.0f) * 100.0f)));
+    check->setChecked(enabled);
+}

--- a/Code/Tools/WWConfigQt/AudioPage.cpp
+++ b/Code/Tools/WWConfigQt/AudioPage.cpp
@@ -3,12 +3,14 @@
 #include <algorithm>
 #include <cmath>
 
+#include <QAbstractItemView>
 #include <QCheckBox>
 #include <QComboBox>
 #include <QFormLayout>
 #include <QGridLayout>
 #include <QGroupBox>
 #include <QLabel>
+#include <QListWidget>
 #include <QSlider>
 #include <QVBoxLayout>
 
@@ -30,6 +32,15 @@ int RateIndexFromSampleRate(int sampleRate)
     default: return 2;
     }
 }
+
+int SampleRateFromIndex(int index)
+{
+    switch (index) {
+    case 0: return 11025;
+    case 1: return 22050;
+    default: return 44100;
+    }
+}
 } // namespace
 
 AudioPage::AudioPage(WWConfigBackend &backend, QWidget *parent)
@@ -43,51 +54,37 @@ AudioPage::AudioPage(WWConfigBackend &backend, QWidget *parent)
 void AudioPage::buildUi()
 {
     auto *layout = new QVBoxLayout(this);
-    layout->setSpacing(12);
+    layout->setContentsMargins(6, 6, 6, 6);
+    layout->setSpacing(8);
 
     auto *deviceGroup = new QGroupBox(tr("Device"), this);
-    auto *deviceLayout = new QFormLayout(deviceGroup);
+    auto *deviceLayout = new QGridLayout(deviceGroup);
+    deviceLayout->setContentsMargins(6, 6, 6, 6);
+    deviceLayout->setHorizontalSpacing(6);
+    deviceLayout->setVerticalSpacing(4);
 
-    m_driverCombo = new QComboBox(deviceGroup);
-    m_driverCombo->setEnabled(false);
-    deviceLayout->addRow(tr("Driver"), m_driverCombo);
+    deviceLayout->addWidget(new QLabel(tr("Driver:"), deviceGroup), 0, 0, Qt::AlignLeft);
+    m_driverList = new QListWidget(deviceGroup);
+    m_driverList->setUniformItemSizes(true);
+    m_driverList->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_driverList->setMinimumHeight(60);
+    deviceLayout->addWidget(m_driverList, 0, 1, 1, 2);
 
-    m_stereoCheck = new QCheckBox(tr("Stereo playback"), deviceGroup);
-    m_stereoCheck->setEnabled(false);
-    deviceLayout->addRow(QString(), m_stereoCheck);
-
+    deviceLayout->setColumnStretch(1, 1);
     layout->addWidget(deviceGroup);
-
-    auto *playbackGroup = new QGroupBox(tr("Playback"), this);
-    auto *playbackLayout = new QFormLayout(playbackGroup);
-
-    m_qualityCombo = new QComboBox(playbackGroup);
-    m_qualityCombo->addItems({tr("8-bit"), tr("16-bit")});
-    m_qualityCombo->setEnabled(false);
-    playbackLayout->addRow(tr("Quality"), m_qualityCombo);
-
-    m_rateCombo = new QComboBox(playbackGroup);
-    m_rateCombo->addItems({tr("11 kHz"), tr("22 kHz"), tr("44 kHz")});
-    m_rateCombo->setEnabled(false);
-    playbackLayout->addRow(tr("Sample Rate"), m_rateCombo);
-
-    m_speakerCombo = new QComboBox(playbackGroup);
-    m_speakerCombo->addItems({tr("2 Speaker"), tr("Headphones"), tr("Surround"), tr("4 Speaker")});
-    m_speakerCombo->setEnabled(false);
-    playbackLayout->addRow(tr("Speaker Setup"), m_speakerCombo);
-
-    layout->addWidget(playbackGroup);
 
     auto *volumeGroup = new QGroupBox(tr("Volume"), this);
     auto *volumeLayout = new QGridLayout(volumeGroup);
+    volumeLayout->setContentsMargins(6, 6, 6, 6);
+    volumeLayout->setHorizontalSpacing(6);
+    volumeLayout->setVerticalSpacing(4);
 
     auto createRow = [&](int row, const QString &labelText, QCheckBox *&check, QSlider *&slider) {
         check = new QCheckBox(labelText, volumeGroup);
-        check->setEnabled(false);
         slider = new QSlider(Qt::Horizontal, volumeGroup);
         slider->setRange(0, 100);
-        slider->setEnabled(false);
-        volumeLayout->addWidget(check, row, 0);
+        slider->setTickInterval(10);
+        volumeLayout->addWidget(check, row, 0, Qt::AlignLeft);
         volumeLayout->addWidget(slider, row, 1);
     };
 
@@ -96,28 +93,76 @@ void AudioPage::buildUi()
     createRow(2, tr("Dialog"), m_dialogEnableCheck, m_dialogSlider);
     createRow(3, tr("Cinematic"), m_cinematicEnableCheck, m_cinematicSlider);
 
+    volumeLayout->setColumnStretch(1, 1);
     layout->addWidget(volumeGroup);
 
-    auto *note = new QLabel(tr("Audio controls mirror the original WWConfig layout. They are locked "
-                               "while we finish extracting the backend logic; current registry "
-                               "values are shown so we can verify the data flow."),
-                            this);
+    auto *playbackGroup = new QGroupBox(tr("Playback"), this);
+    auto *playbackLayout = new QGridLayout(playbackGroup);
+    playbackLayout->setContentsMargins(6, 6, 6, 6);
+    playbackLayout->setHorizontalSpacing(8);
+    playbackLayout->setVerticalSpacing(4);
+
+    m_qualityCombo = new QComboBox(playbackGroup);
+    m_qualityCombo->addItems({tr("8-bit"), tr("16-bit")});
+    playbackLayout->addWidget(new QLabel(tr("Quality"), playbackGroup), 0, 0, Qt::AlignLeft);
+    playbackLayout->addWidget(m_qualityCombo, 1, 0);
+
+    m_rateCombo = new QComboBox(playbackGroup);
+    m_rateCombo->addItems({tr("11 kHz"), tr("22 kHz"), tr("44 kHz")});
+    playbackLayout->addWidget(new QLabel(tr("Playback Rate"), playbackGroup), 0, 1, Qt::AlignLeft);
+    playbackLayout->addWidget(m_rateCombo, 1, 1);
+
+    m_speakerCombo = new QComboBox(playbackGroup);
+    m_speakerCombo->addItems({tr("2 Speaker"), tr("Headphones"), tr("Surround"), tr("4 Speaker")});
+    playbackLayout->addWidget(new QLabel(tr("Speaker Setup"), playbackGroup), 0, 2, Qt::AlignLeft);
+    playbackLayout->addWidget(m_speakerCombo, 1, 2);
+
+    playbackLayout->setColumnStretch(0, 1);
+    playbackLayout->setColumnStretch(1, 1);
+    playbackLayout->setColumnStretch(2, 1);
+    layout->addWidget(playbackGroup);
+
+    m_stereoCheck = new QCheckBox(tr("Stereo playback"), this);
+    layout->addWidget(m_stereoCheck, 0, Qt::AlignLeft);
+
+    auto *note = new QLabel(tr("Audio changes are saved to Renegade.ini immediately."), this);
     note->setWordWrap(true);
     layout->addWidget(note);
     layout->addStretch();
+
+    auto applyOnChange = [this]() {
+        applySettings();
+    };
+
+    connect(m_stereoCheck, &QCheckBox::toggled, this, applyOnChange);
+    connect(m_qualityCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, applyOnChange);
+    connect(m_rateCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, applyOnChange);
+    connect(m_speakerCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, applyOnChange);
+    connect(m_soundEnableCheck, &QCheckBox::toggled, this, applyOnChange);
+    connect(m_musicEnableCheck, &QCheckBox::toggled, this, applyOnChange);
+    connect(m_dialogEnableCheck, &QCheckBox::toggled, this, applyOnChange);
+    connect(m_cinematicEnableCheck, &QCheckBox::toggled, this, applyOnChange);
+    connect(m_soundSlider, &QSlider::valueChanged, this, applyOnChange);
+    connect(m_musicSlider, &QSlider::valueChanged, this, applyOnChange);
+    connect(m_dialogSlider, &QSlider::valueChanged, this, applyOnChange);
+    connect(m_cinematicSlider, &QSlider::valueChanged, this, applyOnChange);
 }
 
 void AudioPage::refresh()
 {
+    m_blockSignals = true;
     m_settings = m_backend.loadAudioSettings();
     updateFromSettings();
+    m_blockSignals = false;
 }
 
 void AudioPage::updateFromSettings()
 {
-    m_driverCombo->clear();
-    m_driverCombo->addItem(DeviceDisplayName(m_settings));
-    m_driverCombo->setCurrentIndex(0);
+    m_driverList->clear();
+    auto *item = new QListWidgetItem(DeviceDisplayName(m_settings));
+    item->setFlags(item->flags() & ~Qt::ItemIsEditable);
+    m_driverList->addItem(item);
+    m_driverList->setCurrentRow(0);
 
     m_stereoCheck->setChecked(m_settings.stereo);
 
@@ -132,8 +177,38 @@ void AudioPage::updateFromSettings()
     setVolumeRow(m_cinematicSlider, m_cinematicEnableCheck, m_settings.cinematicVolume, m_settings.cinematicEnabled);
 }
 
+void AudioPage::applySettings()
+{
+    if (m_blockSignals) {
+        return;
+    }
+
+    m_settings.stereo = m_stereoCheck->isChecked();
+    m_settings.bitDepth = (m_qualityCombo->currentIndex() == 0) ? 8 : 16;
+    m_settings.sampleRate = SampleRateFromIndex(m_rateCombo->currentIndex());
+    m_settings.speakerType = m_speakerCombo->currentIndex();
+
+    m_settings.soundEnabled = m_soundEnableCheck->isChecked();
+    m_settings.musicEnabled = m_musicEnableCheck->isChecked();
+    m_settings.dialogEnabled = m_dialogEnableCheck->isChecked();
+    m_settings.cinematicEnabled = m_cinematicEnableCheck->isChecked();
+
+    m_soundSlider->setEnabled(m_settings.soundEnabled);
+    m_musicSlider->setEnabled(m_settings.musicEnabled);
+    m_dialogSlider->setEnabled(m_settings.dialogEnabled);
+    m_cinematicSlider->setEnabled(m_settings.cinematicEnabled);
+
+    m_settings.soundVolume = std::clamp(m_soundSlider->value() / 100.0f, 0.0f, 1.0f);
+    m_settings.musicVolume = std::clamp(m_musicSlider->value() / 100.0f, 0.0f, 1.0f);
+    m_settings.dialogVolume = std::clamp(m_dialogSlider->value() / 100.0f, 0.0f, 1.0f);
+    m_settings.cinematicVolume = std::clamp(m_cinematicSlider->value() / 100.0f, 0.0f, 1.0f);
+
+    m_backend.saveAudioSettings(m_settings);
+}
+
 void AudioPage::setVolumeRow(QSlider *slider, QCheckBox *check, float value, bool enabled)
 {
     slider->setValue(static_cast<int>(std::lround(std::clamp(value, 0.0f, 1.0f) * 100.0f)));
     check->setChecked(enabled);
+    slider->setEnabled(enabled);
 }

--- a/Code/Tools/WWConfigQt/AudioPage.cpp
+++ b/Code/Tools/WWConfigQt/AudioPage.cpp
@@ -125,13 +125,13 @@ void AudioPage::buildUi()
     m_stereoCheck = new QCheckBox(tr("Stereo playback"), this);
     layout->addWidget(m_stereoCheck, 0, Qt::AlignLeft);
 
-    auto *note = new QLabel(tr("Audio changes are saved to Renegade.ini immediately."), this);
+    auto *note = new QLabel(tr("Press OK to save audio changes to Renegade.ini."), this);
     note->setWordWrap(true);
     layout->addWidget(note);
     layout->addStretch();
 
     auto applyOnChange = [this]() {
-        applySettings();
+        updateSettingsFromControls();
     };
 
     connect(m_stereoCheck, &QCheckBox::toggled, this, applyOnChange);
@@ -156,6 +156,12 @@ void AudioPage::refresh()
     m_blockSignals = false;
 }
 
+bool AudioPage::save()
+{
+    updateSettingsFromControls();
+    return m_backend.saveAudioSettings(m_settings);
+}
+
 void AudioPage::updateFromSettings()
 {
     m_driverList->clear();
@@ -177,7 +183,7 @@ void AudioPage::updateFromSettings()
     setVolumeRow(m_cinematicSlider, m_cinematicEnableCheck, m_settings.cinematicVolume, m_settings.cinematicEnabled);
 }
 
-void AudioPage::applySettings()
+void AudioPage::updateSettingsFromControls()
 {
     if (m_blockSignals) {
         return;
@@ -203,7 +209,6 @@ void AudioPage::applySettings()
     m_settings.dialogVolume = std::clamp(m_dialogSlider->value() / 100.0f, 0.0f, 1.0f);
     m_settings.cinematicVolume = std::clamp(m_cinematicSlider->value() / 100.0f, 0.0f, 1.0f);
 
-    m_backend.saveAudioSettings(m_settings);
 }
 
 void AudioPage::setVolumeRow(QSlider *slider, QCheckBox *check, float value, bool enabled)

--- a/Code/Tools/WWConfigQt/AudioPage.h
+++ b/Code/Tools/WWConfigQt/AudioPage.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QWidget>
+
+#include "WWConfigBackend.h"
+
+class QCheckBox;
+class QComboBox;
+class QLabel;
+class QSlider;
+
+class AudioPage : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit AudioPage(WWConfigBackend &backend, QWidget *parent = nullptr);
+
+    void refresh();
+
+private:
+    void buildUi();
+    void updateFromSettings();
+    void setVolumeRow(QSlider *slider, QCheckBox *check, float value, bool enabled);
+
+    WWConfigBackend &m_backend;
+    AudioSettings m_settings;
+
+    QComboBox *m_driverCombo = nullptr;
+    QCheckBox *m_stereoCheck = nullptr;
+    QComboBox *m_qualityCombo = nullptr;
+    QComboBox *m_rateCombo = nullptr;
+    QComboBox *m_speakerCombo = nullptr;
+
+    QCheckBox *m_soundEnableCheck = nullptr;
+    QCheckBox *m_musicEnableCheck = nullptr;
+    QCheckBox *m_dialogEnableCheck = nullptr;
+    QCheckBox *m_cinematicEnableCheck = nullptr;
+
+    QSlider *m_soundSlider = nullptr;
+    QSlider *m_musicSlider = nullptr;
+    QSlider *m_dialogSlider = nullptr;
+    QSlider *m_cinematicSlider = nullptr;
+};

--- a/Code/Tools/WWConfigQt/AudioPage.h
+++ b/Code/Tools/WWConfigQt/AudioPage.h
@@ -7,6 +7,7 @@
 class QCheckBox;
 class QComboBox;
 class QLabel;
+class QListWidget;
 class QSlider;
 
 class AudioPage : public QWidget
@@ -21,12 +22,14 @@ public:
 private:
     void buildUi();
     void updateFromSettings();
+    void applySettings();
     void setVolumeRow(QSlider *slider, QCheckBox *check, float value, bool enabled);
 
     WWConfigBackend &m_backend;
     AudioSettings m_settings;
+    bool m_blockSignals = false;
 
-    QComboBox *m_driverCombo = nullptr;
+    QListWidget *m_driverList = nullptr;
     QCheckBox *m_stereoCheck = nullptr;
     QComboBox *m_qualityCombo = nullptr;
     QComboBox *m_rateCombo = nullptr;

--- a/Code/Tools/WWConfigQt/AudioPage.h
+++ b/Code/Tools/WWConfigQt/AudioPage.h
@@ -18,11 +18,12 @@ public:
     explicit AudioPage(WWConfigBackend &backend, QWidget *parent = nullptr);
 
     void refresh();
+    bool save();
 
 private:
     void buildUi();
     void updateFromSettings();
-    void applySettings();
+    void updateSettingsFromControls();
     void setVolumeRow(QSlider *slider, QCheckBox *check, float value, bool enabled);
 
     WWConfigBackend &m_backend;

--- a/Code/Tools/WWConfigQt/CMakeLists.txt
+++ b/Code/Tools/WWConfigQt/CMakeLists.txt
@@ -10,6 +10,8 @@ set(WWCONFIG_QT_SRC
     AudioPage.h
     WWConfigBackend.cpp
     WWConfigBackend.h
+    wwconfig_qt.rc
+    resources.qrc
 )
 
 add_executable(wwconfig_qt WIN32)

--- a/Code/Tools/WWConfigQt/CMakeLists.txt
+++ b/Code/Tools/WWConfigQt/CMakeLists.txt
@@ -1,0 +1,53 @@
+set(WWCONFIG_QT_SRC
+    main.cpp
+    MainWindow.cpp
+    MainWindow.h
+    PerformancePage.cpp
+    PerformancePage.h
+    VideoPage.cpp
+    VideoPage.h
+    AudioPage.cpp
+    AudioPage.h
+    WWConfigBackend.cpp
+    WWConfigBackend.h
+)
+
+add_executable(wwconfig_qt WIN32)
+
+target_sources(wwconfig_qt PRIVATE ${WWCONFIG_QT_SRC})
+
+target_include_directories(wwconfig_qt
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(wwconfig_qt
+    PRIVATE
+        w3d_qt_toolkit
+        wwconfig_core
+        wwcommon
+        wwdebug
+        wwmath
+        wwphys
+        wwsaveload
+        ww3d2
+        wwaudio
+        winmm
+)
+
+if(WIN32)
+    find_program(WINDEPLOYQT_EXECUTABLE
+        NAMES windeployqt.exe
+        HINTS "${Qt6_DIR}/../../../tools/Qt6/bin"
+    )
+    if(WINDEPLOYQT_EXECUTABLE)
+        add_custom_command(TARGET wwconfig_qt POST_BUILD
+            COMMAND "${WINDEPLOYQT_EXECUTABLE}"
+                --no-translations
+                "$<TARGET_FILE:wwconfig_qt>"
+            COMMENT "Running windeployqt for wwconfig_qt"
+            VERBATIM)
+    else()
+        message(WARNING "windeployqt not found; wwconfig_qt will require manual Qt runtime deployment.")
+    endif()
+endif()

--- a/Code/Tools/WWConfigQt/CMakeLists.txt
+++ b/Code/Tools/WWConfigQt/CMakeLists.txt
@@ -10,9 +10,14 @@ set(WWCONFIG_QT_SRC
     AudioPage.h
     WWConfigBackend.cpp
     WWConfigBackend.h
-    wwconfig_qt.rc
     resources.qrc
 )
+
+if(WIN32)
+    list(APPEND WWCONFIG_QT_SRC
+        wwconfig_qt.rc
+    )
+endif()
 
 add_executable(wwconfig_qt WIN32)
 
@@ -28,14 +33,19 @@ target_link_libraries(wwconfig_qt
         w3d_qt_toolkit
         wwconfig_core
         wwcommon
+        wwaudio
+)
+
+if(WIN32)
+    target_link_libraries(wwconfig_qt PRIVATE
         wwdebug
         wwmath
         wwphys
         wwsaveload
         ww3d2
-        wwaudio
-        winmm
-)
+    )
+    target_link_libraries(wwconfig_qt PRIVATE winmm)
+endif()
 
 if(WIN32)
     find_program(WINDEPLOYQT_EXECUTABLE

--- a/Code/Tools/WWConfigQt/MainWindow.cpp
+++ b/Code/Tools/WWConfigQt/MainWindow.cpp
@@ -1,6 +1,11 @@
 #include "MainWindow.h"
 
+#include <QFrame>
+#include <QHBoxLayout>
+#include <QIcon>
 #include <QLabel>
+#include <QPixmap>
+#include <QPushButton>
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <QWidget>
@@ -23,21 +28,28 @@ void MainWindow::setupUi()
 {
     auto *central = new QWidget(this);
     auto *layout = new QVBoxLayout(central);
-    layout->setContentsMargins(16, 16, 16, 16);
-    layout->setSpacing(12);
+    layout->setContentsMargins(8, 8, 8, 8);
+    layout->setSpacing(6);
 
-    m_statusLabel = new QLabel(tr("Loading locale data..."), central);
-    m_statusLabel->setWordWrap(true);
-    layout->addWidget(m_statusLabel);
+    auto *banner = new QLabel(central);
+    banner->setFrameShape(QFrame::Panel);
+    banner->setFrameShadow(QFrame::Sunken);
+    banner->setAlignment(Qt::AlignCenter);
+    banner->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    QPixmap logo(QStringLiteral(":/wwconfig/logo.bmp"));
+    if (!logo.isNull()) {
+        banner->setPixmap(logo);
+        banner->setScaledContents(true);
+        banner->setMinimumHeight(logo.height());
+    } else {
+        banner->setText(tr("Renegade Config"));
+        banner->setMinimumHeight(40);
+    }
+    layout->addWidget(banner);
 
     m_tabWidget = new QTabWidget(central);
+    m_tabWidget->setDocumentMode(true);
     layout->addWidget(m_tabWidget);
-
-    m_performancePage = new PerformancePage(m_backend, m_tabWidget);
-    m_tabWidget->addTab(m_performancePage, tr("Performance"));
-    connect(m_performancePage, &PerformancePage::settingsChanged, this, [this]() {
-        updateStatusText();
-    });
 
     m_videoPage = new VideoPage(m_backend, m_tabWidget);
     m_tabWidget->addTab(m_videoPage, tr("Video"));
@@ -45,11 +57,33 @@ void MainWindow::setupUi()
     m_audioPage = new AudioPage(m_backend, m_tabWidget);
     m_tabWidget->addTab(m_audioPage, tr("Audio"));
 
-    layout->addStretch();
+    m_performancePage = new PerformancePage(m_backend, m_tabWidget);
+    m_tabWidget->addTab(m_performancePage, tr("Performance"));
+    connect(m_performancePage, &PerformancePage::settingsChanged, this, [this]() {
+        updateStatusText();
+    });
+
+    m_statusLabel = new QLabel(tr("Loading locale data..."), central);
+    m_statusLabel->setWordWrap(true);
+    m_statusLabel->setStyleSheet(QStringLiteral("color: palette(mid);"));
+    layout->addWidget(m_statusLabel);
+
+    auto *buttonRow = new QHBoxLayout();
+    buttonRow->addStretch();
+    auto *okButton = new QPushButton(tr("OK"), central);
+    auto *cancelButton = new QPushButton(tr("Cancel"), central);
+    buttonRow->addWidget(okButton);
+    buttonRow->addWidget(cancelButton);
+    layout->addLayout(buttonRow);
+
+    connect(okButton, &QPushButton::clicked, this, &QWidget::close);
+    connect(cancelButton, &QPushButton::clicked, this, &QWidget::close);
 
     setCentralWidget(central);
-    setMinimumSize(420, 280);
-    setWindowTitle(tr("Renegade Configuration (Qt)"));
+    resize(420, 480);
+    setMinimumSize(360, 360);
+    setWindowTitle(tr("Renegade Config"));
+    setWindowIcon(QIcon(QStringLiteral(":/wwconfig/wwconfig.ico")));
 }
 
 void MainWindow::updateStatusText()
@@ -64,14 +98,12 @@ void MainWindow::updateStatusText()
                               : tr("Locale bank unavailable, using fallback strings.");
 
     const RenderSettings settings = m_backend.loadRenderSettings();
-    const QString renderSummary = tr("LOD budget: %1\nTexture filter: %2\nShadow mode: %3")
+    const QString renderSummary = tr("LOD %1  Filter %2  Shadows %3")
                                       .arg(settings.dynamicLOD)
                                       .arg(settings.textureFilter)
                                       .arg(settings.shadowMode);
 
-    m_statusLabel->setText(
-        tr("Qt port work-in-progress.\n\n%1\n\nCurrent render settings:\n%2\n\nMore panels coming soon.")
-            .arg(state, renderSummary));
+    m_statusLabel->setText(tr("%1 · %2").arg(state, renderSummary));
 
     refreshTabs();
 }

--- a/Code/Tools/WWConfigQt/MainWindow.cpp
+++ b/Code/Tools/WWConfigQt/MainWindow.cpp
@@ -1,0 +1,90 @@
+#include "MainWindow.h"
+
+#include <QLabel>
+#include <QTabWidget>
+#include <QVBoxLayout>
+#include <QWidget>
+
+#include "WWConfigBackend.h"
+#include "PerformancePage.h"
+#include "VideoPage.h"
+#include "AudioPage.h"
+#include "../WWConfig/wwconfig_ids.h"
+
+MainWindow::MainWindow(WWConfigBackend &backend, QWidget *parent)
+    : QMainWindow(parent),
+      m_backend(backend)
+{
+    setupUi();
+    updateStatusText();
+}
+
+void MainWindow::setupUi()
+{
+    auto *central = new QWidget(this);
+    auto *layout = new QVBoxLayout(central);
+    layout->setContentsMargins(16, 16, 16, 16);
+    layout->setSpacing(12);
+
+    m_statusLabel = new QLabel(tr("Loading locale data..."), central);
+    m_statusLabel->setWordWrap(true);
+    layout->addWidget(m_statusLabel);
+
+    m_tabWidget = new QTabWidget(central);
+    layout->addWidget(m_tabWidget);
+
+    m_performancePage = new PerformancePage(m_backend, m_tabWidget);
+    m_tabWidget->addTab(m_performancePage, tr("Performance"));
+    connect(m_performancePage, &PerformancePage::settingsChanged, this, [this]() {
+        updateStatusText();
+    });
+
+    m_videoPage = new VideoPage(m_backend, m_tabWidget);
+    m_tabWidget->addTab(m_videoPage, tr("Video"));
+
+    m_audioPage = new AudioPage(m_backend, m_tabWidget);
+    m_tabWidget->addTab(m_audioPage, tr("Audio"));
+
+    layout->addStretch();
+
+    setCentralWidget(central);
+    setMinimumSize(420, 280);
+    setWindowTitle(tr("Renegade Configuration (Qt)"));
+}
+
+void MainWindow::updateStatusText()
+{
+    const QString localizedTitle = m_backend.localizedString(IDS_WWCONFIG_TITLE);
+    if (!localizedTitle.isEmpty()) {
+        setWindowTitle(localizedTitle);
+    }
+
+    const QString state = m_backend.isLocaleReady()
+                              ? tr("Locale bank loaded.")
+                              : tr("Locale bank unavailable, using fallback strings.");
+
+    const RenderSettings settings = m_backend.loadRenderSettings();
+    const QString renderSummary = tr("LOD budget: %1\nTexture filter: %2\nShadow mode: %3")
+                                      .arg(settings.dynamicLOD)
+                                      .arg(settings.textureFilter)
+                                      .arg(settings.shadowMode);
+
+    m_statusLabel->setText(
+        tr("Qt port work-in-progress.\n\n%1\n\nCurrent render settings:\n%2\n\nMore panels coming soon.")
+            .arg(state, renderSummary));
+
+    refreshTabs();
+}
+
+void MainWindow::refreshTabs()
+{
+    if (m_performancePage) {
+        m_performancePage->refresh();
+    }
+    if (m_videoPage) {
+        m_videoPage->refresh();
+    }
+    if (m_audioPage) {
+        m_audioPage->refresh();
+    }
+}

--- a/Code/Tools/WWConfigQt/MainWindow.cpp
+++ b/Code/Tools/WWConfigQt/MainWindow.cpp
@@ -4,8 +4,10 @@
 #include <QHBoxLayout>
 #include <QIcon>
 #include <QLabel>
+#include <QPalette>
 #include <QPixmap>
 #include <QPushButton>
+#include <QSize>
 #include <QTabWidget>
 #include <QVBoxLayout>
 #include <QWidget>
@@ -36,10 +38,15 @@ void MainWindow::setupUi()
     banner->setFrameShadow(QFrame::Sunken);
     banner->setAlignment(Qt::AlignCenter);
     banner->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    QPalette bannerPalette = banner->palette();
+    bannerPalette.setColor(QPalette::Window, Qt::black);
+    bannerPalette.setColor(QPalette::WindowText, Qt::white);
+    banner->setAutoFillBackground(true);
+    banner->setPalette(bannerPalette);
     QPixmap logo(QStringLiteral(":/wwconfig/logo.bmp"));
     if (!logo.isNull()) {
         banner->setPixmap(logo);
-        banner->setScaledContents(true);
+        banner->setScaledContents(false);
         banner->setMinimumHeight(logo.height());
     } else {
         banner->setText(tr("Renegade Config"));
@@ -59,9 +66,6 @@ void MainWindow::setupUi()
 
     m_performancePage = new PerformancePage(m_backend, m_tabWidget);
     m_tabWidget->addTab(m_performancePage, tr("Performance"));
-    connect(m_performancePage, &PerformancePage::settingsChanged, this, [this]() {
-        updateStatusText();
-    });
 
     auto *buttonRow = new QHBoxLayout();
     buttonRow->addStretch();
@@ -71,14 +75,31 @@ void MainWindow::setupUi()
     buttonRow->addWidget(cancelButton);
     layout->addLayout(buttonRow);
 
-    connect(okButton, &QPushButton::clicked, this, &QWidget::close);
+    connect(okButton, &QPushButton::clicked, this, [this]() {
+        saveChanges();
+        close();
+    });
     connect(cancelButton, &QPushButton::clicked, this, &QWidget::close);
 
     setCentralWidget(central);
-    resize(420, 480);
-    setMinimumSize(360, 360);
+    const QSize windowSize(420, 480);
+    resize(windowSize);
+    setMinimumSize(windowSize);
     setWindowTitle(tr("Renegade Config"));
     setWindowIcon(QIcon(QStringLiteral(":/wwconfig/wwconfig.ico")));
+}
+
+void MainWindow::saveChanges()
+{
+    if (m_videoPage) {
+        m_videoPage->save();
+    }
+    if (m_audioPage) {
+        m_audioPage->save();
+    }
+    if (m_performancePage) {
+        m_performancePage->save();
+    }
 }
 
 void MainWindow::updateStatusText()

--- a/Code/Tools/WWConfigQt/MainWindow.cpp
+++ b/Code/Tools/WWConfigQt/MainWindow.cpp
@@ -63,11 +63,6 @@ void MainWindow::setupUi()
         updateStatusText();
     });
 
-    m_statusLabel = new QLabel(tr("Loading locale data..."), central);
-    m_statusLabel->setWordWrap(true);
-    m_statusLabel->setStyleSheet(QStringLiteral("color: palette(mid);"));
-    layout->addWidget(m_statusLabel);
-
     auto *buttonRow = new QHBoxLayout();
     buttonRow->addStretch();
     auto *okButton = new QPushButton(tr("OK"), central);
@@ -92,18 +87,6 @@ void MainWindow::updateStatusText()
     if (!localizedTitle.isEmpty()) {
         setWindowTitle(localizedTitle);
     }
-
-    const QString state = m_backend.isLocaleReady()
-                              ? tr("Locale bank loaded.")
-                              : tr("Locale bank unavailable, using fallback strings.");
-
-    const RenderSettings settings = m_backend.loadRenderSettings();
-    const QString renderSummary = tr("LOD %1  Filter %2  Shadows %3")
-                                      .arg(settings.dynamicLOD)
-                                      .arg(settings.textureFilter)
-                                      .arg(settings.shadowMode);
-
-    m_statusLabel->setText(tr("%1 · %2").arg(state, renderSummary));
 
     refreshTabs();
 }

--- a/Code/Tools/WWConfigQt/MainWindow.h
+++ b/Code/Tools/WWConfigQt/MainWindow.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <QMainWindow>
+
+class QLabel;
+class QTabWidget;
+class WWConfigBackend;
+class PerformancePage;
+class VideoPage;
+class AudioPage;
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    explicit MainWindow(WWConfigBackend &backend, QWidget *parent = nullptr);
+
+private:
+    void setupUi();
+    void updateStatusText();
+    void refreshTabs();
+
+    WWConfigBackend &m_backend;
+    QLabel *m_statusLabel = nullptr;
+    QTabWidget *m_tabWidget = nullptr;
+    PerformancePage *m_performancePage = nullptr;
+    VideoPage *m_videoPage = nullptr;
+    AudioPage *m_audioPage = nullptr;
+};

--- a/Code/Tools/WWConfigQt/MainWindow.h
+++ b/Code/Tools/WWConfigQt/MainWindow.h
@@ -2,7 +2,6 @@
 
 #include <QMainWindow>
 
-class QLabel;
 class QTabWidget;
 class WWConfigBackend;
 class PerformancePage;
@@ -22,7 +21,6 @@ private:
     void refreshTabs();
 
     WWConfigBackend &m_backend;
-    QLabel *m_statusLabel = nullptr;
     QTabWidget *m_tabWidget = nullptr;
     PerformancePage *m_performancePage = nullptr;
     VideoPage *m_videoPage = nullptr;

--- a/Code/Tools/WWConfigQt/MainWindow.h
+++ b/Code/Tools/WWConfigQt/MainWindow.h
@@ -17,6 +17,7 @@ public:
 
 private:
     void setupUi();
+    void saveChanges();
     void updateStatusText();
     void refreshTabs();
 

--- a/Code/Tools/WWConfigQt/PerformancePage.cpp
+++ b/Code/Tools/WWConfigQt/PerformancePage.cpp
@@ -62,22 +62,34 @@ PerformancePage::PerformancePage(WWConfigBackend &backend, QWidget *parent)
 void PerformancePage::buildUi()
 {
     auto *mainLayout = new QVBoxLayout(this);
-    mainLayout->setSpacing(12);
+    mainLayout->setContentsMargins(4, 4, 4, 4);
+    mainLayout->setSpacing(8);
 
-    auto *overallLayout = new QHBoxLayout();
-    overallLayout->addWidget(new QLabel(tr("Detail:"), this));
+    auto *detailGroup = new QGroupBox(tr("Detail"), this);
+    auto *detailLayout = new QGridLayout(detailGroup);
 
-    m_overallSlider = new QSlider(Qt::Horizontal, this);
+    auto *lowFast = new QLabel(tr("Low (fastest)"), detailGroup);
+    lowFast->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    detailLayout->addWidget(lowFast, 0, 0);
+
+    m_overallSlider = new QSlider(Qt::Horizontal, detailGroup);
     m_overallSlider->setRange(0, 3);
-    overallLayout->addWidget(m_overallSlider, 1);
+    m_overallSlider->setTickInterval(1);
+    m_overallSlider->setTickPosition(QSlider::TicksBelow);
+    detailLayout->addWidget(m_overallSlider, 0, 1);
 
-    m_expertCheck = new QCheckBox(tr("Expert Mode"), this);
-    overallLayout->addWidget(m_expertCheck);
+    auto *highSlow = new QLabel(tr("High (slowest)"), detailGroup);
+    highSlow->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    detailLayout->addWidget(highSlow, 0, 2);
 
-    m_autoButton = new QPushButton(tr("Auto Config"), this);
-    overallLayout->addWidget(m_autoButton);
+    m_expertCheck = new QCheckBox(tr("Expert Mode"), detailGroup);
+    detailLayout->addWidget(m_expertCheck, 1, 0, 1, 2);
 
-    mainLayout->addLayout(overallLayout);
+    m_autoButton = new QPushButton(tr("Auto Config"), detailGroup);
+    detailLayout->addWidget(m_autoButton, 1, 2, Qt::AlignRight);
+
+    detailLayout->setColumnStretch(1, 1);
+    mainLayout->addWidget(detailGroup);
 
     m_expertGroup = new QGroupBox(tr("Expert Settings"), this);
     auto *groupLayout = new QGridLayout(m_expertGroup);
@@ -96,25 +108,23 @@ void PerformancePage::buildUi()
     m_surfaceSlider = createSlider();
 
     int row = 0;
-    groupLayout->addWidget(new QLabel(tr("Geometry Detail"), m_expertGroup), row, 0);
-    groupLayout->addWidget(m_geometrySlider, row, 1);
-    ++row;
+    auto addSliderRow = [&](const QString &label, QSlider *slider) {
+        auto *title = new QLabel(label, m_expertGroup);
+        groupLayout->addWidget(title, row, 0);
+        groupLayout->addWidget(slider, row, 1);
+        auto *lowLabel = new QLabel(tr("Low"), m_expertGroup);
+        lowLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+        groupLayout->addWidget(lowLabel, row, 2);
+        auto *highLabel = new QLabel(tr("High"), m_expertGroup);
+        groupLayout->addWidget(highLabel, row, 3);
+        ++row;
+    };
 
-    groupLayout->addWidget(new QLabel(tr("Character Shadows"), m_expertGroup), row, 0);
-    groupLayout->addWidget(m_shadowSlider, row, 1);
-    ++row;
-
-    groupLayout->addWidget(new QLabel(tr("Texture Detail"), m_expertGroup), row, 0);
-    groupLayout->addWidget(m_textureSlider, row, 1);
-    ++row;
-
-    groupLayout->addWidget(new QLabel(tr("Particle Detail"), m_expertGroup), row, 0);
-    groupLayout->addWidget(m_particleSlider, row, 1);
-    ++row;
-
-    groupLayout->addWidget(new QLabel(tr("Surface Effect Detail"), m_expertGroup), row, 0);
-    groupLayout->addWidget(m_surfaceSlider, row, 1);
-    ++row;
+    addSliderRow(tr("Geometry Detail"), m_geometrySlider);
+    addSliderRow(tr("Character Shadows"), m_shadowSlider);
+    addSliderRow(tr("Texture Detail"), m_textureSlider);
+    addSliderRow(tr("Particle Detail"), m_particleSlider);
+    addSliderRow(tr("Surface Effect Detail"), m_surfaceSlider);
 
     m_lightingCombo = new QComboBox(m_expertGroup);
     m_lightingCombo->addItems({tr("Vertex"), tr("Multi-pass"), tr("Multi-texture")});
@@ -129,8 +139,9 @@ void PerformancePage::buildUi()
     ++row;
 
     m_terrainCheck = new QCheckBox(tr("Terrain Casts Shadows"), m_expertGroup);
-    groupLayout->addWidget(m_terrainCheck, row, 0, 1, 2);
+    groupLayout->addWidget(m_terrainCheck, row, 0, 1, 4);
 
+    groupLayout->setColumnStretch(1, 1);
     mainLayout->addWidget(m_expertGroup);
 
     setExpertControlsEnabled(false);

--- a/Code/Tools/WWConfigQt/PerformancePage.cpp
+++ b/Code/Tools/WWConfigQt/PerformancePage.cpp
@@ -1,0 +1,293 @@
+#include "PerformancePage.h"
+
+#include <algorithm>
+#include <array>
+#include <iterator>
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFormLayout>
+#include <QGridLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QSlider>
+#include <QVBoxLayout>
+
+#include "../../ww3d2/ww3d.h"
+#include "../../ww3d2/texture.h"
+
+namespace
+{
+struct PresetLevel
+{
+    int geometry;
+    int character;
+    int texture;
+    int surface;
+    int particle;
+    int textureFilter;
+    int lightingMode;
+    bool terrainShadows;
+};
+
+constexpr PresetLevel kPresets[] = {
+    {0, 0, 0, 0, 0, 0, 0, false},
+    {0, 1, 1, 0, 0, 0, WW3D::PRELIT_MODE_LIGHTMAP_MULTI_TEXTURE, false},
+    {1, 2, 2, 1, 1, 1, WW3D::PRELIT_MODE_LIGHTMAP_MULTI_TEXTURE, true},
+    {2, 3, 2, 2, 2, 1, WW3D::PRELIT_MODE_LIGHTMAP_MULTI_TEXTURE, true},
+};
+constexpr int kPresetCount = sizeof(kPresets) / sizeof(kPresets[0]);
+
+int textureSliderFromResolution(int textureRes)
+{
+    return std::clamp(2 - textureRes, 0, 2);
+}
+
+int textureResolutionFromSlider(int sliderValue)
+{
+    return std::max(2 - sliderValue, 0);
+}
+} // namespace
+
+PerformancePage::PerformancePage(WWConfigBackend &backend, QWidget *parent)
+    : QWidget(parent),
+      m_backend(backend)
+{
+    buildUi();
+    refresh();
+}
+
+void PerformancePage::buildUi()
+{
+    auto *mainLayout = new QVBoxLayout(this);
+    mainLayout->setSpacing(12);
+
+    auto *overallLayout = new QHBoxLayout();
+    overallLayout->addWidget(new QLabel(tr("Detail:"), this));
+
+    m_overallSlider = new QSlider(Qt::Horizontal, this);
+    m_overallSlider->setRange(0, 3);
+    overallLayout->addWidget(m_overallSlider, 1);
+
+    m_expertCheck = new QCheckBox(tr("Expert Mode"), this);
+    overallLayout->addWidget(m_expertCheck);
+
+    m_autoButton = new QPushButton(tr("Auto Config"), this);
+    overallLayout->addWidget(m_autoButton);
+
+    mainLayout->addLayout(overallLayout);
+
+    m_expertGroup = new QGroupBox(tr("Expert Settings"), this);
+    auto *groupLayout = new QGridLayout(m_expertGroup);
+
+    auto createSlider = [this]() {
+        auto *slider = new QSlider(Qt::Horizontal, m_expertGroup);
+        slider->setRange(0, 2);
+        return slider;
+    };
+
+    m_geometrySlider = createSlider();
+    m_shadowSlider = new QSlider(Qt::Horizontal, m_expertGroup);
+    m_shadowSlider->setRange(0, 3);
+    m_textureSlider = createSlider();
+    m_particleSlider = createSlider();
+    m_surfaceSlider = createSlider();
+
+    int row = 0;
+    groupLayout->addWidget(new QLabel(tr("Geometry Detail"), m_expertGroup), row, 0);
+    groupLayout->addWidget(m_geometrySlider, row, 1);
+    ++row;
+
+    groupLayout->addWidget(new QLabel(tr("Character Shadows"), m_expertGroup), row, 0);
+    groupLayout->addWidget(m_shadowSlider, row, 1);
+    ++row;
+
+    groupLayout->addWidget(new QLabel(tr("Texture Detail"), m_expertGroup), row, 0);
+    groupLayout->addWidget(m_textureSlider, row, 1);
+    ++row;
+
+    groupLayout->addWidget(new QLabel(tr("Particle Detail"), m_expertGroup), row, 0);
+    groupLayout->addWidget(m_particleSlider, row, 1);
+    ++row;
+
+    groupLayout->addWidget(new QLabel(tr("Surface Effect Detail"), m_expertGroup), row, 0);
+    groupLayout->addWidget(m_surfaceSlider, row, 1);
+    ++row;
+
+    m_lightingCombo = new QComboBox(m_expertGroup);
+    m_lightingCombo->addItems({tr("Vertex"), tr("Multi-pass"), tr("Multi-texture")});
+    groupLayout->addWidget(new QLabel(tr("Lighting Mode"), m_expertGroup), row, 0);
+    groupLayout->addWidget(m_lightingCombo, row, 1);
+    ++row;
+
+    m_filterCombo = new QComboBox(m_expertGroup);
+    m_filterCombo->addItems({tr("Bilinear"), tr("Trilinear")});
+    groupLayout->addWidget(new QLabel(tr("Texture Filter"), m_expertGroup), row, 0);
+    groupLayout->addWidget(m_filterCombo, row, 1);
+    ++row;
+
+    m_terrainCheck = new QCheckBox(tr("Terrain Casts Shadows"), m_expertGroup);
+    groupLayout->addWidget(m_terrainCheck, row, 0, 1, 2);
+
+    mainLayout->addWidget(m_expertGroup);
+
+    setExpertControlsEnabled(false);
+
+    connect(m_overallSlider, &QSlider::valueChanged, this, [this](int value) {
+        if (m_blockSignals) {
+            return;
+        }
+        if (!m_expertCheck->isChecked()) {
+            applyPreset(value);
+        }
+    });
+
+    connect(m_expertCheck, &QCheckBox::toggled, this, [this](bool checked) {
+        setExpertControlsEnabled(checked);
+        if (!checked) {
+            applyPreset(m_overallSlider->value());
+        }
+    });
+
+    connect(m_autoButton, &QPushButton::clicked, this, [this]() {
+        m_backend.autoConfigRenderSettings();
+        refresh();
+        emit settingsChanged();
+    });
+
+    auto sliderChanged = [this]() {
+        if (m_blockSignals) {
+            return;
+        }
+        applySettingsFromControls();
+    };
+
+    connect(m_geometrySlider, &QSlider::valueChanged, this, sliderChanged);
+    connect(m_shadowSlider, &QSlider::valueChanged, this, sliderChanged);
+    connect(m_textureSlider, &QSlider::valueChanged, this, sliderChanged);
+    connect(m_surfaceSlider, &QSlider::valueChanged, this, sliderChanged);
+    connect(m_particleSlider, &QSlider::valueChanged, this, sliderChanged);
+    connect(m_lightingCombo, &QComboBox::currentIndexChanged, this, sliderChanged);
+    connect(m_filterCombo, &QComboBox::currentIndexChanged, this, sliderChanged);
+    connect(m_terrainCheck, &QCheckBox::toggled, this, sliderChanged);
+}
+
+void PerformancePage::refresh()
+{
+    loadSettings();
+    updateControlsFromSettings();
+}
+
+void PerformancePage::loadSettings()
+{
+    m_settings = m_backend.loadRenderSettings();
+}
+
+void PerformancePage::updateControlsFromSettings()
+{
+    m_blockSignals = true;
+
+    m_geometrySlider->setValue(geometryLevelFromSettings());
+    m_shadowSlider->setValue(std::clamp(m_settings.shadowMode, 0, 3));
+    m_textureSlider->setValue(textureSliderFromResolution(m_settings.textureResolution));
+    m_surfaceSlider->setValue(std::clamp(m_settings.surfaceEffect, 0, 2));
+    m_particleSlider->setValue(std::clamp(m_settings.particleDetail, 0, 2));
+    m_lightingCombo->setCurrentIndex(std::clamp(m_settings.prelitMode, 0, 2));
+    m_filterCombo->setCurrentIndex(std::clamp(m_settings.textureFilter, 0, 1));
+    m_terrainCheck->setChecked(m_settings.staticShadows != 0);
+
+    const int presetLevel = determinePresetLevel();
+    m_overallSlider->setValue(presetLevel);
+
+    m_blockSignals = false;
+}
+
+void PerformancePage::applySettingsFromControls()
+{
+    const int lodValue = [this]() {
+        switch (m_geometrySlider->value()) {
+        case 0: return 0;
+        case 1: return 5000;
+        default: return 10000;
+        }
+    }();
+    m_settings.dynamicLOD = lodValue;
+    m_settings.staticLOD = lodValue;
+
+    m_settings.shadowMode = m_shadowSlider->value();
+    m_settings.dynamicShadows = (m_settings.shadowMode != 0) ? 1 : 0;
+    m_settings.textureResolution = textureResolutionFromSlider(m_textureSlider->value());
+    m_settings.surfaceEffect = m_surfaceSlider->value();
+    m_settings.particleDetail = m_particleSlider->value();
+    m_settings.prelitMode = m_lightingCombo->currentIndex();
+    m_settings.textureFilter = m_filterCombo->currentIndex();
+    m_settings.staticShadows = m_terrainCheck->isChecked() ? 1 : 0;
+
+    m_backend.saveRenderSettings(m_settings);
+    emit settingsChanged();
+}
+
+void PerformancePage::applyPreset(int level)
+{
+    const int index = std::clamp(level, 0, kPresetCount - 1);
+    const PresetLevel &preset = kPresets[index];
+
+    m_blockSignals = true;
+    m_geometrySlider->setValue(preset.geometry);
+    m_shadowSlider->setValue(preset.character);
+    m_textureSlider->setValue(preset.texture);
+    m_surfaceSlider->setValue(preset.surface);
+    m_particleSlider->setValue(preset.particle);
+    m_filterCombo->setCurrentIndex(preset.textureFilter);
+    m_lightingCombo->setCurrentIndex(preset.lightingMode);
+    m_terrainCheck->setChecked(preset.terrainShadows);
+    m_blockSignals = false;
+
+    applySettingsFromControls();
+}
+
+int PerformancePage::determinePresetLevel() const
+{
+    const int geometry = m_geometrySlider->value();
+    const int shadow = m_shadowSlider->value();
+    const int texture = m_textureSlider->value();
+    const int surface = m_surfaceSlider->value();
+    const int particle = m_particleSlider->value();
+    const int filter = m_filterCombo->currentIndex();
+    const int lighting = m_lightingCombo->currentIndex();
+    const bool terrain = m_terrainCheck->isChecked();
+
+    for (int i = 0; i < kPresetCount; ++i) {
+        const auto &preset = kPresets[i];
+        if (preset.geometry == geometry &&
+            preset.character == shadow &&
+            preset.texture == texture &&
+            preset.surface == surface &&
+            preset.particle == particle &&
+            preset.textureFilter == filter &&
+            preset.lightingMode == lighting &&
+            preset.terrainShadows == terrain) {
+            return i;
+        }
+    }
+
+    return geometry;
+}
+
+int PerformancePage::geometryLevelFromSettings() const
+{
+    if (m_settings.dynamicLOD < 1000 && m_settings.staticLOD < 1000) {
+        return 0;
+    }
+    if (m_settings.dynamicLOD <= 5000 && m_settings.staticLOD <= 5000) {
+        return 1;
+    }
+    return 2;
+}
+
+void PerformancePage::setExpertControlsEnabled(bool enabled)
+{
+    m_expertGroup->setEnabled(enabled);
+}

--- a/Code/Tools/WWConfigQt/PerformancePage.cpp
+++ b/Code/Tools/WWConfigQt/PerformancePage.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstring>
 #include <iterator>
 
 #include <QCheckBox>
@@ -15,7 +16,12 @@
 #include <QSlider>
 #include <QVBoxLayout>
 
+#include "../WWConfig/wwconfig_ids.h"
 #include "../../ww3d2/ww3d.h"
+#if defined(_WIN32)
+#include "../../ww3d2/dx8caps.h"
+#include "../../ww3d2/formconv.h"
+#endif
 #include "../../ww3d2/texture.h"
 
 namespace
@@ -33,10 +39,10 @@ struct PresetLevel
 };
 
 constexpr PresetLevel kPresets[] = {
-    {0, 0, 0, 0, 0, 0, 0, false},
-    {0, 1, 1, 0, 0, 0, WW3D::PRELIT_MODE_LIGHTMAP_MULTI_TEXTURE, false},
-    {1, 2, 2, 1, 1, 1, WW3D::PRELIT_MODE_LIGHTMAP_MULTI_TEXTURE, true},
-    {2, 3, 2, 2, 2, 1, WW3D::PRELIT_MODE_LIGHTMAP_MULTI_TEXTURE, true},
+    {0, 0, 0, 0, 0, TextureClass::TEXTURE_FILTER_BILINEAR, WW3D::PRELIT_MODE_VERTEX, false},
+    {0, 1, 1, 0, 0, TextureClass::TEXTURE_FILTER_BILINEAR, WW3D::PRELIT_MODE_LIGHTMAP_MULTI_TEXTURE, false},
+    {1, 2, 2, 1, 1, TextureClass::TEXTURE_FILTER_TRILINEAR, WW3D::PRELIT_MODE_LIGHTMAP_MULTI_TEXTURE, true},
+    {2, 3, 2, 2, 2, TextureClass::TEXTURE_FILTER_TRILINEAR, WW3D::PRELIT_MODE_LIGHTMAP_MULTI_TEXTURE, true},
 };
 constexpr int kPresetCount = sizeof(kPresets) / sizeof(kPresets[0]);
 
@@ -48,6 +54,63 @@ int textureSliderFromResolution(int textureRes)
 int textureResolutionFromSlider(int sliderValue)
 {
     return std::max(2 - sliderValue, 0);
+}
+
+struct RenderCapabilityInfo
+{
+    bool canMultiPass = true;
+    bool canMultiTexture = true;
+    bool canAnisotropic = false;
+};
+
+QString LocalizedText(const WWConfigBackend &backend, int id, const QString &fallback)
+{
+    const QString text = backend.localizedString(id);
+    return text.isEmpty() ? fallback : text;
+}
+
+RenderCapabilityInfo QueryRenderCapabilities(const VideoSettings &settings)
+{
+    RenderCapabilityInfo caps;
+
+#if !defined(_WIN32)
+    (void)settings;
+    return caps;
+#else
+    IDirect3D9 *d3d = Direct3DCreate9(D3D_SDK_VERSION);
+    if (!d3d) {
+        return caps;
+    }
+
+    UINT adapterIndex = D3DADAPTER_DEFAULT;
+    if (!settings.deviceName.empty()) {
+        const UINT adapterCount = d3d->GetAdapterCount();
+        for (UINT i = 0; i < adapterCount; ++i) {
+            D3DADAPTER_IDENTIFIER9 identifier = {};
+            if (FAILED(d3d->GetAdapterIdentifier(i, 0, &identifier))) {
+                continue;
+            }
+            if (_stricmp(identifier.Description, settings.deviceName.c_str()) == 0) {
+                adapterIndex = i;
+                break;
+            }
+        }
+    }
+
+    D3DCAPS9 d3dCaps = {};
+    D3DADAPTER_IDENTIFIER9 adapterId = {};
+    if (SUCCEEDED(d3d->GetDeviceCaps(adapterIndex, D3DDEVTYPE_HAL, &d3dCaps)) &&
+        SUCCEEDED(d3d->GetAdapterIdentifier(adapterIndex, 0, &adapterId))) {
+        const D3DFORMAT displayFormat = (settings.bitDepth == 16) ? D3DFMT_R5G6B5 : D3DFMT_A8R8G8B8;
+        DX8Caps dxCaps(d3d, d3dCaps, D3DFormat_To_WW3DFormat(displayFormat), adapterId);
+        caps.canMultiPass = dxCaps.Can_Do_Multi_Pass();
+        caps.canMultiTexture = dxCaps.Get_Max_Textures_Per_Pass() > 1;
+        caps.canAnisotropic = dxCaps.Support_Anisotropic_Filtering();
+    }
+
+    d3d->Release();
+    return caps;
+#endif
 }
 } // namespace
 
@@ -65,10 +128,10 @@ void PerformancePage::buildUi()
     mainLayout->setContentsMargins(4, 4, 4, 4);
     mainLayout->setSpacing(8);
 
-    auto *detailGroup = new QGroupBox(tr("Detail"), this);
+    auto *detailGroup = new QGroupBox(LocalizedText(m_backend, IDS_DETAIL, tr("Detail")), this);
     auto *detailLayout = new QGridLayout(detailGroup);
 
-    auto *lowFast = new QLabel(tr("Low (fastest)"), detailGroup);
+    auto *lowFast = new QLabel(LocalizedText(m_backend, IDS_LOW_DESC, tr("Low (fastest)")), detailGroup);
     lowFast->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     detailLayout->addWidget(lowFast, 0, 0);
 
@@ -78,20 +141,20 @@ void PerformancePage::buildUi()
     m_overallSlider->setTickPosition(QSlider::TicksBelow);
     detailLayout->addWidget(m_overallSlider, 0, 1);
 
-    auto *highSlow = new QLabel(tr("High (slowest)"), detailGroup);
+    auto *highSlow = new QLabel(LocalizedText(m_backend, IDS_HIGH_DESC, tr("High (slowest)")), detailGroup);
     highSlow->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     detailLayout->addWidget(highSlow, 0, 2);
 
-    m_expertCheck = new QCheckBox(tr("Expert Mode"), detailGroup);
+    m_expertCheck = new QCheckBox(LocalizedText(m_backend, IDS_EXPERT_MODE, tr("Expert Mode")), detailGroup);
     detailLayout->addWidget(m_expertCheck, 1, 0, 1, 2);
 
-    m_autoButton = new QPushButton(tr("Auto Config"), detailGroup);
+    m_autoButton = new QPushButton(LocalizedText(m_backend, IDS_AUTOCONFIG, tr("Auto Config")), detailGroup);
     detailLayout->addWidget(m_autoButton, 1, 2, Qt::AlignRight);
 
     detailLayout->setColumnStretch(1, 1);
     mainLayout->addWidget(detailGroup);
 
-    m_expertGroup = new QGroupBox(tr("Expert Settings"), this);
+    m_expertGroup = new QGroupBox(LocalizedText(m_backend, IDS_EXPERT_SETTINGS, tr("Expert Settings")), this);
     auto *groupLayout = new QGridLayout(m_expertGroup);
 
     auto createSlider = [this]() {
@@ -112,33 +175,36 @@ void PerformancePage::buildUi()
         auto *title = new QLabel(label, m_expertGroup);
         groupLayout->addWidget(title, row, 0);
         groupLayout->addWidget(slider, row, 1);
-        auto *lowLabel = new QLabel(tr("Low"), m_expertGroup);
+        auto *lowLabel = new QLabel(LocalizedText(m_backend, IDS_LOW, tr("Low")), m_expertGroup);
         lowLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
         groupLayout->addWidget(lowLabel, row, 2);
-        auto *highLabel = new QLabel(tr("High"), m_expertGroup);
+        auto *highLabel = new QLabel(LocalizedText(m_backend, IDS_HIGH, tr("High")), m_expertGroup);
         groupLayout->addWidget(highLabel, row, 3);
         ++row;
     };
 
-    addSliderRow(tr("Geometry Detail"), m_geometrySlider);
-    addSliderRow(tr("Character Shadows"), m_shadowSlider);
-    addSliderRow(tr("Texture Detail"), m_textureSlider);
-    addSliderRow(tr("Particle Detail"), m_particleSlider);
-    addSliderRow(tr("Surface Effect Detail"), m_surfaceSlider);
+    addSliderRow(LocalizedText(m_backend, IDS_GEOMETRY_DETAIL, tr("Geometry Detail")), m_geometrySlider);
+    addSliderRow(LocalizedText(m_backend, IDS_CHARACTER_SHADOWS, tr("Character Shadows")), m_shadowSlider);
+    addSliderRow(LocalizedText(m_backend, IDS_TEXTURE_DETAIL, tr("Texture Detail")), m_textureSlider);
+    addSliderRow(LocalizedText(m_backend, IDS_PARTICLE_DETAIL, tr("Particle Detail")), m_particleSlider);
+    addSliderRow(LocalizedText(m_backend, IDS_SURFACE_EFFECT_DETAIL, tr("Surface Effect Detail")), m_surfaceSlider);
 
     m_lightingCombo = new QComboBox(m_expertGroup);
-    m_lightingCombo->addItems({tr("Vertex"), tr("Multi-pass"), tr("Multi-texture")});
-    groupLayout->addWidget(new QLabel(tr("Lighting Mode"), m_expertGroup), row, 0);
+    groupLayout->addWidget(new QLabel(LocalizedText(m_backend, IDS_LIGHTING_MODE, tr("Lighting Mode")), m_expertGroup),
+                           row,
+                           0);
     groupLayout->addWidget(m_lightingCombo, row, 1);
     ++row;
 
     m_filterCombo = new QComboBox(m_expertGroup);
-    m_filterCombo->addItems({tr("Bilinear"), tr("Trilinear")});
-    groupLayout->addWidget(new QLabel(tr("Texture Filter"), m_expertGroup), row, 0);
+    groupLayout->addWidget(new QLabel(LocalizedText(m_backend, IDS_TEXTURE_FILTER, tr("Texture Filter")), m_expertGroup),
+                           row,
+                           0);
     groupLayout->addWidget(m_filterCombo, row, 1);
     ++row;
 
-    m_terrainCheck = new QCheckBox(tr("Terrain Casts Shadows"), m_expertGroup);
+    m_terrainCheck = new QCheckBox(LocalizedText(m_backend, IDS_TERRAIN_SHADOWS, tr("Terrain Casts Shadows")),
+                                   m_expertGroup);
     groupLayout->addWidget(m_terrainCheck, row, 0, 1, 4);
 
     groupLayout->setColumnStretch(1, 1);
@@ -194,19 +260,28 @@ void PerformancePage::refresh()
 void PerformancePage::loadSettings()
 {
     m_settings = m_backend.loadRenderSettings();
+    m_videoSettings = m_backend.loadVideoSettings();
 }
 
 void PerformancePage::updateControlsFromSettings()
 {
     m_blockSignals = true;
 
+    updateCapabilityCombos();
+
     m_geometrySlider->setValue(geometryLevelFromSettings());
     m_shadowSlider->setValue(std::clamp(m_settings.shadowMode, 0, 3));
     m_textureSlider->setValue(textureSliderFromResolution(m_settings.textureResolution));
     m_surfaceSlider->setValue(std::clamp(m_settings.surfaceEffect, 0, 2));
     m_particleSlider->setValue(std::clamp(m_settings.particleDetail, 0, 2));
-    m_lightingCombo->setCurrentIndex(std::clamp(m_settings.prelitMode, 0, 2));
-    m_filterCombo->setCurrentIndex(std::clamp(m_settings.textureFilter, 0, 1));
+    const int lightingFallback = (m_settings.prelitMode == WW3D::PRELIT_MODE_LIGHTMAP_MULTI_PASS)
+                                     ? WW3D::PRELIT_MODE_LIGHTMAP_MULTI_TEXTURE
+                                     : WW3D::PRELIT_MODE_VERTEX;
+    setComboValue(m_lightingCombo, m_settings.prelitMode, lightingFallback);
+    const int filterFallback = (m_settings.textureFilter == TextureClass::TEXTURE_FILTER_BILINEAR)
+                                   ? TextureClass::TEXTURE_FILTER_BILINEAR
+                                   : TextureClass::TEXTURE_FILTER_TRILINEAR;
+    setComboValue(m_filterCombo, m_settings.textureFilter, filterFallback);
     m_terrainCheck->setChecked(m_settings.staticShadows != 0);
 
     const int presetLevel = determinePresetLevel();
@@ -232,8 +307,8 @@ void PerformancePage::applySettingsFromControls()
     m_settings.textureResolution = textureResolutionFromSlider(m_textureSlider->value());
     m_settings.surfaceEffect = m_surfaceSlider->value();
     m_settings.particleDetail = m_particleSlider->value();
-    m_settings.prelitMode = m_lightingCombo->currentIndex();
-    m_settings.textureFilter = m_filterCombo->currentIndex();
+    m_settings.prelitMode = comboValue(m_lightingCombo, m_settings.prelitMode);
+    m_settings.textureFilter = comboValue(m_filterCombo, m_settings.textureFilter);
     m_settings.staticShadows = m_terrainCheck->isChecked() ? 1 : 0;
 
     m_backend.saveRenderSettings(m_settings);
@@ -251,8 +326,14 @@ void PerformancePage::applyPreset(int level)
     m_textureSlider->setValue(preset.texture);
     m_surfaceSlider->setValue(preset.surface);
     m_particleSlider->setValue(preset.particle);
-    m_filterCombo->setCurrentIndex(preset.textureFilter);
-    m_lightingCombo->setCurrentIndex(preset.lightingMode);
+    const int lightingFallback = (preset.lightingMode == WW3D::PRELIT_MODE_LIGHTMAP_MULTI_PASS)
+                                     ? WW3D::PRELIT_MODE_LIGHTMAP_MULTI_TEXTURE
+                                     : WW3D::PRELIT_MODE_VERTEX;
+    setComboValue(m_lightingCombo, preset.lightingMode, lightingFallback);
+    const int filterFallback = (preset.textureFilter == TextureClass::TEXTURE_FILTER_BILINEAR)
+                                   ? TextureClass::TEXTURE_FILTER_BILINEAR
+                                   : TextureClass::TEXTURE_FILTER_TRILINEAR;
+    setComboValue(m_filterCombo, preset.textureFilter, filterFallback);
     m_terrainCheck->setChecked(preset.terrainShadows);
     m_blockSignals = false;
 
@@ -261,30 +342,52 @@ void PerformancePage::applyPreset(int level)
 
 int PerformancePage::determinePresetLevel() const
 {
-    const int geometry = m_geometrySlider->value();
-    const int shadow = m_shadowSlider->value();
-    const int texture = m_textureSlider->value();
-    const int surface = m_surfaceSlider->value();
-    const int particle = m_particleSlider->value();
-    const int filter = m_filterCombo->currentIndex();
-    const int lighting = m_lightingCombo->currentIndex();
-    const bool terrain = m_terrainCheck->isChecked();
+    const std::array<int, 8> optionValues = {
+        m_shadowSlider->value(),
+        m_textureSlider->value(),
+        m_particleSlider->value(),
+        m_surfaceSlider->value(),
+        m_geometrySlider->value(),
+        comboValue(m_filterCombo, m_settings.textureFilter),
+        comboValue(m_lightingCombo, m_settings.prelitMode),
+        m_terrainCheck->isChecked() ? 1 : 0,
+    };
 
-    for (int i = 0; i < kPresetCount; ++i) {
-        const auto &preset = kPresets[i];
-        if (preset.geometry == geometry &&
-            preset.character == shadow &&
-            preset.texture == texture &&
-            preset.surface == surface &&
-            preset.particle == particle &&
-            preset.textureFilter == filter &&
-            preset.lightingMode == lighting &&
-            preset.terrainShadows == terrain) {
-            return i;
+    std::array<float, 8> optionLevels = {};
+    std::array<int, 8> countPerOption = {};
+
+    for (int level = kPresetCount - 1; level >= 0; --level) {
+        const auto &preset = kPresets[level];
+        const std::array<int, 8> presetValues = {
+            preset.character,
+            preset.texture,
+            preset.particle,
+            preset.surface,
+            preset.geometry,
+            preset.textureFilter,
+            preset.lightingMode,
+            preset.terrainShadows ? 1 : 0,
+        };
+
+        for (size_t index = 0; index < presetValues.size(); ++index) {
+            if (optionValues[index] == presetValues[index]) {
+                optionLevels[index] += static_cast<float>(level);
+                countPerOption[index] += 1;
+            }
         }
     }
 
-    return geometry;
+    float levelSum = 0.0f;
+    for (size_t index = 0; index < optionValues.size(); ++index) {
+        const float normalized = (countPerOption[index] > 0)
+                                     ? (optionLevels[index] / countPerOption[index])
+                                     : 0.0f;
+        levelSum += normalized;
+    }
+
+    const float levelRating = levelSum / static_cast<float>(optionValues.size());
+    const int level = static_cast<int>(levelRating + 0.5f);
+    return std::clamp(level, 0, kPresetCount - 1);
 }
 
 int PerformancePage::geometryLevelFromSettings() const
@@ -301,4 +404,63 @@ int PerformancePage::geometryLevelFromSettings() const
 void PerformancePage::setExpertControlsEnabled(bool enabled)
 {
     m_expertGroup->setEnabled(enabled);
+    m_expertGroup->setVisible(enabled);
+}
+
+void PerformancePage::updateCapabilityCombos()
+{
+    const RenderCapabilityInfo caps = QueryRenderCapabilities(m_videoSettings);
+
+    m_lightingCombo->clear();
+    m_lightingCombo->addItem(LocalizedText(m_backend, IDS_VERTEX, tr("Vertex")), WW3D::PRELIT_MODE_VERTEX);
+    if (caps.canMultiPass) {
+        m_lightingCombo->addItem(LocalizedText(m_backend, IDS_MULTI_PASS, tr("Multi-pass")),
+                                 WW3D::PRELIT_MODE_LIGHTMAP_MULTI_PASS);
+    }
+    if (caps.canMultiTexture) {
+        m_lightingCombo->addItem(LocalizedText(m_backend, IDS_MULTI_TEXTURE, tr("Multi-texture")),
+                                 WW3D::PRELIT_MODE_LIGHTMAP_MULTI_TEXTURE);
+    }
+
+    m_filterCombo->clear();
+    m_filterCombo->addItem(LocalizedText(m_backend, IDS_BILINEAR, tr("Bilinear")),
+                           TextureClass::TEXTURE_FILTER_BILINEAR);
+    m_filterCombo->addItem(LocalizedText(m_backend, IDS_TRILINEAR, tr("Trilinear")),
+                           TextureClass::TEXTURE_FILTER_TRILINEAR);
+    if (caps.canAnisotropic) {
+        m_filterCombo->addItem(LocalizedText(m_backend, IDS_ANISOTROPIC, tr("Anisotropic")),
+                               TextureClass::TEXTURE_FILTER_ANISOTROPIC);
+    }
+}
+
+int PerformancePage::comboValue(const QComboBox *combo, int fallback) const
+{
+    if (!combo) {
+        return fallback;
+    }
+
+    const QVariant data = combo->currentData();
+    if (data.isValid()) {
+        return data.toInt();
+    }
+
+    return combo->currentIndex();
+}
+
+void PerformancePage::setComboValue(QComboBox *combo, int value, int fallback)
+{
+    if (!combo) {
+        return;
+    }
+
+    int index = combo->findData(value);
+    if (index < 0) {
+        index = combo->findData(fallback);
+    }
+    if (index < 0 && combo->count() > 0) {
+        index = combo->count() - 1;
+    }
+    if (index >= 0) {
+        combo->setCurrentIndex(index);
+    }
 }

--- a/Code/Tools/WWConfigQt/PerformancePage.cpp
+++ b/Code/Tools/WWConfigQt/PerformancePage.cpp
@@ -157,15 +157,16 @@ void PerformancePage::buildUi()
     m_expertGroup = new QGroupBox(LocalizedText(m_backend, IDS_EXPERT_SETTINGS, tr("Expert Settings")), this);
     auto *groupLayout = new QGridLayout(m_expertGroup);
 
-    auto createSlider = [this]() {
+    auto createSlider = [this](int maximum = 2) {
         auto *slider = new QSlider(Qt::Horizontal, m_expertGroup);
-        slider->setRange(0, 2);
+        slider->setRange(0, maximum);
+        slider->setTickInterval(1);
+        slider->setTickPosition(QSlider::TicksBelow);
         return slider;
     };
 
     m_geometrySlider = createSlider();
-    m_shadowSlider = new QSlider(Qt::Horizontal, m_expertGroup);
-    m_shadowSlider->setRange(0, 3);
+    m_shadowSlider = createSlider(3);
     m_textureSlider = createSlider();
     m_particleSlider = createSlider();
     m_surfaceSlider = createSlider();
@@ -229,16 +230,24 @@ void PerformancePage::buildUi()
     });
 
     connect(m_autoButton, &QPushButton::clicked, this, [this]() {
+        const RenderSettings previousRenderSettings = m_backend.loadRenderSettings();
+        const VideoSettings previousVideoSettings = m_backend.loadVideoSettings();
+
         m_backend.autoConfigRenderSettings();
-        refresh();
-        emit settingsChanged();
+        m_settings = m_backend.loadRenderSettings();
+        m_videoSettings = m_backend.loadVideoSettings();
+
+        m_backend.saveRenderSettings(previousRenderSettings);
+        m_backend.saveVideoSettings(previousVideoSettings);
+
+        updateControlsFromSettings();
     });
 
     auto sliderChanged = [this]() {
         if (m_blockSignals) {
             return;
         }
-        applySettingsFromControls();
+        updateSettingsFromControls();
     };
 
     connect(m_geometrySlider, &QSlider::valueChanged, this, sliderChanged);
@@ -255,6 +264,12 @@ void PerformancePage::refresh()
 {
     loadSettings();
     updateControlsFromSettings();
+}
+
+bool PerformancePage::save()
+{
+    updateSettingsFromControls();
+    return m_backend.saveRenderSettings(m_settings);
 }
 
 void PerformancePage::loadSettings()
@@ -290,7 +305,7 @@ void PerformancePage::updateControlsFromSettings()
     m_blockSignals = false;
 }
 
-void PerformancePage::applySettingsFromControls()
+void PerformancePage::updateSettingsFromControls()
 {
     const int lodValue = [this]() {
         switch (m_geometrySlider->value()) {
@@ -310,9 +325,6 @@ void PerformancePage::applySettingsFromControls()
     m_settings.prelitMode = comboValue(m_lightingCombo, m_settings.prelitMode);
     m_settings.textureFilter = comboValue(m_filterCombo, m_settings.textureFilter);
     m_settings.staticShadows = m_terrainCheck->isChecked() ? 1 : 0;
-
-    m_backend.saveRenderSettings(m_settings);
-    emit settingsChanged();
 }
 
 void PerformancePage::applyPreset(int level)
@@ -337,7 +349,7 @@ void PerformancePage::applyPreset(int level)
     m_terrainCheck->setChecked(preset.terrainShadows);
     m_blockSignals = false;
 
-    applySettingsFromControls();
+    updateSettingsFromControls();
 }
 
 int PerformancePage::determinePresetLevel() const
@@ -404,7 +416,6 @@ int PerformancePage::geometryLevelFromSettings() const
 void PerformancePage::setExpertControlsEnabled(bool enabled)
 {
     m_expertGroup->setEnabled(enabled);
-    m_expertGroup->setVisible(enabled);
 }
 
 void PerformancePage::updateCapabilityCombos()

--- a/Code/Tools/WWConfigQt/PerformancePage.h
+++ b/Code/Tools/WWConfigQt/PerformancePage.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <QWidget>
+
+#include "WWConfigBackend.h"
+
+class QCheckBox;
+class QComboBox;
+class QPushButton;
+class QSlider;
+class QGroupBox;
+
+class PerformancePage : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PerformancePage(WWConfigBackend &backend, QWidget *parent = nullptr);
+
+    void refresh();
+
+signals:
+    void settingsChanged();
+
+private:
+    void buildUi();
+    void loadSettings();
+    void updateControlsFromSettings();
+    void applySettingsFromControls();
+    void applyPreset(int level);
+    int determinePresetLevel() const;
+    int geometryLevelFromSettings() const;
+
+    void setExpertControlsEnabled(bool enabled);
+
+    WWConfigBackend &m_backend;
+    RenderSettings m_settings;
+    bool m_blockSignals = false;
+
+    QSlider *m_overallSlider = nullptr;
+    QCheckBox *m_expertCheck = nullptr;
+    QPushButton *m_autoButton = nullptr;
+
+    QGroupBox *m_expertGroup = nullptr;
+    QSlider *m_geometrySlider = nullptr;
+    QSlider *m_shadowSlider = nullptr;
+    QSlider *m_textureSlider = nullptr;
+    QSlider *m_surfaceSlider = nullptr;
+    QSlider *m_particleSlider = nullptr;
+    QComboBox *m_lightingCombo = nullptr;
+    QComboBox *m_filterCombo = nullptr;
+    QCheckBox *m_terrainCheck = nullptr;
+};

--- a/Code/Tools/WWConfigQt/PerformancePage.h
+++ b/Code/Tools/WWConfigQt/PerformancePage.h
@@ -32,9 +32,13 @@ private:
     int geometryLevelFromSettings() const;
 
     void setExpertControlsEnabled(bool enabled);
+    void updateCapabilityCombos();
+    int comboValue(const QComboBox *combo, int fallback) const;
+    static void setComboValue(QComboBox *combo, int value, int fallback);
 
     WWConfigBackend &m_backend;
     RenderSettings m_settings;
+    VideoSettings m_videoSettings;
     bool m_blockSignals = false;
 
     QSlider *m_overallSlider = nullptr;

--- a/Code/Tools/WWConfigQt/PerformancePage.h
+++ b/Code/Tools/WWConfigQt/PerformancePage.h
@@ -18,6 +18,7 @@ public:
     explicit PerformancePage(WWConfigBackend &backend, QWidget *parent = nullptr);
 
     void refresh();
+    bool save();
 
 signals:
     void settingsChanged();
@@ -26,7 +27,7 @@ private:
     void buildUi();
     void loadSettings();
     void updateControlsFromSettings();
-    void applySettingsFromControls();
+    void updateSettingsFromControls();
     void applyPreset(int level);
     int determinePresetLevel() const;
     int geometryLevelFromSettings() const;

--- a/Code/Tools/WWConfigQt/VideoPage.cpp
+++ b/Code/Tools/WWConfigQt/VideoPage.cpp
@@ -4,11 +4,16 @@
 #include <cstdlib>
 #include <limits>
 
+#include <QAbstractItemView>
 #include <QCheckBox>
 #include <QComboBox>
+#include <QGridLayout>
 #include <QFormLayout>
 #include <QGroupBox>
+#include <QHBoxLayout>
 #include <QLabel>
+#include <QListWidget>
+#include <QStyle>
 #include <QSlider>
 #include <QVBoxLayout>
 
@@ -37,46 +42,64 @@ VideoPage::VideoPage(WWConfigBackend &backend, QWidget *parent)
 void VideoPage::buildUi()
 {
     auto *layout = new QVBoxLayout(this);
-    layout->setSpacing(12);
+    layout->setContentsMargins(4, 4, 4, 4);
+    layout->setSpacing(8);
 
     auto *deviceGroup = new QGroupBox(tr("Device"), this);
-    auto *deviceLayout = new QFormLayout(deviceGroup);
+    auto *deviceLayout = new QVBoxLayout(deviceGroup);
 
-    m_driverCombo = new QComboBox(deviceGroup);
-    deviceLayout->addRow(tr("Adapter"), m_driverCombo);
+    auto *driverRow = new QHBoxLayout();
+    auto *driverIcon = new QLabel(deviceGroup);
+    driverIcon->setPixmap(style()->standardIcon(QStyle::SP_ComputerIcon).pixmap(20, 20));
+    driverIcon->setFixedSize(20, 20);
+    driverRow->addWidget(driverIcon);
+    driverRow->addWidget(new QLabel(tr("Driver:"), deviceGroup));
+    driverRow->addStretch();
+    deviceLayout->addLayout(driverRow);
 
-    m_bitDepthCombo = new QComboBox(deviceGroup);
-    deviceLayout->addRow(tr("Color Depth"), m_bitDepthCombo);
-
-    m_windowedCheck = new QCheckBox(tr("Run in window"), deviceGroup);
-    deviceLayout->addRow(QString(), m_windowedCheck);
+    m_driverList = new QListWidget(deviceGroup);
+    m_driverList->setUniformItemSizes(true);
+    m_driverList->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_driverList->setMinimumHeight(64);
+    deviceLayout->addWidget(m_driverList);
 
     layout->addWidget(deviceGroup);
 
-    auto *resolutionGroup = new QGroupBox(tr("Resolution"), this);
-    auto *resolutionLayout = new QFormLayout(resolutionGroup);
+    auto *displayGroup = new QGroupBox(tr("Display"), this);
+    auto *displayLayout = new QGridLayout(displayGroup);
+    displayLayout->setHorizontalSpacing(6);
+    displayLayout->setVerticalSpacing(4);
 
-    m_resolutionSlider = new QSlider(Qt::Horizontal, resolutionGroup);
+    displayLayout->addWidget(new QLabel(tr("Resolution:"), displayGroup), 0, 0);
+    m_resolutionSlider = new QSlider(Qt::Horizontal, displayGroup);
     m_resolutionSlider->setRange(0, 0);
-    resolutionLayout->addRow(tr("Preset"), m_resolutionSlider);
+    m_resolutionSlider->setTickPosition(QSlider::TicksBelow);
+    m_resolutionSlider->setTickInterval(1);
+    displayLayout->addWidget(m_resolutionSlider, 0, 1);
+    m_resolutionValue = new QLabel(tr("N/A"), displayGroup);
+    m_resolutionValue->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    displayLayout->addWidget(m_resolutionValue, 0, 2);
 
-    m_resolutionValue = new QLabel(tr("N/A"), resolutionGroup);
-    resolutionLayout->addRow(tr("Current"), m_resolutionValue);
+    displayLayout->addWidget(new QLabel(tr("Color Depth:"), displayGroup), 1, 0);
+    m_bitDepthCombo = new QComboBox(displayGroup);
+    displayLayout->addWidget(m_bitDepthCombo, 1, 1, 1, 2);
 
-    m_textureDepthLabel = new QLabel(tr("Texture depth: --"), resolutionGroup);
-    resolutionLayout->addRow(QString(), m_textureDepthLabel);
+    m_windowedCheck = new QCheckBox(tr("Windowed Mode"), displayGroup);
+    displayLayout->addWidget(m_windowedCheck, 2, 0, 1, 3);
 
-    layout->addWidget(resolutionGroup);
+    m_textureDepthLabel = new QLabel(tr("Texture depth: --"), displayGroup);
+    displayLayout->addWidget(m_textureDepthLabel, 3, 0, 1, 3);
 
-    auto *note = new QLabel(tr("Pick any adapter and resolution combination. Changes are written to "
-                               "the same registry keys that the classic WWConfig dialog edits, so the "
-                               "game and the MFC tool will see them immediately."),
+    layout->addWidget(displayGroup);
+
+    auto *note = new QLabel(tr("Changes are saved straight to Renegade.ini so both the game and classic "
+                               "WWConfig see them immediately."),
                             this);
     note->setWordWrap(true);
     layout->addWidget(note);
     layout->addStretch();
 
-    connect(m_driverCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int) {
+    connect(m_driverList, &QListWidget::currentRowChanged, this, [this](int) {
         if (m_blockSignals) {
             return;
         }
@@ -130,10 +153,12 @@ void VideoPage::refresh()
 
 void VideoPage::populateDrivers()
 {
-    m_driverCombo->clear();
+    m_driverList->clear();
 
     if (m_adapters.empty()) {
-        m_driverCombo->addItem(tr("No adapters detected"));
+        auto *item = new QListWidgetItem(tr("No adapters detected"));
+        item->setFlags(Qt::NoItemFlags);
+        m_driverList->addItem(item);
         return;
     }
 
@@ -141,7 +166,9 @@ void VideoPage::populateDrivers()
     int selectedIndex = 0;
     for (int i = 0; i < static_cast<int>(m_adapters.size()); ++i) {
         const QString label = AdapterDisplayName(m_adapters[i]);
-        m_driverCombo->addItem(label, i);
+        auto *item = new QListWidgetItem(label);
+        item->setData(Qt::UserRole, i);
+        m_driverList->addItem(item);
         if (!desired.isEmpty()) {
             const QString adapterName = QString::fromStdString(m_adapters[i].deviceName);
             if (adapterName.compare(desired, Qt::CaseInsensitive) == 0) {
@@ -150,7 +177,7 @@ void VideoPage::populateDrivers()
         }
     }
 
-    m_driverCombo->setCurrentIndex(selectedIndex);
+    m_driverList->setCurrentRow(selectedIndex);
 }
 
 void VideoPage::updateBitDepthOptions()
@@ -292,7 +319,7 @@ void VideoPage::applySelection(bool persist)
 void VideoPage::updateControlStates()
 {
     const bool hasAdapters = !m_adapters.empty();
-    m_driverCombo->setEnabled(hasAdapters);
+    m_driverList->setEnabled(hasAdapters);
     m_bitDepthCombo->setEnabled(hasAdapters && m_bitDepthCombo->count() > 0);
     m_windowedCheck->setEnabled(hasAdapters);
     m_resolutionSlider->setEnabled(hasAdapters && !m_activeResolutions.empty());
@@ -304,7 +331,7 @@ const VideoAdapterInfo *VideoPage::currentAdapter() const
         return nullptr;
     }
 
-    const int row = m_driverCombo->currentIndex();
+    const int row = m_driverList->currentRow();
     if (row < 0 || row >= static_cast<int>(m_adapters.size())) {
         return nullptr;
     }

--- a/Code/Tools/WWConfigQt/VideoPage.cpp
+++ b/Code/Tools/WWConfigQt/VideoPage.cpp
@@ -1,0 +1,312 @@
+#include "VideoPage.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <limits>
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QSlider>
+#include <QVBoxLayout>
+
+namespace
+{
+QString AdapterDisplayName(const VideoAdapterInfo &adapter)
+{
+    if (!adapter.description.empty()) {
+        return QString::fromStdString(adapter.description);
+    }
+    if (!adapter.deviceName.empty()) {
+        return QString::fromStdString(adapter.deviceName);
+    }
+    return QObject::tr("Display Adapter");
+}
+} // namespace
+
+VideoPage::VideoPage(WWConfigBackend &backend, QWidget *parent)
+    : QWidget(parent),
+      m_backend(backend)
+{
+    buildUi();
+    refresh();
+}
+
+void VideoPage::buildUi()
+{
+    auto *layout = new QVBoxLayout(this);
+    layout->setSpacing(12);
+
+    auto *deviceGroup = new QGroupBox(tr("Device"), this);
+    auto *deviceLayout = new QFormLayout(deviceGroup);
+
+    m_driverCombo = new QComboBox(deviceGroup);
+    deviceLayout->addRow(tr("Adapter"), m_driverCombo);
+
+    m_bitDepthCombo = new QComboBox(deviceGroup);
+    deviceLayout->addRow(tr("Color Depth"), m_bitDepthCombo);
+
+    m_windowedCheck = new QCheckBox(tr("Run in window"), deviceGroup);
+    deviceLayout->addRow(QString(), m_windowedCheck);
+
+    layout->addWidget(deviceGroup);
+
+    auto *resolutionGroup = new QGroupBox(tr("Resolution"), this);
+    auto *resolutionLayout = new QFormLayout(resolutionGroup);
+
+    m_resolutionSlider = new QSlider(Qt::Horizontal, resolutionGroup);
+    m_resolutionSlider->setRange(0, 0);
+    resolutionLayout->addRow(tr("Preset"), m_resolutionSlider);
+
+    m_resolutionValue = new QLabel(tr("N/A"), resolutionGroup);
+    resolutionLayout->addRow(tr("Current"), m_resolutionValue);
+
+    m_textureDepthLabel = new QLabel(tr("Texture depth: --"), resolutionGroup);
+    resolutionLayout->addRow(QString(), m_textureDepthLabel);
+
+    layout->addWidget(resolutionGroup);
+
+    auto *note = new QLabel(tr("Pick any adapter and resolution combination. Changes are written to "
+                               "the same registry keys that the classic WWConfig dialog edits, so the "
+                               "game and the MFC tool will see them immediately."),
+                            this);
+    note->setWordWrap(true);
+    layout->addWidget(note);
+    layout->addStretch();
+
+    connect(m_driverCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int) {
+        if (m_blockSignals) {
+            return;
+        }
+        updateBitDepthOptions();
+        updateResolutionSlider();
+        applySelection();
+        updateControlStates();
+    });
+
+    connect(m_bitDepthCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this](int) {
+        if (m_blockSignals) {
+            return;
+        }
+        m_currentBitDepth = m_bitDepthCombo->currentData().toInt();
+        updateResolutionSlider();
+        applySelection();
+    });
+
+    connect(m_resolutionSlider, &QSlider::valueChanged, this, [this](int) {
+        if (m_blockSignals) {
+            return;
+        }
+        updateResolutionLabel();
+        applySelection();
+    });
+
+    connect(m_windowedCheck, &QCheckBox::toggled, this, [this](bool) {
+        if (m_blockSignals) {
+            return;
+        }
+        applySelection();
+    });
+}
+
+void VideoPage::refresh()
+{
+    m_blockSignals = true;
+    m_settings = m_backend.loadVideoSettings();
+    m_adapters = m_backend.enumerateVideoAdapters();
+    populateDrivers();
+    updateBitDepthOptions();
+    updateResolutionSlider();
+    m_windowedCheck->setChecked(m_settings.windowed);
+    m_textureDepthLabel->setText(tr("Texture depth: %1-bit")
+                                     .arg(m_settings.textureDepth > 0 ? m_settings.textureDepth : 0));
+    updateControlStates();
+    m_blockSignals = false;
+    updateResolutionLabel();
+    applySelection(false);
+}
+
+void VideoPage::populateDrivers()
+{
+    m_driverCombo->clear();
+
+    if (m_adapters.empty()) {
+        m_driverCombo->addItem(tr("No adapters detected"));
+        return;
+    }
+
+    const QString desired = QString::fromStdString(m_settings.deviceName);
+    int selectedIndex = 0;
+    for (int i = 0; i < static_cast<int>(m_adapters.size()); ++i) {
+        const QString label = AdapterDisplayName(m_adapters[i]);
+        m_driverCombo->addItem(label, i);
+        if (!desired.isEmpty()) {
+            const QString adapterName = QString::fromStdString(m_adapters[i].deviceName);
+            if (adapterName.compare(desired, Qt::CaseInsensitive) == 0) {
+                selectedIndex = i;
+            }
+        }
+    }
+
+    m_driverCombo->setCurrentIndex(selectedIndex);
+}
+
+void VideoPage::updateBitDepthOptions()
+{
+    m_bitDepthCombo->clear();
+
+    const VideoAdapterInfo *adapter = currentAdapter();
+    if (!adapter) {
+        m_currentBitDepth = (m_settings.bitDepth > 0) ? m_settings.bitDepth : 32;
+        return;
+    }
+
+    std::vector<int> depths;
+    depths.reserve(adapter->resolutions.size());
+    for (const VideoResolution &mode : adapter->resolutions) {
+        if (std::find(depths.begin(), depths.end(), mode.bitDepth) == depths.end()) {
+            depths.push_back(mode.bitDepth);
+        }
+    }
+    std::sort(depths.begin(), depths.end());
+
+    if (depths.empty()) {
+        m_currentBitDepth = (m_settings.bitDepth > 0) ? m_settings.bitDepth : 32;
+        return;
+    }
+
+    int targetDepth = (m_settings.bitDepth > 0) ? m_settings.bitDepth : depths.front();
+    if (std::find(depths.begin(), depths.end(), targetDepth) == depths.end()) {
+        targetDepth = depths.front();
+    }
+
+    for (int depth : depths) {
+        m_bitDepthCombo->addItem(tr("%1-bit color").arg(depth), depth);
+        if (depth == targetDepth) {
+            m_bitDepthCombo->setCurrentIndex(m_bitDepthCombo->count() - 1);
+        }
+    }
+    m_currentBitDepth = targetDepth;
+}
+
+void VideoPage::updateResolutionSlider()
+{
+    m_activeResolutions.clear();
+    const VideoAdapterInfo *adapter = currentAdapter();
+
+    if (!adapter) {
+        m_resolutionSlider->setRange(0, 0);
+        m_resolutionSlider->setEnabled(false);
+        m_resolutionValue->setText(tr("N/A"));
+        return;
+    }
+
+    for (const VideoResolution &mode : adapter->resolutions) {
+        if (mode.bitDepth == m_currentBitDepth) {
+            m_activeResolutions.push_back(mode);
+        }
+    }
+
+    if (m_activeResolutions.empty()) {
+        m_resolutionSlider->setRange(0, 0);
+        m_resolutionSlider->setEnabled(false);
+        m_resolutionValue->setText(tr("N/A"));
+        return;
+    }
+
+    const int maxIndex = static_cast<int>(m_activeResolutions.size()) - 1;
+
+    int selectedIndex = 0;
+    const auto matchIt = std::find_if(
+        m_activeResolutions.begin(), m_activeResolutions.end(), [&](const VideoResolution &mode) {
+            return mode.width == m_settings.width && mode.height == m_settings.height;
+        });
+    if (matchIt != m_activeResolutions.end()) {
+        selectedIndex = static_cast<int>(std::distance(m_activeResolutions.begin(), matchIt));
+    } else if (m_settings.width > 0 && m_settings.height > 0) {
+        int bestError = std::numeric_limits<int>::max();
+        for (int i = 0; i <= maxIndex; ++i) {
+            const VideoResolution &mode = m_activeResolutions[i];
+            const int error = std::abs(mode.width - m_settings.width) + std::abs(mode.height - m_settings.height);
+            if (error < bestError) {
+                bestError = error;
+                selectedIndex = i;
+            }
+        }
+    }
+
+    m_resolutionSlider->setEnabled(true);
+    m_blockSignals = true;
+    m_resolutionSlider->setRange(0, maxIndex);
+    m_resolutionSlider->setValue(selectedIndex);
+    m_blockSignals = false;
+    updateResolutionLabel();
+}
+
+void VideoPage::updateResolutionLabel()
+{
+    if (m_activeResolutions.empty()) {
+        m_resolutionValue->setText(tr("N/A"));
+        return;
+    }
+
+    const int index = std::clamp(
+        m_resolutionSlider->value(), 0, static_cast<int>(m_activeResolutions.size()) - 1);
+    const VideoResolution &mode = m_activeResolutions[index];
+    m_resolutionValue->setText(tr("%1 x %2").arg(mode.width).arg(mode.height));
+}
+
+void VideoPage::applySelection(bool persist)
+{
+    if (m_activeResolutions.empty()) {
+        return;
+    }
+
+    const VideoAdapterInfo *adapter = currentAdapter();
+    if (!adapter) {
+        return;
+    }
+
+    const int index = std::clamp(
+        m_resolutionSlider->value(), 0, static_cast<int>(m_activeResolutions.size()) - 1);
+    const VideoResolution &mode = m_activeResolutions[index];
+
+    m_settings.deviceName = adapter->deviceName;
+    m_settings.width = mode.width;
+    m_settings.height = mode.height;
+    m_settings.bitDepth = mode.bitDepth;
+    m_settings.windowed = m_windowedCheck->isChecked();
+
+    if (m_settings.textureDepth <= 0) {
+        m_settings.textureDepth = mode.bitDepth;
+    }
+    m_textureDepthLabel->setText(tr("Texture depth: %1-bit").arg(m_settings.textureDepth));
+
+    if (persist) {
+        m_backend.saveVideoSettings(m_settings);
+    }
+}
+
+void VideoPage::updateControlStates()
+{
+    const bool hasAdapters = !m_adapters.empty();
+    m_driverCombo->setEnabled(hasAdapters);
+    m_bitDepthCombo->setEnabled(hasAdapters && m_bitDepthCombo->count() > 0);
+    m_windowedCheck->setEnabled(hasAdapters);
+    m_resolutionSlider->setEnabled(hasAdapters && !m_activeResolutions.empty());
+}
+
+const VideoAdapterInfo *VideoPage::currentAdapter() const
+{
+    if (m_adapters.empty()) {
+        return nullptr;
+    }
+
+    const int row = m_driverCombo->currentIndex();
+    if (row < 0 || row >= static_cast<int>(m_adapters.size())) {
+        return nullptr;
+    }
+    return &m_adapters[row];
+}

--- a/Code/Tools/WWConfigQt/VideoPage.cpp
+++ b/Code/Tools/WWConfigQt/VideoPage.cpp
@@ -7,12 +7,14 @@
 #include <QAbstractItemView>
 #include <QCheckBox>
 #include <QComboBox>
+#include <QFontMetrics>
 #include <QGridLayout>
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QListWidget>
+#include <QSizePolicy>
 #include <QStyle>
 #include <QSlider>
 #include <QVBoxLayout>
@@ -78,6 +80,8 @@ void VideoPage::buildUi()
     displayLayout->addWidget(m_resolutionSlider, 0, 1);
     m_resolutionValue = new QLabel(tr("N/A"), displayGroup);
     m_resolutionValue->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    m_resolutionValue->setFixedWidth(m_resolutionValue->fontMetrics().horizontalAdvance(QStringLiteral("9999 x 9999")) + 8);
+    m_resolutionValue->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Preferred);
     displayLayout->addWidget(m_resolutionValue, 0, 2);
 
     displayLayout->addWidget(new QLabel(tr("Color Depth:"), displayGroup), 1, 0);
@@ -92,9 +96,7 @@ void VideoPage::buildUi()
 
     layout->addWidget(displayGroup);
 
-    auto *note = new QLabel(tr("Changes are saved straight to Renegade.ini so both the game and classic "
-                               "WWConfig see them immediately."),
-                            this);
+    auto *note = new QLabel(tr("Press OK to save video changes to Renegade.ini."), this);
     note->setWordWrap(true);
     layout->addWidget(note);
     layout->addStretch();
@@ -148,7 +150,13 @@ void VideoPage::refresh()
     updateControlStates();
     m_blockSignals = false;
     updateResolutionLabel();
-    applySelection(false);
+    applySelection();
+}
+
+bool VideoPage::save()
+{
+    applySelection();
+    return m_backend.saveVideoSettings(m_settings);
 }
 
 void VideoPage::populateDrivers()
@@ -285,7 +293,7 @@ void VideoPage::updateResolutionLabel()
     m_resolutionValue->setText(tr("%1 x %2").arg(mode.width).arg(mode.height));
 }
 
-void VideoPage::applySelection(bool persist)
+void VideoPage::applySelection()
 {
     if (m_activeResolutions.empty()) {
         return;
@@ -311,9 +319,6 @@ void VideoPage::applySelection(bool persist)
     }
     m_textureDepthLabel->setText(tr("Texture depth: %1-bit").arg(m_settings.textureDepth));
 
-    if (persist) {
-        m_backend.saveVideoSettings(m_settings);
-    }
 }
 
 void VideoPage::updateControlStates()

--- a/Code/Tools/WWConfigQt/VideoPage.h
+++ b/Code/Tools/WWConfigQt/VideoPage.h
@@ -9,6 +9,7 @@
 class QCheckBox;
 class QComboBox;
 class QLabel;
+class QListWidget;
 class QSlider;
 
 class VideoPage : public QWidget
@@ -38,7 +39,7 @@ private:
     int m_currentBitDepth = 32;
     bool m_blockSignals = false;
 
-    QComboBox *m_driverCombo = nullptr;
+    QListWidget *m_driverList = nullptr;
     QComboBox *m_bitDepthCombo = nullptr;
     QSlider *m_resolutionSlider = nullptr;
     QLabel *m_resolutionValue = nullptr;

--- a/Code/Tools/WWConfigQt/VideoPage.h
+++ b/Code/Tools/WWConfigQt/VideoPage.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <QWidget>
+
+#include <vector>
+
+#include "WWConfigBackend.h"
+
+class QCheckBox;
+class QComboBox;
+class QLabel;
+class QSlider;
+
+class VideoPage : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit VideoPage(WWConfigBackend &backend, QWidget *parent = nullptr);
+
+    void refresh();
+
+private:
+    void buildUi();
+    void populateDrivers();
+    void updateBitDepthOptions();
+    void updateResolutionSlider();
+    void updateResolutionLabel();
+    void applySelection(bool persist = true);
+    void updateControlStates();
+
+    const VideoAdapterInfo *currentAdapter() const;
+
+    WWConfigBackend &m_backend;
+    VideoSettings m_settings;
+    std::vector<VideoAdapterInfo> m_adapters;
+    std::vector<VideoResolution> m_activeResolutions;
+    int m_currentBitDepth = 32;
+    bool m_blockSignals = false;
+
+    QComboBox *m_driverCombo = nullptr;
+    QComboBox *m_bitDepthCombo = nullptr;
+    QSlider *m_resolutionSlider = nullptr;
+    QLabel *m_resolutionValue = nullptr;
+    QCheckBox *m_windowedCheck = nullptr;
+    QLabel *m_textureDepthLabel = nullptr;
+};

--- a/Code/Tools/WWConfigQt/VideoPage.h
+++ b/Code/Tools/WWConfigQt/VideoPage.h
@@ -20,6 +20,7 @@ public:
     explicit VideoPage(WWConfigBackend &backend, QWidget *parent = nullptr);
 
     void refresh();
+    bool save();
 
 private:
     void buildUi();
@@ -27,7 +28,7 @@ private:
     void updateBitDepthOptions();
     void updateResolutionSlider();
     void updateResolutionLabel();
-    void applySelection(bool persist = true);
+    void applySelection();
     void updateControlStates();
 
     const VideoAdapterInfo *currentAdapter() const;

--- a/Code/Tools/WWConfigQt/WWConfigBackend.cpp
+++ b/Code/Tools/WWConfigQt/WWConfigBackend.cpp
@@ -1,13 +1,18 @@
 #include "WWConfigBackend.h"
 
+#if defined(_WIN32)
 #include <d3d9.h>
+#endif
+
 #include <QObject>
 
 #include "../WWConfig/Locale_API.h"
 #include "../WWConfig/WWConfigSettings.h"
 #include "../WWConfig/wwconfig_ids.h"
+#if defined(_WIN32)
 #include "../../ww3d2/dx8caps.h"
 #include "../../ww3d2/ww3d.h"
+#endif
 
 WWConfigBackend::WWConfigBackend() = default;
 
@@ -107,6 +112,9 @@ bool WWConfigBackend::checkDriverWarning(DriverWarningInfo &info) const
     info.show = false;
     info.message.clear();
 
+#if !defined(_WIN32)
+    return false;
+#else
     if (WWConfig::IsDriverWarningDisabled()) {
         return false;
     }
@@ -171,6 +179,7 @@ bool WWConfigBackend::checkDriverWarning(DriverWarningInfo &info) const
                             versionText);
     info.show = true;
     return true;
+#endif
 }
 
 void WWConfigBackend::disableDriverWarning() const

--- a/Code/Tools/WWConfigQt/WWConfigBackend.cpp
+++ b/Code/Tools/WWConfigQt/WWConfigBackend.cpp
@@ -1,0 +1,92 @@
+#include "WWConfigBackend.h"
+
+#include "../WWConfig/Locale_API.h"
+#include "../WWConfig/WWConfigSettings.h"
+
+WWConfigBackend::WWConfigBackend() = default;
+
+WWConfigBackend::~WWConfigBackend()
+{
+    if (m_localeInitialized) {
+        Locale_Restore();
+        m_localeInitialized = false;
+    }
+}
+
+bool WWConfigBackend::initializeLocale(int languageOverride)
+{
+    if (m_localeInitialized) {
+        Locale_Restore();
+        m_localeInitialized = false;
+    }
+
+    int language = languageOverride;
+    if (Locale_Init(language, "WWConfig.loc")) {
+        m_localeInitialized = true;
+        return true;
+    }
+
+    return false;
+}
+
+QString WWConfigBackend::localizedString(int stringId) const
+{
+    if (!m_localeInitialized) {
+        return {};
+    }
+
+    const wchar_t *text = Locale_GetString(stringId);
+    if (!text) {
+        return {};
+    }
+
+    return QString::fromWCharArray(text);
+}
+
+RenderSettings WWConfigBackend::loadRenderSettings() const
+{
+    RenderSettings settings;
+    WWConfig::LoadRenderSettings(settings);
+    return settings;
+}
+
+bool WWConfigBackend::saveRenderSettings(const RenderSettings &settings)
+{
+    return WWConfig::SaveRenderSettings(settings);
+}
+
+void WWConfigBackend::autoConfigRenderSettings()
+{
+    WWConfig::AutoConfigRenderSettings();
+}
+
+VideoSettings WWConfigBackend::loadVideoSettings() const
+{
+    VideoSettings settings;
+    WWConfig::LoadVideoSettings(settings);
+    return settings;
+}
+
+bool WWConfigBackend::saveVideoSettings(const VideoSettings &settings)
+{
+    return WWConfig::SaveVideoSettings(settings);
+}
+
+AudioSettings WWConfigBackend::loadAudioSettings() const
+{
+    AudioSettings settings;
+    WWConfig::LoadAudioSettings(settings);
+    return settings;
+}
+
+bool WWConfigBackend::saveAudioSettings(const AudioSettings &settings)
+{
+    return WWConfig::SaveAudioSettings(settings);
+}
+
+std::vector<VideoAdapterInfo> WWConfigBackend::enumerateVideoAdapters() const
+{
+    std::vector<VideoAdapterInfo> adapters;
+    WWConfig::EnumerateVideoAdapters(adapters);
+    return adapters;
+}

--- a/Code/Tools/WWConfigQt/WWConfigBackend.h
+++ b/Code/Tools/WWConfigQt/WWConfigBackend.h
@@ -4,6 +4,12 @@
 #include <vector>
 #include "../WWConfig/WWConfigSettings.h"
 
+struct DriverWarningInfo
+{
+    bool show = false;
+    QString message;
+};
+
 class WWConfigBackend
 {
 public:
@@ -25,6 +31,10 @@ public:
     bool saveAudioSettings(const AudioSettings &settings);
 
     std::vector<VideoAdapterInfo> enumerateVideoAdapters() const;
+
+    QString configPath() const;
+    bool checkDriverWarning(DriverWarningInfo &info) const;
+    void disableDriverWarning() const;
 
 private:
     bool m_localeInitialized = false;

--- a/Code/Tools/WWConfigQt/WWConfigBackend.h
+++ b/Code/Tools/WWConfigQt/WWConfigBackend.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <QString>
+#include <vector>
+#include "../WWConfig/WWConfigSettings.h"
+
+class WWConfigBackend
+{
+public:
+    WWConfigBackend();
+    ~WWConfigBackend();
+
+    bool initializeLocale(int languageOverride);
+    bool isLocaleReady() const { return m_localeInitialized; }
+    QString localizedString(int stringId) const;
+
+    RenderSettings loadRenderSettings() const;
+    bool saveRenderSettings(const RenderSettings &settings);
+    void autoConfigRenderSettings();
+
+    VideoSettings loadVideoSettings() const;
+    bool saveVideoSettings(const VideoSettings &settings);
+
+    AudioSettings loadAudioSettings() const;
+    bool saveAudioSettings(const AudioSettings &settings);
+
+    std::vector<VideoAdapterInfo> enumerateVideoAdapters() const;
+
+private:
+    bool m_localeInitialized = false;
+};

--- a/Code/Tools/WWConfigQt/main.cpp
+++ b/Code/Tools/WWConfigQt/main.cpp
@@ -1,0 +1,79 @@
+#include <QApplication>
+#include <QCommandLineOption>
+#include <QCommandLineParser>
+#include <QDebug>
+#include <QStringList>
+
+#include "MainWindow.h"
+#include "WWConfigBackend.h"
+#include "../WWConfig/wwconfig_ids.h"
+
+namespace
+{
+constexpr int kInvalidLanguage = -999;
+
+int LanguageFromString(const QString &value)
+{
+    const QString normalized = value.trimmed().toLower();
+    if (normalized == "english" || normalized == "en") {
+        return IDL_ENGLISH;
+    }
+    if (normalized == "french" || normalized == "fr") {
+        return IDL_FRENCH;
+    }
+    if (normalized == "german" || normalized == "de") {
+        return IDL_GERMAN;
+    }
+    if (normalized == "japanese" || normalized == "jp" || normalized == "ja") {
+        return IDL_JAPANESE;
+    }
+    if (normalized == "korean" || normalized == "ko") {
+        return IDL_KOREAN;
+    }
+    if (normalized == "chinese" || normalized == "zh") {
+        return IDL_CHINESE;
+    }
+    if (normalized.isEmpty()) {
+        return -1;
+    }
+    return kInvalidLanguage;
+}
+} // namespace
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+    QCoreApplication::setApplicationName(QStringLiteral("WWConfigQt"));
+    QCoreApplication::setApplicationVersion(QStringLiteral("0.1"));
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription(QObject::tr("Renegade configuration (Qt prototype)"));
+    parser.addHelpOption();
+    parser.addVersionOption();
+
+    QCommandLineOption languageOption(
+        {QStringLiteral("l"), QStringLiteral("language")},
+        QObject::tr("Override the UI language (english, french, german, japanese, korean, chinese)."),
+        QObject::tr("language"));
+    parser.addOption(languageOption);
+
+    parser.process(app);
+
+    int languageOverride = -1;
+    if (parser.isSet(languageOption)) {
+        languageOverride = LanguageFromString(parser.value(languageOption));
+        if (languageOverride == kInvalidLanguage) {
+            qWarning() << "Unknown language override:" << parser.value(languageOption);
+            languageOverride = -1;
+        }
+    }
+
+    WWConfigBackend backend;
+    if (!backend.initializeLocale(languageOverride)) {
+        qWarning() << "Failed to initialize locale bank, continuing with built-in strings.";
+    }
+
+    MainWindow window(backend);
+    window.show();
+    return app.exec();
+}

--- a/Code/Tools/WWConfigQt/main.cpp
+++ b/Code/Tools/WWConfigQt/main.cpp
@@ -2,6 +2,10 @@
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 #include <QDebug>
+#include <QCheckBox>
+#include <QIcon>
+#include <QFileInfo>
+#include <QMessageBox>
 #include <QStringList>
 
 #include "MainWindow.h"
@@ -59,6 +63,8 @@ int main(int argc, char *argv[])
 
     parser.process(app);
 
+    app.setWindowIcon(QIcon(QStringLiteral(":/wwconfig/wwconfig.ico")));
+
     int languageOverride = -1;
     if (parser.isSet(languageOption)) {
         languageOverride = LanguageFromString(parser.value(languageOption));
@@ -71,6 +77,35 @@ int main(int argc, char *argv[])
     WWConfigBackend backend;
     if (!backend.initializeLocale(languageOverride)) {
         qWarning() << "Failed to initialize locale bank, continuing with built-in strings.";
+    }
+
+    // Offer to auto-config on first run (no ini file yet).
+    const QString configPath = backend.configPath();
+    if (!QFileInfo::exists(configPath)) {
+        const auto answer = QMessageBox::question(
+            nullptr,
+            QObject::tr("Auto Config"),
+            QObject::tr("No Renegade.ini was found. Run Auto Config now?"),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::Yes);
+        if (answer == QMessageBox::Yes) {
+            backend.autoConfigRenderSettings();
+        }
+    }
+
+    // Driver version warning flow.
+    DriverWarningInfo warningInfo;
+    if (backend.checkDriverWarning(warningInfo) && warningInfo.show) {
+        QMessageBox box(QMessageBox::Warning,
+                        QObject::tr("Driver Warning"),
+                        warningInfo.message,
+                        QMessageBox::Ok);
+        QCheckBox *dontShow = new QCheckBox(QObject::tr("Don't show this warning again"));
+        box.setCheckBox(dontShow);
+        box.exec();
+        if (dontShow->isChecked()) {
+            backend.disableDriverWarning();
+        }
     }
 
     MainWindow window(backend);

--- a/Code/Tools/WWConfigQt/main.cpp
+++ b/Code/Tools/WWConfigQt/main.cpp
@@ -1,4 +1,5 @@
 #include <QApplication>
+#include <QByteArray>
 #include <QCommandLineOption>
 #include <QCommandLineParser>
 #include <QDebug>
@@ -11,6 +12,7 @@
 #include "MainWindow.h"
 #include "WWConfigBackend.h"
 #include "../WWConfig/wwconfig_ids.h"
+#include "../../wwlib/openw3d.h"
 
 namespace
 {
@@ -55,6 +57,12 @@ int main(int argc, char *argv[])
     parser.addHelpOption();
     parser.addVersionOption();
 
+    QCommandLineOption iniOption(
+        QStringLiteral("ini"),
+        QObject::tr("Use the specified OpenW3D configuration file."),
+        QObject::tr("path"));
+    parser.addOption(iniOption);
+
     QCommandLineOption languageOption(
         {QStringLiteral("l"), QStringLiteral("language")},
         QObject::tr("Override the UI language (english, french, german, japanese, korean, chinese)."),
@@ -62,6 +70,12 @@ int main(int argc, char *argv[])
     parser.addOption(languageOption);
 
     parser.process(app);
+
+    if (parser.isSet(iniOption)) {
+        const QString iniPath = QFileInfo(parser.value(iniOption)).absoluteFilePath();
+        const QByteArray iniPathBytes = iniPath.toLocal8Bit();
+        OpenW3D::Set_Config_File_Path_Override(iniPathBytes.constData());
+    }
 
     app.setWindowIcon(QIcon(QStringLiteral(":/wwconfig/wwconfig.ico")));
 

--- a/Code/Tools/WWConfigQt/resources.qrc
+++ b/Code/Tools/WWConfigQt/resources.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/wwconfig">
+        <file alias="logo.bmp">../WWConfig/res/logo.bmp</file>
+        <file alias="wwconfig.ico">../WWConfig/res/WWConfig.ico</file>
+    </qresource>
+</RCC>

--- a/Code/Tools/WWConfigQt/wwconfig_qt.rc
+++ b/Code/Tools/WWConfigQt/wwconfig_qt.rc
@@ -1,0 +1,1 @@
+IDI_ICON1 ICON "../WWConfig/res/WWConfig.ico"

--- a/cmake/qt_tools.cmake
+++ b/cmake/qt_tools.cmake
@@ -1,0 +1,43 @@
+include_guard(GLOBAL)
+
+if(TARGET w3d_qt_toolkit)
+    return()
+endif()
+
+set(W3D_QT_MIN_VERSION "6.6" CACHE STRING "Minimum Qt version to search for")
+set(_w3d_qt_components Core Gui Widgets Svg OpenGLWidgets)
+set(_w3d_qt_optional_components LinguistTools)
+
+find_package(Qt6 ${W3D_QT_MIN_VERSION} COMPONENTS ${_w3d_qt_components} OPTIONAL_COMPONENTS ${_w3d_qt_optional_components} QUIET)
+
+if(Qt6_FOUND)
+    set(W3D_QT_PACKAGE "Qt6" CACHE STRING "Qt package namespace" FORCE)
+    set(W3D_QT_VERSION "${Qt6_VERSION}" CACHE STRING "Detected Qt version" FORCE)
+else()
+    find_package(Qt5 5.15 COMPONENTS ${_w3d_qt_components} OPTIONAL_COMPONENTS ${_w3d_qt_optional_components} REQUIRED)
+    set(W3D_QT_PACKAGE "Qt5" CACHE STRING "Qt package namespace" FORCE)
+    set(W3D_QT_VERSION "${Qt5_VERSION}" CACHE STRING "Detected Qt version" FORCE)
+endif()
+
+if(W3D_QT_PACKAGE STREQUAL "Qt6")
+    set(_w3d_qt_libraries
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Widgets
+        Qt6::Svg
+        Qt6::OpenGLWidgets
+    )
+else()
+    set(_w3d_qt_libraries
+        Qt5::Core
+        Qt5::Gui
+        Qt5::Widgets
+        Qt5::Svg
+        Qt5::OpenGLWidgets
+    )
+endif()
+
+add_library(w3d_qt_toolkit INTERFACE)
+target_link_libraries(w3d_qt_toolkit INTERFACE ${_w3d_qt_libraries})
+
+set(W3D_QT_COMPONENTS ${_w3d_qt_components} CACHE INTERNAL "Qt components enabled for W3D")

--- a/cmake/qt_tools.cmake
+++ b/cmake/qt_tools.cmake
@@ -8,34 +8,18 @@ set(W3D_QT_MIN_VERSION "6.6" CACHE STRING "Minimum Qt version to search for")
 set(_w3d_qt_components Core Gui Widgets Svg OpenGLWidgets)
 set(_w3d_qt_optional_components LinguistTools)
 
-find_package(Qt6 ${W3D_QT_MIN_VERSION} COMPONENTS ${_w3d_qt_components} OPTIONAL_COMPONENTS ${_w3d_qt_optional_components} QUIET)
+find_package(Qt6 ${W3D_QT_MIN_VERSION} REQUIRED COMPONENTS ${_w3d_qt_components} OPTIONAL_COMPONENTS ${_w3d_qt_optional_components})
 
-if(Qt6_FOUND)
-    set(W3D_QT_PACKAGE "Qt6" CACHE STRING "Qt package namespace" FORCE)
-    set(W3D_QT_VERSION "${Qt6_VERSION}" CACHE STRING "Detected Qt version" FORCE)
-else()
-    find_package(Qt5 5.15 COMPONENTS ${_w3d_qt_components} OPTIONAL_COMPONENTS ${_w3d_qt_optional_components} REQUIRED)
-    set(W3D_QT_PACKAGE "Qt5" CACHE STRING "Qt package namespace" FORCE)
-    set(W3D_QT_VERSION "${Qt5_VERSION}" CACHE STRING "Detected Qt version" FORCE)
-endif()
+set(W3D_QT_PACKAGE "Qt6" CACHE STRING "Qt package namespace" FORCE)
+set(W3D_QT_VERSION "${Qt6_VERSION}" CACHE STRING "Detected Qt version" FORCE)
 
-if(W3D_QT_PACKAGE STREQUAL "Qt6")
-    set(_w3d_qt_libraries
-        Qt6::Core
-        Qt6::Gui
-        Qt6::Widgets
-        Qt6::Svg
-        Qt6::OpenGLWidgets
-    )
-else()
-    set(_w3d_qt_libraries
-        Qt5::Core
-        Qt5::Gui
-        Qt5::Widgets
-        Qt5::Svg
-        Qt5::OpenGLWidgets
-    )
-endif()
+set(_w3d_qt_libraries
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Widgets
+    Qt6::Svg
+    Qt6::OpenGLWidgets
+)
 
 add_library(w3d_qt_toolkit INTERFACE)
 target_link_libraries(w3d_qt_toolkit INTERFACE ${_w3d_qt_libraries})

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,6 +4,10 @@
   "dependencies": [
     "ffmpeg",
     "icu",
-    "sdl3"
+    "sdl3",
+    "qtbase",
+    "qttools",
+    "qtimageformats",
+    "qtsvg"
   ]
 }


### PR DESCRIPTION
## Summary

Adds the new `wwconfig_qt` tool as an opt-in Qt frontend for the existing WWConfig settings flow.

This builds on the shared config path handling from #104, so the Qt tool uses the same resolved `openw3d.conf` / `Renegade.ini` path behavior as the game and classic WWConfig. It also supports `--ini PATH` for explicit config-file selection.

## Changes

- Adds shared `wwconfig_core` code used by both classic WWConfig and WWConfigQt.
- Adds the initial `Code/Tools/WWConfigQt` UI for video, audio, and performance settings.
- Adds opt-in CMake wiring behind `W3D_BUILD_QT_TOOLS`.
- Adds Qt build presets for Windows Qt tool builds.
- Adds required vcpkg Qt dependencies.
- Adds `WWConfigQt --ini PATH` support through the shared OpenW3D config-path override.
- Keeps WWConfigQt scoped to this tool only.

