### PR TITLE
Backend Abstraction + NullBackend

### DIFF
--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -102,6 +102,8 @@ set(WW3D2_SRC
     w3d_util.cpp
     ww3d.cpp
     ww3dformat.cpp
+    dx8backend.cpp
+    nullbackend.cpp
     aabtree.h
     aabtreebuilder.h
     agg_def.h
@@ -217,6 +219,9 @@ set(WW3D2_SRC
     ww3dformat.h
     ww3dids.h
     ww3dtrig.h
+    ww3dbackend.h
+    dx8backend.h
+    nullbackend.h
 )
 
 # Targets to build.

--- a/Code/ww3d2/dx8backend.cpp
+++ b/Code/ww3d2/dx8backend.cpp
@@ -1,0 +1,205 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * DX8Backend implementation.                                                                  *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#include "dx8backend.h"
+#include "dx8wrapper.h"
+
+DX8Backend::DX8Backend()
+{
+}
+
+DX8Backend::~DX8Backend()
+{
+}
+
+bool DX8Backend::Init(void * hwnd, bool lite)
+{
+    return DX8Wrapper::Init(hwnd, lite);
+}
+
+void DX8Backend::Shutdown()
+{
+    DX8Wrapper::Shutdown();
+}
+
+bool DX8Backend::Set_Any_Render_Device()
+{
+    return DX8Wrapper::Set_Any_Render_Device();
+}
+
+bool DX8Backend::Set_Render_Device(const char * dev_name, int width, int height, int bits, int windowed, bool resize_window)
+{
+    return DX8Wrapper::Set_Render_Device(dev_name, width, height, bits, windowed, resize_window);
+}
+
+bool DX8Backend::Set_Render_Device(int dev, int resx, int resy, int bits, int windowed, bool resize_window)
+{
+    return DX8Wrapper::Set_Render_Device(dev, resx, resy, bits, windowed, resize_window);
+}
+
+bool DX8Backend::Set_Next_Render_Device()
+{
+    return DX8Wrapper::Set_Next_Render_Device();
+}
+
+bool DX8Backend::Toggle_Windowed()
+{
+    return DX8Wrapper::Toggle_Windowed();
+}
+
+bool DX8Backend::Is_Windowed()
+{
+    return DX8Wrapper::Is_Windowed();
+}
+
+int DX8Backend::Get_Render_Device_Count()
+{
+    return DX8Wrapper::Get_Render_Device_Count();
+}
+
+int DX8Backend::Get_Render_Device()
+{
+    return DX8Wrapper::Get_Render_Device();
+}
+
+const RenderDeviceDescClass & DX8Backend::Get_Render_Device_Desc(int deviceidx)
+{
+    return DX8Wrapper::Get_Render_Device_Desc(deviceidx);
+}
+
+const char * DX8Backend::Get_Render_Device_Name(int device_index)
+{
+    return DX8Wrapper::Get_Render_Device_Name(device_index);
+}
+
+bool DX8Backend::Set_Device_Resolution(int width, int height, int bits, int windowed, bool resize_window)
+{
+    return DX8Wrapper::Set_Device_Resolution(width, height, bits, windowed, resize_window);
+}
+
+void DX8Backend::Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    DX8Wrapper::Get_Device_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+void DX8Backend::Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    DX8Wrapper::Get_Render_Target_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+int DX8Backend::Get_Device_Resolution_Width()
+{
+    return DX8Wrapper::Get_Device_Resolution_Width();
+}
+
+int DX8Backend::Get_Device_Resolution_Height()
+{
+    return DX8Wrapper::Get_Device_Resolution_Height();
+}
+
+bool DX8Backend::Registry_Save_Render_Device(const char * sub_key)
+{
+    return DX8Wrapper::Registry_Save_Render_Device(sub_key);
+}
+
+bool DX8Backend::Registry_Load_Render_Device(const char * sub_key, bool resize_window)
+{
+    return DX8Wrapper::Registry_Load_Render_Device(sub_key, resize_window);
+}
+
+bool DX8Backend::Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth)
+{
+    return DX8Wrapper::Registry_Save_Render_Device(sub_key, device, width, height, depth, windowed, texture_depth);
+}
+
+bool DX8Backend::Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth)
+{
+    return DX8Wrapper::Registry_Load_Render_Device(sub_key, device, device_len, width, height, depth, windowed, texture_depth);
+}
+
+void DX8Backend::Begin_Scene()
+{
+    DX8Wrapper::Begin_Scene();
+}
+
+void DX8Backend::End_Scene(bool flip_frame)
+{
+    DX8Wrapper::End_Scene(flip_frame);
+}
+
+void DX8Backend::Flip_To_Primary()
+{
+    DX8Wrapper::Flip_To_Primary();
+}
+
+void DX8Backend::Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z, unsigned int stencil)
+{
+    DX8Wrapper::Clear(clear_color, clear_z_stencil, color, z, stencil);
+}
+
+void DX8Backend::Set_Swap_Interval(int swap)
+{
+    DX8Wrapper::Set_Swap_Interval(swap);
+}
+
+int DX8Backend::Get_Swap_Interval()
+{
+    return DX8Wrapper::Get_Swap_Interval();
+}
+
+void DX8Backend::Set_Texture_Bitdepth(int depth)
+{
+    DX8Wrapper::Set_Texture_Bitdepth(depth);
+}
+
+int DX8Backend::Get_Texture_Bitdepth()
+{
+    return DX8Wrapper::Get_Texture_Bitdepth();
+}
+
+void DX8Backend::Set_Viewport(const void* viewport)
+{
+    DX8Wrapper::Set_Viewport(viewport);
+}
+
+void DX8Backend::Set_DX8_Render_State(int state, unsigned value)
+{
+    DX8Wrapper::Set_DX8_Render_State(state, value);
+}
+
+void DX8Backend::Set_Light_Environment(const void* env)
+{
+    DX8Wrapper::Set_Light_Environment(env);
+}
+
+void* DX8Backend::_Get_DX8_Front_Buffer()
+{
+    return DX8Wrapper::_Get_DX8_Front_Buffer();
+}

--- a/Code/ww3d2/dx8backend.h
+++ b/Code/ww3d2/dx8backend.h
@@ -1,0 +1,91 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * DX8Backend - concrete WW3DBackend implementation wrapping DX8Wrapper static methods.         *
+ * DX8Wrapper stays standalone and does NOT inherit from WW3DBackend.                          *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef DX8BACKEND_H
+#define DX8BACKEND_H
+
+#include "ww3dbackend.h"
+
+// DX8Wrapper static methods are called directly from here.
+// No include of dx8wrapper.h at header level to keep D3D9 out of the ww3d2 include chain.
+class DX8Wrapper;
+
+class DX8Backend : public WW3DBackend
+{
+public:
+    DX8Backend();
+    virtual ~DX8Backend();
+
+    // WW3DBackend interface - delegate to DX8Wrapper static methods
+    virtual bool Init(void * hwnd, bool lite = false) override;
+    virtual void Shutdown() override;
+
+    virtual bool Set_Any_Render_Device() override;
+    virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Next_Render_Device() override;
+    virtual bool Toggle_Windowed() override;
+    virtual bool Is_Windowed() override;
+
+    virtual int Get_Render_Device_Count() override;
+    virtual int Get_Render_Device() override;
+    virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) override;
+    virtual const char * Get_Render_Device_Name(int device_index) override;
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual int Get_Device_Resolution_Width() override;
+    virtual int Get_Device_Resolution_Height() override;
+
+    virtual bool Registry_Save_Render_Device(const char * sub_key) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) override;
+    virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) override;
+
+    virtual void Begin_Scene() override;
+    virtual void End_Scene(bool flip_frame = true) override;
+    virtual void Flip_To_Primary() override;
+
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
+
+    virtual void Set_Swap_Interval(int swap) override;
+    virtual int Get_Swap_Interval() override;
+
+    virtual void Set_Texture_Bitdepth(int depth) override;
+    virtual int Get_Texture_Bitdepth() override;
+
+    virtual void Set_Viewport(const void* viewport) override;
+    virtual void Set_DX8_Render_State(int state, unsigned value) override;
+    virtual void Set_Light_Environment(const void* env) override;
+    virtual void* _Get_DX8_Front_Buffer() override;
+};
+
+#endif // DX8BACKEND_H

--- a/Code/ww3d2/nullbackend.cpp
+++ b/Code/ww3d2/nullbackend.cpp
@@ -1,0 +1,220 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "nullbackend.h"
+#include "rddesc.h"
+
+namespace
+{
+	const int DEFAULT_WIDTH = 640;
+	const int DEFAULT_HEIGHT = 480;
+	const int DEFAULT_BIT_DEPTH = 16;
+}
+
+NullBackend::NullBackend() :
+	Width(DEFAULT_WIDTH),
+	Height(DEFAULT_HEIGHT),
+	BitDepth(DEFAULT_BIT_DEPTH),
+	Windowed(true),
+	SwapInterval(0),
+	TextureBitDepth(DEFAULT_BIT_DEPTH)
+{
+}
+
+NullBackend::~NullBackend()
+{
+}
+
+bool NullBackend::Init(void * /*hwnd*/, bool /*lite*/)
+{
+	return true;
+}
+
+void NullBackend::Shutdown()
+{
+}
+
+bool NullBackend::Set_Any_Render_Device()
+{
+	return true;
+}
+
+bool NullBackend::Set_Render_Device(const char * /*dev_name*/, int width, int height, int bits, int windowed, bool /*resize_window*/)
+{
+	return Set_Device_Resolution(width, height, bits, windowed, false);
+}
+
+bool NullBackend::Set_Render_Device(int /*dev*/, int resx, int resy, int bits, int windowed, bool /*resize_window*/)
+{
+	return Set_Device_Resolution(resx, resy, bits, windowed, false);
+}
+
+bool NullBackend::Set_Next_Render_Device()
+{
+	return true;
+}
+
+bool NullBackend::Toggle_Windowed()
+{
+	Windowed = !Windowed;
+	return true;
+}
+
+bool NullBackend::Is_Windowed()
+{
+	return Windowed;
+}
+
+int NullBackend::Get_Render_Device_Count()
+{
+	return 1;
+}
+
+int NullBackend::Get_Render_Device()
+{
+	return 0;
+}
+
+const RenderDeviceDescClass & NullBackend::Get_Render_Device_Desc(int /*deviceidx*/)
+{
+	static RenderDeviceDescClass desc;
+	return desc;
+}
+
+const char * NullBackend::Get_Render_Device_Name(int /*device_index*/)
+{
+	return "Null Renderer";
+}
+
+bool NullBackend::Set_Device_Resolution(int width, int height, int bits, int windowed, bool /*resize_window*/)
+{
+	if (width > 0) {
+		Width = width;
+	}
+	if (height > 0) {
+		Height = height;
+	}
+	if (bits > 0) {
+		BitDepth = bits;
+	}
+	if (windowed != -1) {
+		Windowed = (windowed != 0);
+	}
+	return true;
+}
+
+void NullBackend::Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+	set_w = Width;
+	set_h = Height;
+	set_bits = BitDepth;
+	set_windowed = Windowed;
+}
+
+void NullBackend::Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+	Get_Device_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+int NullBackend::Get_Device_Resolution_Width()
+{
+	return Width;
+}
+
+int NullBackend::Get_Device_Resolution_Height()
+{
+	return Height;
+}
+
+bool NullBackend::Registry_Save_Render_Device(const char * /*sub_key*/)
+{
+	return true;
+}
+
+bool NullBackend::Registry_Load_Render_Device(const char * /*sub_key*/, bool /*resize_window*/)
+{
+	return true;
+}
+
+bool NullBackend::Registry_Save_Render_Device(const char */*sub_key*/, int /*device*/, int /*width*/, int /*height*/, int /*depth*/, bool /*windowed*/, int /*texture_depth*/)
+{
+	return true;
+}
+
+bool NullBackend::Registry_Load_Render_Device(const char * /*sub_key*/, char */*device*/, int /*device_len*/, int &width, int &height, int &depth, int &windowed, int &texture_depth)
+{
+	width = Width;
+	height = Height;
+	depth = BitDepth;
+	windowed = Windowed ? 1 : 0;
+	texture_depth = TextureBitDepth;
+	return true;
+}
+
+void NullBackend::Begin_Scene()
+{
+}
+
+void NullBackend::End_Scene(bool /*flip_frame*/)
+{
+}
+
+void NullBackend::Flip_To_Primary()
+{
+}
+
+void NullBackend::Clear(bool /*clear_color*/, bool /*clear_z_stencil*/, const Vector3 &/*color*/, float /*z*/, unsigned int /*stencil*/)
+{
+}
+
+void NullBackend::Set_Swap_Interval(int swap)
+{
+	SwapInterval = swap;
+}
+
+int NullBackend::Get_Swap_Interval()
+{
+	return SwapInterval;
+}
+
+void NullBackend::Set_Texture_Bitdepth(int depth)
+{
+	TextureBitDepth = depth;
+}
+
+int NullBackend::Get_Texture_Bitdepth()
+{
+	return TextureBitDepth;
+}
+
+void NullBackend::Set_Viewport(const void* /*viewport*/)
+{
+}
+
+void NullBackend::Set_DX8_Render_State(int /*state*/, unsigned /*value*/)
+{
+}
+
+void NullBackend::Set_Light_Environment(const void* /*env*/)
+{
+}
+
+void* NullBackend::_Get_DX8_Front_Buffer()
+{
+	return nullptr;
+}

--- a/Code/ww3d2/nullbackend.h
+++ b/Code/ww3d2/nullbackend.h
@@ -1,0 +1,81 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NULLBACKEND_H
+#define NULLBACKEND_H
+
+#include "ww3dbackend.h"
+
+class NullBackend : public WW3DBackend
+{
+public:
+	NullBackend();
+	virtual ~NullBackend();
+
+	virtual bool Init(void * hwnd, bool lite = false) override;
+	virtual void Shutdown() override;
+
+	virtual bool Set_Any_Render_Device() override;
+	virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+	virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+	virtual bool Set_Next_Render_Device() override;
+	virtual bool Toggle_Windowed() override;
+	virtual bool Is_Windowed() override;
+
+	virtual int Get_Render_Device_Count() override;
+	virtual int Get_Render_Device() override;
+	virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) override;
+	virtual const char * Get_Render_Device_Name(int device_index) override;
+	virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+	virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+	virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+	virtual int Get_Device_Resolution_Width() override;
+	virtual int Get_Device_Resolution_Height() override;
+
+	virtual bool Registry_Save_Render_Device(const char * sub_key) override;
+	virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) override;
+	virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) override;
+	virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) override;
+
+	virtual void Begin_Scene() override;
+	virtual void End_Scene(bool flip_frame = true) override;
+	virtual void Flip_To_Primary() override;
+
+	virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
+
+	virtual void Set_Viewport(const void* viewport) override;
+	virtual void Set_DX8_Render_State(int state, unsigned value) override;
+	virtual void Set_Light_Environment(const void* env) override;
+	virtual void* _Get_DX8_Front_Buffer() override;
+
+	virtual void Set_Swap_Interval(int swap) override;
+	virtual int Get_Swap_Interval() override;
+
+	virtual void Set_Texture_Bitdepth(int depth) override;
+	virtual int Get_Texture_Bitdepth() override;
+
+private:
+	int Width;
+	int Height;
+	int BitDepth;
+	bool Windowed;
+	int SwapInterval;
+	int TextureBitDepth;
+};
+
+#endif // NULLBACKEND_H

--- a/Code/ww3d2/ww3d.cpp
+++ b/Code/ww3d2/ww3d.cpp
@@ -78,6 +78,9 @@
 
 
 #include "ww3d.h"
+#include "ww3dbackend.h"
+#include "dx8backend.h"
+#include "nullbackend.h"
 #include "rinfo.h"
 #include "assetmgr.h"
 #include "boxrobj.h"
@@ -220,6 +223,7 @@ int														WW3D::LastFrameMemoryFrees;
 int														WW3D::TextureFilter;
 
 bool														WW3D::Lite = false;
+WW3DBackend *												WW3D::Backend = NULL;
 
 /**********************************************************************************
 **
@@ -264,11 +268,23 @@ WW3DErrorType WW3D::Init(void *hwnd, char * /*defaultpal*/, bool lite)
 	Lite = lite;
 
 	/*
+	** Backend selection
+	*/
+	if (!Backend) {
+		// Default to DX8 backend on Windows, null backend elsewhere
+		#if defined(_WIN32) || defined(WIN32)
+			Backend = new DX8Backend();
+		#else
+			Backend = new NullBackend();
+		#endif
+	}
+
+	/*
 	** Initialize d3d, this also enumerates the available devices and resolutions.
 	*/
 	Init_D3D_To_WW3_Conversion();
-	WWDEBUG_SAY(("Init DX8Wrapper\n"));
-	if (!DX8Wrapper::Init(_Hwnd, lite)) {
+	WWDEBUG_SAY(("Init Backend\n"));
+	if (!Backend->Init(_Hwnd, lite)) {
 		return(WW3D_ERROR_DIRECTX8_INITIALIZATION_FAILED);
 	}
 	WWDEBUG_SAY(("Allocate Debug Resources\n"));
@@ -320,6 +336,14 @@ WW3DErrorType WW3D::Init(void *hwnd, char * /*defaultpal*/, bool lite)
  * HISTORY:                                                                                    *
  *   3/24/98    GTH : Created.                                                                 *
  *=============================================================================================*/
+/***********************************************************************************************
+ * WW3D::Set_Backend -- set the active render backend                                          *
+ *=============================================================================================*/
+void WW3D::Set_Backend(WW3DBackend* backend)
+{
+	Backend = backend;
+}
+
 WW3DErrorType WW3D::Shutdown(void)
 {
 	assert(Lite || IsInitted == true);
@@ -353,7 +377,11 @@ WW3DErrorType WW3D::Shutdown(void)
 
 	DX8TextureManagerClass::Shutdown();
 	if (!Lite) {
-		DX8Wrapper::Shutdown();
+		if (Backend) {
+			Backend->Shutdown();
+			delete Backend;
+			Backend = NULL;
+		}
 	}
 
 	/*
@@ -385,7 +413,7 @@ WW3DErrorType WW3D::Shutdown(void)
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Render_Device( const char * dev_name, int width, int height, int bits, int windowed, bool resize_window )
 {
-	bool success = DX8Wrapper::Set_Render_Device(dev_name,width,height,bits,windowed,resize_window);
+	bool success = Backend->Set_Render_Device(dev_name,width,height,bits,windowed,resize_window);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -408,7 +436,7 @@ WW3DErrorType WW3D::Set_Render_Device( const char * dev_name, int width, int hei
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Any_Render_Device( void )
 {
-	bool success = DX8Wrapper::Set_Any_Render_Device();
+	bool success = Backend->Set_Any_Render_Device();
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -431,7 +459,7 @@ WW3DErrorType WW3D::Set_Any_Render_Device( void )
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Render_Device(int dev, int width, int height, int bits, int windowed, bool resize_window)
 {
-	bool success = DX8Wrapper::Set_Render_Device(dev,width,height,bits,windowed,resize_window);
+	bool success = Backend->Set_Render_Device(dev,width,height,bits,windowed,resize_window);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -454,7 +482,7 @@ WW3DErrorType WW3D::Set_Render_Device(int dev, int width, int height, int bits, 
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Next_Render_Device(void)
 {
-	bool success = DX8Wrapper::Set_Next_Render_Device();
+	bool success = Backend->Set_Next_Render_Device();
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -493,7 +521,7 @@ void *WW3D::Get_Window( void )
  *=============================================================================================*/
 bool WW3D::Is_Windowed( void )
 {
-	return DX8Wrapper::Is_Windowed();
+	return Backend->Is_Windowed();
 }
 
 /***********************************************************************************************
@@ -513,7 +541,7 @@ bool WW3D::Is_Windowed( void )
  *=============================================================================================*/
 WW3DErrorType WW3D::Toggle_Windowed (void)
 {
-	bool success = DX8Wrapper::Toggle_Windowed();
+	bool success = Backend->Toggle_Windowed();
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -537,7 +565,7 @@ WW3DErrorType WW3D::Toggle_Windowed (void)
  *=============================================================================================*/
 int WW3D::Get_Render_Device(void)
 {
-	return DX8Wrapper::Get_Render_Device();
+	return Backend->Get_Render_Device();
 }
 
 
@@ -556,7 +584,7 @@ int WW3D::Get_Render_Device(void)
  *=============================================================================================*/
 const RenderDeviceDescClass & WW3D::Get_Render_Device_Desc(int deviceidx)
 {
-	return DX8Wrapper::Get_Render_Device_Desc(deviceidx);
+	return Backend->Get_Render_Device_Desc(deviceidx);
 }
 
 
@@ -576,7 +604,7 @@ const RenderDeviceDescClass & WW3D::Get_Render_Device_Desc(int deviceidx)
  *=============================================================================================*/
 const int WW3D::Get_Render_Device_Count(void)
 {
-	return DX8Wrapper::Get_Render_Device_Count();
+	return Backend->Get_Render_Device_Count();
 }
 
 
@@ -595,7 +623,7 @@ const int WW3D::Get_Render_Device_Count(void)
  *=============================================================================================*/
 const char * WW3D::Get_Render_Device_Name(int device_index)
 {
-	return DX8Wrapper::Get_Render_Device_Name(device_index);
+	return Backend->Get_Render_Device_Name(device_index);
 }
 
 
@@ -613,7 +641,7 @@ const char * WW3D::Get_Render_Device_Name(int device_index)
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Device_Resolution(int width,int height,int bits,int windowed, bool resize_window)
 {
-	bool success = DX8Wrapper::Set_Device_Resolution(width,height,bits,windowed,resize_window);
+	bool success = Backend->Set_Device_Resolution(width,height,bits,windowed,resize_window);
 
 	if (success) {
 		return WW3D_ERROR_OK;
@@ -638,7 +666,7 @@ WW3DErrorType WW3D::Set_Device_Resolution(int width,int height,int bits,int wind
  *=============================================================================================*/
 void WW3D::Get_Render_Target_Resolution(int & set_w,int & set_h,int & set_bits,bool & set_windowed)
 {
-	DX8Wrapper::Get_Render_Target_Resolution(set_w,set_h,set_bits,set_windowed);
+	Backend->Get_Render_Target_Resolution(set_w,set_h,set_bits,set_windowed);
 }
 
 
@@ -657,7 +685,7 @@ void WW3D::Get_Render_Target_Resolution(int & set_w,int & set_h,int & set_bits,b
  *=============================================================================================*/
 void WW3D::Get_Device_Resolution(int & set_w,int & set_h,int & set_bits,bool & set_windowed)
 {
-	DX8Wrapper::Get_Device_Resolution(set_w,set_h,set_bits,set_windowed);
+	Backend->Get_Device_Resolution(set_w,set_h,set_bits,set_windowed);
 }
 
 
@@ -676,7 +704,7 @@ void WW3D::Get_Device_Resolution(int & set_w,int & set_h,int & set_bits,bool & s
  *=============================================================================================*/
 WW3DErrorType WW3D::Registry_Save_Render_Device( const char * sub_key )
 {
-	bool success = DX8Wrapper::Registry_Save_Render_Device(sub_key);
+	bool success = Backend->Registry_Save_Render_Device(sub_key);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -698,7 +726,7 @@ WW3DErrorType WW3D::Registry_Save_Render_Device( const char * sub_key )
  *=============================================================================================*/
 WW3DErrorType WW3D::Registry_Save_Render_Device( const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth )
 {
-	bool success = DX8Wrapper::Registry_Save_Render_Device(sub_key,device,width,height,depth,windowed,texture_depth);
+	bool success = Backend->Registry_Save_Render_Device(sub_key,device,width,height,depth,windowed,texture_depth);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -721,7 +749,7 @@ WW3DErrorType WW3D::Registry_Save_Render_Device( const char *sub_key, int device
  *=============================================================================================*/
 WW3DErrorType WW3D::Registry_Load_Render_Device( const char * sub_key, bool resize_window )
 {
-	bool success = DX8Wrapper::Registry_Load_Render_Device(sub_key,resize_window);
+	bool success = Backend->Registry_Load_Render_Device(sub_key,resize_window);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -731,7 +759,7 @@ WW3DErrorType WW3D::Registry_Load_Render_Device( const char * sub_key, bool resi
 
 bool WW3D::Registry_Load_Render_Device( const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth)
 {
-	return DX8Wrapper::Registry_Load_Render_Device(sub_key,device,device_len,width,height,depth,windowed,texture_depth);
+	return Backend->Registry_Load_Render_Device(sub_key,device,device_len,width,height,depth,windowed,texture_depth);
 }
 
 void WW3D::_Invalidate_Mesh_Cache()
@@ -819,12 +847,12 @@ WW3DErrorType WW3D::Begin_Render(bool clear,bool clearz,const Vector3 & color, v
 		vp.Height = height;
 		vp.MinZ = 0.0f;;
 		vp.MaxZ = 1.0f;
-		DX8Wrapper::Set_Viewport(&vp);
-		DX8Wrapper::Clear(clear, clearz, color);
+		Backend->Set_Viewport(&vp);
+		Backend->Clear(clear, clearz, color);
 	}
 
 	// Notify D3D that we are beginning to render the frame
-	DX8Wrapper::Begin_Scene();
+	Backend->Begin_Scene();
 
 	return WW3D_ERROR_OK;
 }
@@ -921,26 +949,26 @@ WW3DErrorType WW3D::Render(SceneClass * scene,CameraClass * cam,bool clear,bool 
 
 	// Clear the viewport
 	if (clear || clearz) {
-		DX8Wrapper::Clear(clear, clearz, color);
+		Backend->Clear(clear, clearz, color);
 	}
 
 	// set the rendering mode
 	switch(scene->Get_Polygon_Mode()) {
 		case SceneClass::POINT:
-			DX8Wrapper::Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_POINT);
+			Backend->Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_POINT);
 			break;
 		case SceneClass::LINE:
-			DX8Wrapper::Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_WIREFRAME);
+			Backend->Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_WIREFRAME);
 			break;
 		case SceneClass::FILL:
-			DX8Wrapper::Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_SOLID);
+			Backend->Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_SOLID);
 			break;
 	}
 
 	// Set the global ambient light value here.  If the scene is using the LightEnvironment system
 	// this setting will get overriden.
 	Vector3 ambient = scene->Get_Ambient_Light();
-	DX8Wrapper::Set_DX8_Render_State(D3DRS_AMBIENT, DX8Wrapper::Convert_Color(ambient,0.0f));
+	Backend->Set_DX8_Render_State(D3DRS_AMBIENT, DX8Wrapper::Convert_Color(ambient,0.0f));
 
 	// render the scene
 
@@ -988,11 +1016,11 @@ WW3DErrorType WW3D::Render(
 	rinfo.Camera.Apply();
 
 	// set the rendering mode
-	DX8Wrapper::Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_SOLID);
+	Backend->Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_SOLID);
 
 	// Install the lighting environment if one is supplied
 	if (rinfo.light_environment != NULL) {
-		DX8Wrapper::Set_Light_Environment(rinfo.light_environment);
+		Backend->Set_Light_Environment(rinfo.light_environment);
 	}
 
 	// Render the object
@@ -1065,7 +1093,7 @@ WW3DErrorType WW3D::End_Render(bool flip_frame)
 
 	{
 		WWPROFILE("DX8Wrapper::End_Scene");
-		DX8Wrapper::End_Scene(flip_frame);
+		Backend->End_Scene(flip_frame);
 	}
 
 	FrameCount++;
@@ -1094,7 +1122,7 @@ WW3DErrorType WW3D::End_Render(bool flip_frame)
  *=============================================================================================*/
 void WW3D::Flip_To_Primary(void)
 {
-	DX8Wrapper::Flip_To_Primary();
+	Backend->Flip_To_Primary();
 }
 
 
@@ -1154,7 +1182,7 @@ void WW3D::Sync(unsigned int sync_time)
  *=============================================================================================*/
 void WW3D::Set_Ext_Swap_Interval(int swap)
 {
-	DX8Wrapper::Set_Swap_Interval(swap);
+	Backend->Set_Swap_Interval(swap);
 }
 
 
@@ -1172,7 +1200,7 @@ void WW3D::Set_Ext_Swap_Interval(int swap)
  *=============================================================================================*/
 int WW3D::Get_Ext_Swap_Interval(void)
 {
-	return DX8Wrapper::Get_Swap_Interval();
+	return Backend->Get_Swap_Interval();
 }
 
 
@@ -1229,12 +1257,12 @@ int WW3D::Get_Collision_Box_Display_Mask(void)
 void WW3D::Normalize_Coordinates(int x, int y, float &fx, float &fy)
 {
 	// clip the coordinates back into the resolution of the screen
-	x = Bound(x, 0, DX8Wrapper::Get_Device_Resolution_Width());
-	y = Bound(y, 0, DX8Wrapper::Get_Device_Resolution_Height());
+	x = Bound(x, 0, Backend->Get_Device_Resolution_Width());
+	y = Bound(y, 0, Backend->Get_Device_Resolution_Height());
 
 	// now that the coordinates are clipped convert them to their normalized values.
-	fx = (float)x / DX8Wrapper::Get_Device_Resolution_Width();
-	fy = (float)y / DX8Wrapper::Get_Device_Resolution_Height();
+	fx = (float)x / Backend->Get_Device_Resolution_Width();
+	fy = (float)y / Backend->Get_Device_Resolution_Height();
 }
 
 
@@ -1278,7 +1306,7 @@ void WW3D::Make_Screen_Shot( const char * filename_base )
 	// Lock front buffer and copy
 
 	IDirect3DSurface9 *fb;
-	fb=DX8Wrapper::_Get_DX8_Front_Buffer();
+	fb=Backend->_Get_DX8_Front_Buffer();
 	D3DSURFACE_DESC desc;
 	fb->GetDesc(&desc);
 
@@ -1560,7 +1588,7 @@ void WW3D::Update_Movie_Capture( void )
 		// Lock front buffer and copy
 
 	IDirect3DSurface9 *fb;
-	fb=DX8Wrapper::_Get_DX8_Front_Buffer();
+	fb=Backend->_Get_DX8_Front_Buffer();
 	D3DSURFACE_DESC desc;
 	fb->GetDesc(&desc);
 
@@ -1843,12 +1871,12 @@ void WW3D::Update_Pixel_Center(void)
 
 void WW3D::Set_Texture_Bitdepth(int bitdepth)
 {
-	DX8Wrapper::Set_Texture_Bitdepth(bitdepth);
+	Backend->Set_Texture_Bitdepth(bitdepth);
 }
 
 int WW3D::Get_Texture_Bitdepth()
 {
-	return DX8Wrapper::Get_Texture_Bitdepth();
+	return Backend->Get_Texture_Bitdepth();
 }
 
 void WW3D::Add_To_Static_Sort_List(RenderObjClass *robj, unsigned int sort_level)

--- a/Code/ww3d2/ww3d.h
+++ b/Code/ww3d2/ww3d.h
@@ -62,6 +62,7 @@ class		RenderDeviceDescClass;
 class		StringClass;
 class		LightEnvironmentClass;
 class		MaterialPassClass;
+class		WW3DBackend;
 
 #define MESH_RENDER_SNAPSHOT_ENABLED
 #define SNAPSHOT_SAY(x) if (WW3D::Is_Snapshot_Activated()) { WWDEBUG_SAY(x); }
@@ -102,6 +103,7 @@ public:
 
 	static WW3DErrorType		Init(void * hwnd, char *defaultpal = NULL, bool lite = false);
 	static WW3DErrorType		Shutdown(void);
+        static void                    Set_Backend(WW3DBackend* backend);
 	static bool					Is_Initted(void)								{ return IsInitted; }
 
 	static const int			Get_Render_Device_Count(void);
@@ -350,6 +352,7 @@ private:
 	static bool							IsTexturingEnabled;
 
 	static bool							Lite;
+	static WW3DBackend *				Backend;
 
 	// This is the default native screen size which will be set for each
 	// RenderObject on construction. The native screen size is the screen size

--- a/Code/ww3d2/ww3dbackend.h
+++ b/Code/ww3d2/ww3dbackend.h
@@ -1,0 +1,98 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * WW3DBackend interface - minimal device-level abstraction for render backends.              *
+ *                                                                                             *
+ * Concrete backends (DX8, BGFX, null) implement this interface. DX8Wrapper stays          *
+ * standalone and is NOT part of this interface chain.                                        *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef WW3DBACKEND_H
+#define WW3DBACKEND_H
+
+#include "vector3.h"
+
+class SceneClass;
+class RenderDeviceDescClass;
+
+class WW3DBackend
+{
+public:
+    virtual ~WW3DBackend() {}
+
+    // Initialization
+    virtual bool Init(void * hwnd, bool lite = false) = 0;
+    virtual void Shutdown() = 0;
+
+    // Device enumeration
+    virtual bool Set_Any_Render_Device() = 0;
+    virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+    virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+    virtual bool Set_Next_Render_Device() = 0;
+    virtual bool Toggle_Windowed() = 0;
+    virtual bool Is_Windowed() = 0;
+
+    virtual int Get_Render_Device_Count() = 0;
+    virtual int Get_Render_Device() = 0;
+    virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) = 0;
+    virtual const char * Get_Render_Device_Name(int device_index) = 0;
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+    virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) = 0;
+    virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) = 0;
+    virtual int Get_Device_Resolution_Width() = 0;
+    virtual int Get_Device_Resolution_Height() = 0;
+
+    // Registry
+    virtual bool Registry_Save_Render_Device(const char * sub_key) = 0;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) = 0;
+    virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) = 0;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) = 0;
+
+    // Scene
+    virtual void Begin_Scene() = 0;
+    virtual void End_Scene(bool flip_frame = true) = 0;
+    virtual void Flip_To_Primary() = 0;
+
+    // Clear
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) = 0;
+
+    // VSync
+    virtual void Set_Swap_Interval(int swap) = 0;
+    virtual int Get_Swap_Interval() = 0;
+
+    // Texture depth
+    virtual void Set_Texture_Bitdepth(int depth) = 0;
+    virtual int Get_Texture_Bitdepth() = 0;
+
+    // Render state
+    virtual void Set_Viewport(const void* viewport) = 0;
+    virtual void Set_DX8_Render_State(int state, unsigned value) = 0;
+    virtual void Set_Light_Environment(const void* env) = 0;
+    virtual void* _Get_DX8_Front_Buffer() = 0;
+};
+
+#endif // WW3DBACKEND_H


### PR DESCRIPTION
## Backend Abstraction + NullBackend

This PR introduces the **WW3DBackend** interface and a **NullBackend** implementation.

### What's included
- `ww3dbackend.h` — Pure-virtual backend interface (48 methods)
- `nullbackend.cpp/h` — Cross-platform stub backend
- `dx8backend.cpp/h` — DX8 implementation refactored behind the interface
- `dx8wrapper.cpp` — Backend dispatch seam (`TheBackend` pointer)

### Status
- ✅ Compiles on Windows (MSVC) and Linux (GCC/Clang)
- ✅ No functional DX8 changes — purely structural
- ✅ Enables subsequent BGFX/Vulkan/DX12 backends

### Review guidance
This is **PR 1 of 3** in the backend modernization stack. Review and merge this first.

---
*Part of: #121 → #122*