### PR TITLE
BGFX Backend Support (Structure)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "external/bgfx"]
+	path = external/bgfx
+	url = https://github.com/bkaradzic/bgfx.git
+[submodule "external/bx"]
+	path = external/bx
+	url = https://github.com/bkaradzic/bx.git
+[submodule "external/bimg"]
+	path = external/bimg
+	url = https://github.com/bkaradzic/bimg.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,14 @@ add_feature_info(OpenW3DClient W3D_CLIENT "Build OpenW3D game client")
 option(W3D_FDS "Build as headless server." ON)
 add_feature_info(OpenW3DHeadless W3D_FDS "Build OpenW3D headless server")
 
+# Enable DX9/DXVK renderer on Linux
+option(WANT_DX9 "Enable DX9 renderer via DXVK (Linux only, for cross-compile testing)." ON)
+add_feature_info(DX9Renderer WANT_DX9 "Enable DX9/DXVK renderer")
+
+# Enable BGFX cross-platform renderer
+option(ENABLE_BGFX_BACKEND "Enable bgfx cross-platform backend" OFF)
+add_feature_info(BGFX_Renderer ENABLE_BGFX_BACKEND "Enable bgfx Backend")
+
 # Do we want to build extra SDK stuff or just the game binary?
 option(W3D_TOOLS "Build additional tools." ON)
 add_feature_info(OpenW3DTools W3D_TOOLS "Build OpenW3D Mod Tools")
@@ -106,7 +114,13 @@ else()
     include(icu)
 endif()
 
-include(dx9)
+if(WANT_DX9)
+    include(dx9)
+endif()
+
+if(ENABLE_BGFX_BACKEND)
+    include(bgfx)
+endif()
 
 include(gamespy)
 

--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -224,6 +224,14 @@ set(WW3D2_SRC
     nullbackend.h
 )
 
+if(ENABLE_BGFX_BACKEND)
+    list(APPEND WW3D2_SRC
+        backends/bgfx/bgfxbackend.cpp
+        backends/bgfx/bgfxbackend.h
+        backends/bgfx/BGFXMaterialMapper.h
+    )
+endif()
+
 # Targets to build.
 add_library(ww3d2 STATIC)
 
@@ -233,6 +241,15 @@ target_link_libraries(ww3d2 PRIVATE
     vfw32
     winmm
 )
+
+# Backend selection defines
+if(ENABLE_BGFX_BACKEND)
+    target_compile_definitions(ww3d2 PRIVATE WW3D_BGFX_BACKEND=1)
+elseif(WIN32 AND WANT_DX9)
+    target_compile_definitions(ww3d2 PRIVATE WW3D_DX9_BACKEND=1)
+else()
+    target_compile_definitions(ww3d2 PRIVATE WW3D_NULL_BACKEND=1)
+endif()
 
 target_sources(ww3d2 PRIVATE ${WW3D2_SRC})
 

--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -102,6 +102,8 @@ set(WW3D2_SRC
     w3d_util.cpp
     ww3d.cpp
     ww3dformat.cpp
+    dx8backend.cpp
+    nullbackend.cpp
     aabtree.h
     aabtreebuilder.h
     agg_def.h
@@ -217,6 +219,9 @@ set(WW3D2_SRC
     ww3dformat.h
     ww3dids.h
     ww3dtrig.h
+    ww3dbackend.h
+    dx8backend.h
+    nullbackend.h
 )
 
 # Targets to build.

--- a/Code/ww3d2/backends/bgfx/BGFXMaterialMapper.h
+++ b/Code/ww3d2/backends/bgfx/BGFXMaterialMapper.h
@@ -79,13 +79,13 @@ public:
     static uint64_t Shader_Blend_To_BGFX(ShaderClass::SrcBlendFuncType src, ShaderClass::DstBlendFuncType dst)
     {
         uint64_t state = BGFX_STATE_DEFAULT;
-        
+
         // Source blend
         uint64_t srcBlend = Src_Blend_To_BGFX(src);
-        
+
         // Destination blend
         uint64_t dstBlend = Dst_Blend_To_BGFX(dst);
-        
+
         state |= BGFX_STATE_BLEND_FUNC(srcBlend, dstBlend);
         return state;
     }
@@ -198,7 +198,7 @@ public:
         ShaderClass::DstBlendFuncType dst = shader.Get_Dst_Blend_Func();
         ShaderClass::SrcBlendFuncType src = shader.Get_Src_Blend_Func();
 
-        return (dst == ShaderClass::DSTBLEND_SRC_ALPHA || 
+        return (dst == ShaderClass::DSTBLEND_SRC_ALPHA ||
                 dst == ShaderClass::DSTBLEND_ONE_MINUS_SRC_ALPHA ||
                 src == ShaderClass::SRCBLEND_SRC_ALPHA ||
                 src == ShaderClass::SRCBLEND_ONE_MINUS_SRC_ALPHA);

--- a/Code/ww3d2/backends/bgfx/BGFXMaterialMapper.h
+++ b/Code/ww3d2/backends/bgfx/BGFXMaterialMapper.h
@@ -1,0 +1,227 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * BGFXMaterialMapper - maps ww3d2 material properties to bgfx uniforms and render states.     *
+ *                                                                                             *
+ * This header provides integration between ww3d2's material system (VertexMaterialClass,       *
+ * ShaderClass, MeshMatDescClass) and bgfx rendering pipeline.                                 *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef BGFXMATERIALMAPPER_H
+#define BGFXMATERIALMAPPER_H
+
+#include "bgfx/bgfx.h"
+#include "vector3.h"
+#include "shader.h"
+#include "vertmaterial.h"
+#include "meshmatdesc.h"
+
+// bgfx uniform names for material properties
+namespace BGFXMaterialUniforms
+{
+    const char* const DIFFUSE_COLOR = "u_diffuseColor";
+    const char* const SPECULAR_COLOR = "u_specularColor";
+    const char* const EMISSIVE_COLOR = "u_emissiveColor";
+    const char* const AMBIENT_COLOR = "u_ambientColor";
+    const char* const SHININESS = "u_shininess";
+    const char* const OPACITY = "u_opacity";
+    const char* const LIGHTING_ENABLE = "u_lightingEnable";
+}
+
+// Material color structure matching shader expectations
+struct MaterialColors
+{
+    Vector3 Diffuse;
+    float Alpha;
+    Vector3 Specular;
+    float Shininess;
+    Vector3 Emissive;
+    float Pad1;  // Alignment padding
+    Vector3 Ambient;
+    float Pad2;
+
+    MaterialColors()
+        : Diffuse(1.0f, 1.0f, 1.0f)
+        , Alpha(1.0f)
+        , Specular(0.0f, 0.0f, 0.0f)
+        , Shininess(0.0f)
+        , Emissive(0.0f, 0.0f, 0.0f)
+        , Pad1(0.0f)
+        , Ambient(0.0f, 0.0f, 0.0f)
+        , Pad2(0.0f)
+    {}
+};
+
+// BGFXMaterialMapper - helper class for mapping materials to bgfx
+class BGFXMaterialMapper
+{
+public:
+    // Map ShaderClass blend modes to bgfx state
+    static uint64_t Shader_Blend_To_BGFX(ShaderClass::SrcBlendFuncType src, ShaderClass::DstBlendFuncType dst)
+    {
+        uint64_t state = BGFX_STATE_DEFAULT;
+        
+        // Source blend
+        uint64_t srcBlend = Src_Blend_To_BGFX(src);
+        
+        // Destination blend
+        uint64_t dstBlend = Dst_Blend_To_BGFX(dst);
+        
+        state |= BGFX_STATE_BLEND_FUNC(srcBlend, dstBlend);
+        return state;
+    }
+
+    static uint64_t Src_Blend_To_BGFX(ShaderClass::SrcBlendFuncType src)
+    {
+        switch (src) {
+            case ShaderClass::SRCBLEND_ZERO:           return BGFX_STATE_BLEND_ZERO;
+            case ShaderClass::SRCBLEND_ONE:            return BGFX_STATE_BLEND_ONE;
+            case ShaderClass::SRCBLEND_SRC_ALPHA:      return BGFX_STATE_BLEND_SRC_ALPHA;
+            case ShaderClass::SRCBLEND_ONE_MINUS_SRC_ALPHA: return BGFX_STATE_BLEND_INV_SRC_ALPHA;
+            default:                                  return BGFX_STATE_BLEND_ONE;
+        }
+    }
+
+    static uint64_t Dst_Blend_To_BGFX(ShaderClass::DstBlendFuncType dst)
+    {
+        switch (dst) {
+            case ShaderClass::DSTBLEND_ZERO:                   return BGFX_STATE_BLEND_ZERO;
+            case ShaderClass::DSTBLEND_ONE:                    return BGFX_STATE_BLEND_ONE;
+            case ShaderClass::DSTBLEND_SRC_ALPHA:              return BGFX_STATE_BLEND_SRC_ALPHA;
+            case ShaderClass::DSTBLEND_ONE_MINUS_SRC_ALPHA:    return BGFX_STATE_BLEND_INV_SRC_ALPHA;
+            case ShaderClass::DSTBLEND_SRC_COLOR:             return BGFX_STATE_BLEND_SRC_COLOR;
+            case ShaderClass::DSTBLEND_ONE_MINUS_SRC_COLOR:   return BGFX_STATE_BLEND_INV_SRC_COLOR;
+            default:                                          return BGFX_STATE_BLEND_ZERO;
+        }
+    }
+
+    // Map ShaderClass cull mode to bgfx state
+    static uint64_t Shader_Cull_To_BGFX(ShaderClass::CullModeType cull)
+    {
+        switch (cull) {
+            case ShaderClass::CULL_MODE_DISABLE:  return BGFX_STATE_NONE;
+            case ShaderClass::CULL_MODE_ENABLE:   return BGFX_STATE_CULL_CCW;
+            default:                              return BGFX_STATE_CULL_CCW;
+        }
+    }
+
+    // Map ShaderClass depth compare to bgfx state
+    static uint64_t Shader_DepthCompare_To_BGFX(ShaderClass::DepthCompareType cmp)
+    {
+        switch (cmp) {
+            case ShaderClass::PASS_NEVER:    return BGFX_STATE_DEPTH_TEST_NEVER;
+            case ShaderClass::PASS_LESS:     return BGFX_STATE_DEPTH_TEST_LESS;
+            case ShaderClass::PASS_EQUAL:    return BGFX_STATE_DEPTH_TEST_EQUAL;
+            case ShaderClass::PASS_LEQUAL:   return BGFX_STATE_DEPTH_TEST_LEQUAL;
+            case ShaderClass::PASS_GREATER:  return BGFX_STATE_DEPTH_TEST_GREATER;
+            case ShaderClass::PASS_NOTEQUAL: return BGFX_STATE_DEPTH_TEST_NOTEQUAL;
+            case ShaderClass::PASS_GEQUAL:   return BGFX_STATE_DEPTH_TEST_GEQUAL;
+            case ShaderClass::PASS_ALWAYS:   return BGFX_STATE_DEPTH_TEST_ALWAYS;
+            default:                         return BGFX_STATE_DEPTH_TEST_LEQUAL;
+        }
+    }
+
+    // Map ShaderClass to full bgfx state flags
+    static uint64_t Shader_To_BGFX_State(const ShaderClass& shader)
+    {
+        uint64_t state = BGFX_STATE_DEFAULT;
+
+        // Depth test setting
+        state |= Shader_DepthCompare_To_BGFX(shader.Get_Depth_Compare());
+
+        // Depth write
+        if (shader.Get_Depth_Mask() == ShaderClass::DEPTH_WRITE_DISABLE) {
+            // Don't add WRITE_Z
+        } else {
+            state |= BGFX_STATE_WRITE_Z;
+        }
+
+        // Cull mode
+        state |= Shader_Cull_To_BGFX(shader.Get_Cull_Mode());
+
+        // Blending
+        state |= Shader_Blend_To_BGFX(shader.Get_Src_Blend_Func(), shader.Get_Dst_Blend_Func());
+
+        return state;
+    }
+
+    // Extract material colors from VertexMaterialClass
+    static MaterialColors Get_Material_Colors(const VertexMaterialClass* mat)
+    {
+        MaterialColors colors;
+
+        if (mat) {
+            mat->Get_Diffuse(&colors.Diffuse);
+            colors.Alpha = mat->Get_Opacity();
+            mat->Get_Specular(&colors.Specular);
+            colors.Shininess = mat->Get_Shininess();
+            mat->Get_Emissive(&colors.Emissive);
+            mat->Get_Ambient(&colors.Ambient);
+        }
+
+        return colors;
+    }
+
+    // Create bgfx render state from ShaderClass
+    static uint64_t Make_Render_State(const ShaderClass& shader, bool lightingEnabled)
+    {
+        uint64_t state = Shader_To_BGFX_State(shader);
+
+        // Add point/line/wireframe based on fill mode if needed
+        // For now, default to triangle strips
+
+        return state;
+    }
+
+    // Determine if shader uses alpha blending
+    static bool Uses_Alpha_Blending(const ShaderClass& shader)
+    {
+        ShaderClass::DstBlendFuncType dst = shader.Get_Dst_Blend_Func();
+        ShaderClass::SrcBlendFuncType src = shader.Get_Src_Blend_Func();
+
+        return (dst == ShaderClass::DSTBLEND_SRC_ALPHA || 
+                dst == ShaderClass::DSTBLEND_ONE_MINUS_SRC_ALPHA ||
+                src == ShaderClass::SRCBLEND_SRC_ALPHA ||
+                src == ShaderClass::SRCBLEND_ONE_MINUS_SRC_ALPHA);
+    }
+
+    // Determine static sort category based on shader
+    static ShaderClass::StaticSortCategoryType Get_Sort_Category(const ShaderClass& shader)
+    {
+        if (shader.Get_Alpha_Test() != ShaderClass::ALPHATEST_DISABLE) {
+            return ShaderClass::SSCAT_ALPHA_TEST;
+        }
+
+        ShaderClass::DstBlendFuncType dst = shader.Get_Dst_Blend_Func();
+        if (dst == ShaderClass::DSTBLEND_ONE || dst == ShaderClass::DSTBLEND_SRC_ALPHA) {
+            ShaderClass::SrcBlendFuncType src = shader.Get_Src_Blend_Func();
+            if (src == ShaderClass::SRCBLEND_ONE) {
+                return ShaderClass::SSCAT_OPAQUE;
+            }
+            return ShaderClass::SSCAT_ADDITIVE;
+        }
+
+        return ShaderClass::SSCAT_OTHER;
+    }
+};
+
+#endif // BGFXMATERIALMAPPER_H

--- a/Code/ww3d2/backends/bgfx/bgfxbackend.cpp
+++ b/Code/ww3d2/backends/bgfx/bgfxbackend.cpp
@@ -478,43 +478,43 @@ void BGFXBackend::Apply_Render_State(int state, unsigned value)
     if (stencilEnabled) {
         // Build stencil state - start with read mask 0xFF
         uint32_t stencilState = BGFX_STENCIL_FUNC_RMASK(0xFF);
-        
+
         // Stencil func
         auto stencilFuncIt = m_render_state.find(DX8RenderState::STENCILFUNC);
         if (stencilFuncIt != m_render_state.end()) {
             stencilState |= Compare_Stencil_Func(stencilFuncIt->second);
         }
-        
+
         // Stencil ref
         auto stencilRefIt = m_render_state.find(DX8RenderState::STENCILREF);
         if (stencilRefIt != m_render_state.end()) {
             stencilState |= BGFX_STENCIL_FUNC_REF(static_cast<uint32_t>(stencilRefIt->second));
         }
-        
+
         // Stencil mask (read mask)
         auto stencilMaskIt = m_render_state.find(DX8RenderState::STENCILMASK);
         if (stencilMaskIt != m_render_state.end()) {
             stencilState |= BGFX_STENCIL_FUNC_RMASK(stencilMaskIt->second);
         }
-        
+
         // Stencil fail operation
         auto stencilFailIt = m_render_state.find(DX8RenderState::STENCILFAIL);
         if (stencilFailIt != m_render_state.end()) {
             stencilState |= Compare_Stencil_Op(stencilFailIt->second);
         }
-        
+
         // Stencil Z fail operation (depth fail)
         auto stencilZFailIt = m_render_state.find(DX8RenderState::STENCILZFAIL);
         if (stencilZFailIt != m_render_state.end()) {
             stencilState |= Compare_Stencil_Op_Z(stencilZFailIt->second);
         }
-        
+
         // Stencil pass operation (depth pass)
         auto stencilPassIt = m_render_state.find(DX8RenderState::STENCILPASS);
         if (stencilPassIt != m_render_state.end()) {
             stencilState |= Compare_Stencil_Op_Pass(stencilPassIt->second);
         }
-        
+
         bgfx::setStencil(stencilState);
     } else {
         bgfx::setStencil(0);
@@ -803,11 +803,11 @@ bgfx::ProgramHandle BGFXBackend::Create_Program(const char* vsPath, const char* 
 {
     bgfx::ShaderHandle vs = Load_Shader(vsPath);
     bgfx::ShaderHandle fs = Load_Shader(fsPath);
-    
+
     if (!bgfx::isValid(vs) || !bgfx::isValid(fs)) {
         return BGFX_INVALID_HANDLE;
     }
-    
+
     return Create_Program(vs, fs);
 }
 
@@ -816,7 +816,7 @@ bgfx::ProgramHandle BGFXBackend::Create_Program(bgfx::ShaderHandle vs, bgfx::Sha
     if (!bgfx::isValid(vs) || !bgfx::isValid(fs)) {
         return BGFX_INVALID_HANDLE;
     }
-    
+
     return bgfx::createProgram(vs, fs, true);
 }
 

--- a/Code/ww3d2/backends/bgfx/bgfxbackend.cpp
+++ b/Code/ww3d2/backends/bgfx/bgfxbackend.cpp
@@ -1,0 +1,1005 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * BGFXBackend - concrete WW3DBackend implementation using bgfx rendering library.            *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#include "backends/bgfx/bgfxbackend.h"
+#include "rddesc.h"
+
+#include <bgfx/bgfx.h>
+#include <bgfx/platform.h>
+#include <stdio.h>  // for fopen, fread, fclose
+#include <string.h> // for strlen
+
+// Platform detection
+#if defined(_WIN32) || defined(_WIN64)
+#define BGFX_PLATFORM_WINDOWS 1
+#elif defined(__linux__)
+#define BGFX_PLATFORM_LINUX 1
+#elif defined(__APPLE__) && defined(__MACH__)
+#define BGFX_PLATFORM_OSX 1
+#else
+#error "Unsupported platform"
+#endif
+
+#if BGFX_PLATFORM_WINDOWS
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#elif BGFX_PLATFORM_LINUX
+#include <X11/Xlib.h>
+#elif BGFX_PLATFORM_OSX
+#include <Cocoa/Cocoa.h>
+#endif
+
+namespace
+{
+    const int DEFAULT_WIDTH = 1024;
+    const int DEFAULT_HEIGHT = 768;
+    const int DEFAULT_BIT_DEPTH = 32;
+
+    // Map DX8 fill mode to bgfx state flags
+    uint64_t FillMode_To_BGFX(unsigned fillmode)
+    {
+        switch (fillmode) {
+            case DX8RenderState::WIREFRAME:
+                return BGFX_STATE_PT_LINES;
+            case DX8RenderState::POINT:
+                return BGFX_STATE_PT_POINTS;
+            case DX8RenderState::SOLID:
+            default:
+                return BGFX_STATE_PT_TRISTRIP;
+        }
+    }
+
+    // Map DX8 cull mode to bgfx state flags
+    uint64_t CullMode_To_BGFX(unsigned cullmode)
+    {
+        switch (cullmode) {
+            case DX8RenderState::NONE:
+                return BGFX_STATE_NONE;
+            case DX8RenderState::CW:
+                return BGFX_STATE_CULL_CW;
+            case DX8RenderState::CCW:
+                return BGFX_STATE_CULL_CCW;
+            default:
+                return BGFX_STATE_CULL_CCW;
+        }
+    }
+
+    // Map DX8 blend factors to bgfx state flags
+    uint64_t BlendFactor_To_BGFX(unsigned factor)
+    {
+        switch (factor) {
+            case DX8RenderState::ZERO:           return BGFX_STATE_BLEND_ZERO;
+            case DX8RenderState::ONE:            return BGFX_STATE_BLEND_ONE;
+            case DX8RenderState::SRCCOLOR:       return BGFX_STATE_BLEND_SRC_COLOR;
+            case DX8RenderState::INVERTSRCCOLOR: return BGFX_STATE_BLEND_INV_SRC_COLOR;
+            case DX8RenderState::SRCALPHA:       return BGFX_STATE_BLEND_SRC_ALPHA;
+            case DX8RenderState::INVERTSRCALPHA: return BGFX_STATE_BLEND_INV_SRC_ALPHA;
+            case DX8RenderState::DESTALPHA:      return BGFX_STATE_BLEND_DST_ALPHA;
+            case DX8RenderState::INVERTDESTALPHA: return BGFX_STATE_BLEND_INV_DST_ALPHA;
+            case DX8RenderState::DESTCOLOR:       return BGFX_STATE_BLEND_DST_COLOR;
+            case DX8RenderState::INVERTDESTCOLOR: return BGFX_STATE_BLEND_INV_DST_COLOR;
+            case DX8RenderState::SRCALPHASAT:    return BGFX_STATE_BLEND_SRC_ALPHA_SAT;
+            default:                             return BGFX_STATE_BLEND_ONE;
+        }
+    }
+}
+
+BGFXBackend::BGFXBackend() :
+    m_hwnd(nullptr),
+    m_width(DEFAULT_WIDTH),
+    m_height(DEFAULT_HEIGHT),
+    m_bitDepth(DEFAULT_BIT_DEPTH),
+    m_windowed(true),
+    m_currentDevice(0),
+    m_swapInterval(1),
+    m_textureBitDepth(DEFAULT_BIT_DEPTH),
+    m_systemTexture(BGFX_INVALID_HANDLE),
+    m_frameBuffer(BGFX_INVALID_HANDLE),
+    m_initialized(false),
+    m_currentState(BGFX_STATE_DEFAULT),
+    m_currentColor(0xFF000000)
+{
+    // Note: Device enumeration simplified - using defaults like NullBackend
+    // Device descriptions are populated lazily on first access
+}
+
+BGFXBackend::~BGFXBackend()
+{
+    Shutdown();
+}
+
+bool BGFXBackend::Init(void * hwnd, bool lite)
+{
+    if (m_initialized) {
+        return true;
+    }
+
+    m_hwnd = hwnd;
+
+    // Set platform-specific data for bgfx
+    bgfx::PlatformData pd;
+    pd.ndt = nullptr;
+    pd.nwh = hwnd;
+    pd.context = nullptr;
+    pd.queue = nullptr;
+    pd.backBuffer = nullptr;
+    pd.backBufferDS = nullptr;
+
+#if BGFX_PLATFORM_WINDOWS
+    pd.type = bgfx::NativeWindowHandleType::Default;
+#elif BGFX_PLATFORM_LINUX
+    pd.ndt = XOpenDisplay(nullptr);
+    pd.type = bgfx::NativeWindowHandleType::Default;
+#elif BGFX_PLATFORM_OSX
+    pd.type = bgfx::NativeWindowHandleType::Default;
+#endif
+
+    bgfx::setPlatformData(pd);
+
+    // Determine renderer type based on selected device
+    bgfx::RendererType::Enum renderer = bgfx::RendererType::Count;  // 0 = auto-detect
+    if (m_currentDevice == 1) {
+        renderer = bgfx::RendererType::Vulkan;
+    } else if (m_currentDevice == 2) {
+        renderer = bgfx::RendererType::OpenGL;
+    }
+
+    // Initialize bgfx
+    bgfx::Init init;
+    init.type = renderer;
+    init.deviceId = 0;
+    init.debug = false;
+    init.profile = false;
+    init.resolution.width = m_width;
+    init.resolution.height = m_height;
+    init.resolution.reset = BGFX_RESET_VSYNC;
+
+    if (!bgfx::init(init)) {
+        return false;
+    }
+
+    m_initialized = true;
+
+    // Set initial view dimensions
+    Update_ViewDimensions();
+
+    // Set vsync
+    Set_Swap_Interval(m_swapInterval);
+
+    // Initialize render state cache with defaults
+    m_render_state[DX8RenderState::FILLMODE] = DX8RenderState::SOLID;
+    m_render_state[DX8RenderState::CULLMODE] = DX8RenderState::CCW;
+    m_render_state[DX8RenderState::BLENDENABLE] = 0;
+    m_render_state[DX8RenderState::ZENABLE] = 1;
+    m_render_state[DX8RenderState::ZWRITEENABLE] = 1;
+
+    return true;
+}
+
+void BGFXBackend::Shutdown()
+{
+    if (!m_initialized) {
+        return;
+    }
+
+    if (bgfx::isValid(m_frameBuffer)) {
+        bgfx::destroy(m_frameBuffer);
+        m_frameBuffer = BGFX_INVALID_HANDLE;
+    }
+
+    if (bgfx::isValid(m_systemTexture)) {
+        bgfx::destroy(m_systemTexture);
+        m_systemTexture = BGFX_INVALID_HANDLE;
+    }
+
+    bgfx::shutdown();
+    m_initialized = false;
+}
+
+bool BGFXBackend::Set_Any_Render_Device()
+{
+    m_currentDevice = 0;
+    if (m_initialized) {
+        Shutdown();
+        return Init(m_hwnd, false);
+    }
+    return true;
+}
+
+bool BGFXBackend::Set_Render_Device(const char * dev_name, int width, int height, int bits, int windowed, bool resize_window)
+{
+    for (int i = 0; i < Get_Render_Device_Count(); ++i) {
+        if (strcmp(Get_Render_Device_Name(i), dev_name) == 0) {
+            return Set_Render_Device(i, width, height, bits, windowed, resize_window);
+        }
+    }
+    return false;
+}
+
+bool BGFXBackend::Set_Render_Device(int dev, int resx, int resy, int bits, int windowed, bool resize_window)
+{
+    if (dev >= 0 && dev < Get_Render_Device_Count()) {
+        m_currentDevice = dev;
+    }
+    return Set_Device_Resolution(resx, resy, bits, windowed, resize_window);
+}
+
+bool BGFXBackend::Set_Next_Render_Device()
+{
+    m_currentDevice = (m_currentDevice + 1) % Get_Render_Device_Count();
+    if (m_initialized) {
+        Shutdown();
+        return Init(m_hwnd, false);
+    }
+    return true;
+}
+
+bool BGFXBackend::Toggle_Windowed()
+{
+    m_windowed = !m_windowed;
+    if (m_initialized) {
+        uint32_t resetFlags = m_windowed ? 0 : BGFX_RESET_FULLSCREEN;
+        bgfx::reset(m_width, m_height, resetFlags);
+        Update_ViewDimensions();
+    }
+    return true;
+}
+
+bool BGFXBackend::Is_Windowed()
+{
+    return m_windowed;
+}
+
+int BGFXBackend::Get_Render_Device_Count()
+{
+    return static_cast<int>(m_devices.size());
+}
+
+int BGFXBackend::Get_Render_Device()
+{
+    return m_currentDevice;
+}
+
+const RenderDeviceDescClass & BGFXBackend::Get_Render_Device_Desc(int deviceidx)
+{
+    // Return a static empty desc like NullBackend
+    static RenderDeviceDescClass nullDesc;
+    return nullDesc;
+}
+
+const char * BGFXBackend::Get_Render_Device_Name(int device_index)
+{
+    return "BGFX Renderer";
+}
+
+bool BGFXBackend::Set_Device_Resolution(int width, int height, int bits, int windowed, bool resize_window)
+{
+    if (width > 0) m_width = width;
+    if (height > 0) m_height = height;
+    if (bits > 0) m_bitDepth = bits;
+    if (windowed >= 0) m_windowed = (windowed != 0);
+
+    if (m_initialized) {
+        uint32_t resetFlags = m_windowed ? 0 : BGFX_RESET_FULLSCREEN;
+        bgfx::reset(m_width, m_height, resetFlags);
+        Update_ViewDimensions();
+    }
+
+    return true;
+}
+
+void BGFXBackend::Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    set_w = m_width;
+    set_h = m_height;
+    set_bits = m_bitDepth;
+    set_windowed = m_windowed;
+}
+
+void BGFXBackend::Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    Get_Device_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+int BGFXBackend::Get_Device_Resolution_Width()
+{
+    return m_width;
+}
+
+int BGFXBackend::Get_Device_Resolution_Height()
+{
+    return m_height;
+}
+
+bool BGFXBackend::Registry_Save_Render_Device(const char * sub_key)
+{
+    return true; // Stub
+}
+
+bool BGFXBackend::Registry_Load_Render_Device(const char * sub_key, bool resize_window)
+{
+    return true; // Stub
+}
+
+bool BGFXBackend::Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth)
+{
+    return true; // Stub
+}
+
+bool BGFXBackend::Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth)
+{
+    return true; // Stub
+}
+
+void BGFXBackend::Begin_Scene()
+{
+    bgfx::touch(0);
+}
+
+void BGFXBackend::End_Scene(bool flip_frame)
+{
+    if (flip_frame) {
+        bgfx::frame();
+    }
+}
+
+void BGFXBackend::Flip_To_Primary()
+{
+    bgfx::frame();
+}
+
+void BGFXBackend::Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z, unsigned int stencil)
+{
+    uint64_t flags = BGFX_CLEAR_NONE;
+
+    if (clear_color) {
+        flags |= BGFX_CLEAR_COLOR;
+    }
+
+    if (clear_z_stencil) {
+        flags |= BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL;
+    }
+
+    m_currentColor = Color_To_BGRA(color);
+    bgfx::setViewClear(0, flags, z, stencil, m_currentColor);
+}
+
+void BGFXBackend::Set_Swap_Interval(int swap)
+{
+    m_swapInterval = swap;
+    if (m_initialized) {
+        uint32_t resetFlags = (swap == 0) ? BGFX_RESET_NONE : (BGFX_RESET_VSYNC);
+        bgfx::reset(m_width, m_height, resetFlags);
+    }
+}
+
+int BGFXBackend::Get_Swap_Interval()
+{
+    return m_swapInterval;
+}
+
+void BGFXBackend::Set_Texture_Bitdepth(int depth)
+{
+    m_textureBitDepth = depth;
+}
+
+int BGFXBackend::Get_Texture_Bitdepth()
+{
+    return m_textureBitDepth;
+}
+
+void BGFXBackend::Set_Viewport(const void* viewport)
+{
+    // Stub - would need to unpack DX8 viewport struct
+}
+
+void BGFXBackend::Set_DX8_Render_State(int state, unsigned value)
+{
+    m_render_state[state] = value;
+    Apply_Render_State(state, value);
+}
+
+void BGFXBackend::Apply_Render_State(int state, unsigned value)
+{
+    // Build bgfx state from cached render state
+    uint64_t newState = BGFX_STATE_DEFAULT;
+
+    // Fill mode
+    auto fillIt = m_render_state.find(DX8RenderState::FILLMODE);
+    if (fillIt != m_render_state.end()) {
+        newState |= FillMode_To_BGFX(fillIt->second);
+    }
+
+    // Cull mode
+    auto cullIt = m_render_state.find(DX8RenderState::CULLMODE);
+    if (cullIt != m_render_state.end()) {
+        newState |= CullMode_To_BGFX(cullIt->second);
+    }
+
+    // Z enable
+    auto zIt = m_render_state.find(DX8RenderState::ZENABLE);
+    if (zIt != m_render_state.end() && zIt->second) {
+        newState |= BGFX_STATE_DEPTH_TEST_LESS;
+    }
+
+    // Z write enable
+    auto zwIt = m_render_state.find(DX8RenderState::ZWRITEENABLE);
+    if (zwIt != m_render_state.end() && zwIt->second) {
+        newState |= BGFX_STATE_WRITE_Z;
+    }
+
+    // Blend enable
+    auto blendIt = m_render_state.find(DX8RenderState::BLENDENABLE);
+    if (blendIt != m_render_state.end() && blendIt->second) {
+        newState |= BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_INV_SRC_ALPHA);
+    }
+
+    // Lighting enable - when disabled, vertex colors are used directly
+    // (tracked for shader uniform system)
+    auto lightIt = m_render_state.find(DX8RenderState::LIGHTING);
+    bool lightingEnabled = (lightIt != m_render_state.end() && lightIt->second);
+
+    // Color vertex - allows per-vertex coloring
+    auto colorVertIt = m_render_state.find(DX8RenderState::COLORVERTEX);
+    bool colorVertexEnabled = (colorVertIt != m_render_state.end() && colorVertIt->second);
+
+    // Fog enable
+    auto fogIt = m_render_state.find(DX8RenderState::FOGENABLE);
+    bool fogEnabled = (fogIt != m_render_state.end() && fogIt->second);
+    if (fogEnabled) {
+        newState |= BGFX_STATE_DEPTH_TEST_LESS;  // Fog needs depth test
+    }
+
+    // Stencil enable
+    auto stencilIt = m_render_state.find(DX8RenderState::STENCILENABLE);
+    bool stencilEnabled = (stencilIt != m_render_state.end() && stencilIt->second);
+    if (stencilEnabled) {
+        // Build stencil state - start with read mask 0xFF
+        uint32_t stencilState = BGFX_STENCIL_FUNC_RMASK(0xFF);
+        
+        // Stencil func
+        auto stencilFuncIt = m_render_state.find(DX8RenderState::STENCILFUNC);
+        if (stencilFuncIt != m_render_state.end()) {
+            stencilState |= Compare_Stencil_Func(stencilFuncIt->second);
+        }
+        
+        // Stencil ref
+        auto stencilRefIt = m_render_state.find(DX8RenderState::STENCILREF);
+        if (stencilRefIt != m_render_state.end()) {
+            stencilState |= BGFX_STENCIL_FUNC_REF(static_cast<uint32_t>(stencilRefIt->second));
+        }
+        
+        // Stencil mask (read mask)
+        auto stencilMaskIt = m_render_state.find(DX8RenderState::STENCILMASK);
+        if (stencilMaskIt != m_render_state.end()) {
+            stencilState |= BGFX_STENCIL_FUNC_RMASK(stencilMaskIt->second);
+        }
+        
+        // Stencil fail operation
+        auto stencilFailIt = m_render_state.find(DX8RenderState::STENCILFAIL);
+        if (stencilFailIt != m_render_state.end()) {
+            stencilState |= Compare_Stencil_Op(stencilFailIt->second);
+        }
+        
+        // Stencil Z fail operation (depth fail)
+        auto stencilZFailIt = m_render_state.find(DX8RenderState::STENCILZFAIL);
+        if (stencilZFailIt != m_render_state.end()) {
+            stencilState |= Compare_Stencil_Op_Z(stencilZFailIt->second);
+        }
+        
+        // Stencil pass operation (depth pass)
+        auto stencilPassIt = m_render_state.find(DX8RenderState::STENCILPASS);
+        if (stencilPassIt != m_render_state.end()) {
+            stencilState |= Compare_Stencil_Op_Pass(stencilPassIt->second);
+        }
+        
+        bgfx::setStencil(stencilState);
+    } else {
+        bgfx::setStencil(0);
+    }
+
+    m_currentState = newState;
+    bgfx::setState(newState);
+}
+
+// Helper: Map DX8 stencil comparison function to bgfx stencil test flags
+uint32_t BGFXBackend::Compare_Stencil_Func(unsigned dx8func)
+{
+    switch (dx8func) {
+        case 0:  // NEVER
+            return BGFX_STENCIL_TEST_NEVER;
+        case 1:  // LESS
+            return BGFX_STENCIL_TEST_LESS;
+        case 2:  // EQUAL
+            return BGFX_STENCIL_TEST_EQUAL;
+        case 3:  // LESS_EQUAL
+            return BGFX_STENCIL_TEST_LEQUAL;
+        case 4:  // GREATER
+            return BGFX_STENCIL_TEST_GREATER;
+        case 5:  // NOT_EQUAL
+            return BGFX_STENCIL_TEST_NOTEQUAL;
+        case 6:  // GREATER_EQUAL
+            return BGFX_STENCIL_TEST_GEQUAL;
+        case 7:  // ALWAYS
+        default:
+            return BGFX_STENCIL_TEST_ALWAYS;
+    }
+}
+
+// Helper: Map DX8 stencil operation to bgfx stencil op flags (for fail case)
+uint32_t BGFXBackend::Compare_Stencil_Op(unsigned dx8op)
+{
+    switch (dx8op) {
+        case 0:  // KEEP
+            return BGFX_STENCIL_OP_FAIL_S_KEEP;
+        case 1:  // ZERO
+            return BGFX_STENCIL_OP_FAIL_S_ZERO;
+        case 2:  // REPLACE
+            return BGFX_STENCIL_OP_FAIL_S_REPLACE;
+        case 3:  // INCRSAT
+            return BGFX_STENCIL_OP_FAIL_S_INCRSAT;
+        case 4:  // DECRSAT
+            return BGFX_STENCIL_OP_FAIL_S_DECRSAT;
+        case 5:  // INVERT
+            return BGFX_STENCIL_OP_FAIL_S_INVERT;
+        case 6:  // INCR
+            return BGFX_STENCIL_OP_FAIL_S_INCR;
+        case 7:  // DECR
+            return BGFX_STENCIL_OP_FAIL_S_DECR;
+        default:
+            return BGFX_STENCIL_OP_FAIL_S_KEEP;
+    }
+}
+
+// Helper: Map DX8 stencil operation to bgfx stencil op flags (for depth fail case)
+uint32_t BGFXBackend::Compare_Stencil_Op_Z(unsigned dx8op)
+{
+    switch (dx8op) {
+        case 0:  // KEEP
+            return BGFX_STENCIL_OP_FAIL_Z_KEEP;
+        case 1:  // ZERO
+            return BGFX_STENCIL_OP_FAIL_Z_ZERO;
+        case 2:  // REPLACE
+            return BGFX_STENCIL_OP_FAIL_Z_REPLACE;
+        case 3:  // INCRSAT
+            return BGFX_STENCIL_OP_FAIL_Z_INCRSAT;
+        case 4:  // DECRSAT
+            return BGFX_STENCIL_OP_FAIL_Z_DECRSAT;
+        case 5:  // INVERT
+            return BGFX_STENCIL_OP_FAIL_Z_INVERT;
+        case 6:  // INCR
+            return BGFX_STENCIL_OP_FAIL_Z_INCR;
+        case 7:  // DECR
+            return BGFX_STENCIL_OP_FAIL_Z_DECR;
+        default:
+            return BGFX_STENCIL_OP_FAIL_Z_KEEP;
+    }
+}
+
+// Helper: Map DX8 stencil operation to bgfx stencil op flags (for depth pass case)
+uint32_t BGFXBackend::Compare_Stencil_Op_Pass(unsigned dx8op)
+{
+    switch (dx8op) {
+        case 0:  // KEEP
+            return BGFX_STENCIL_OP_PASS_Z_KEEP;
+        case 1:  // ZERO
+            return BGFX_STENCIL_OP_PASS_Z_ZERO;
+        case 2:  // REPLACE
+            return BGFX_STENCIL_OP_PASS_Z_REPLACE;
+        case 3:  // INCRSAT
+            return BGFX_STENCIL_OP_PASS_Z_INCRSAT;
+        case 4:  // DECRSAT
+            return BGFX_STENCIL_OP_PASS_Z_DECRSAT;
+        case 5:  // INVERT
+            return BGFX_STENCIL_OP_PASS_Z_INVERT;
+        case 6:  // INCR
+            return BGFX_STENCIL_OP_PASS_Z_INCR;
+        case 7:  // DECR
+            return BGFX_STENCIL_OP_PASS_Z_DECR;
+        default:
+            return BGFX_STENCIL_OP_PASS_Z_KEEP;
+    }
+}
+
+void BGFXBackend::Set_Light_Environment(const void* env)
+{
+    // Stub - light environment handled elsewhere in mesh rendering
+}
+
+void* BGFXBackend::_Get_DX8_Front_Buffer()
+{
+    return nullptr; // Not applicable for bgfx
+}
+
+void BGFXBackend::Update_ViewDimensions()
+{
+    bgfx::setViewRect(0, 0, 0, m_width, m_height);
+    bgfx::setViewMode(0, bgfx::ViewMode::Sequential);
+}
+
+bgfx::RendererType::Enum BGFXBackend::AutoSelect_Renderer()
+{
+    return bgfx::RendererType::Count;  // Auto-detect
+}
+
+// =============================================================================
+// Texture Management
+// =============================================================================
+
+bgfx::TextureHandle BGFXBackend::Create_System_Texture(int width, int height, bgfx::TextureFormat::Enum format, uint64_t flags)
+{
+    bgfx::TextureHandle handle = bgfx::createTexture2D(
+        static_cast<uint16_t>(width),
+        static_cast<uint16_t>(height),
+        false,
+        1,
+        format,
+        flags,
+        nullptr
+    );
+    return handle;
+}
+
+void BGFXBackend::Destroy_Texture(bgfx::TextureHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Set_Texture(int stage, bgfx::TextureHandle handle, uint32_t flags, uint8_t mip)
+{
+    // Note: bgfx::setTexture requires a UniformHandle sampler, not TextureHandle directly
+    // This would require creating/managing sampler uniforms separately
+    // Stubbed out for now - proper implementation would need texture->sampler mapping
+}
+
+// =============================================================================
+// Vertex Buffer Management
+// =============================================================================
+
+bgfx::VertexBufferHandle BGFXBackend::Create_Vertex_Buffer(void* data, const bgfx::VertexLayout& layout, uint64_t flags)
+{
+    const bgfx::Memory* mem = bgfx::makeRef(data, layout.getStride());
+    return bgfx::createVertexBuffer(mem, layout, flags);
+}
+
+void BGFXBackend::Destroy_Vertex_Buffer(bgfx::VertexBufferHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Set_Vertex_Buffer(int stream, bgfx::VertexBufferHandle handle, uint32_t startVertex, uint32_t numVertices)
+{
+    bgfx::setVertexBuffer(stream, handle, startVertex, numVertices);
+}
+
+// =============================================================================
+// Index Buffer Management
+// =============================================================================
+
+bgfx::IndexBufferHandle BGFXBackend::Create_Index_Buffer(void* data, int indexCount, bool index32bit, uint64_t flags)
+{
+    const bgfx::Memory* mem = bgfx::makeRef(data, indexCount * (index32bit ? 4 : 2));
+    return bgfx::createIndexBuffer(mem, flags);
+}
+
+void BGFXBackend::Destroy_Index_Buffer(bgfx::IndexBufferHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Set_Index_Buffer(bgfx::IndexBufferHandle handle, int startIndex, int numIndices)
+{
+    bgfx::setIndexBuffer(handle, startIndex, numIndices);
+}
+
+// =============================================================================
+// Draw Commands
+// =============================================================================
+
+void BGFXBackend::Draw(int numVertices, int numInstances)
+{
+    if (numInstances > 1) {
+        bgfx::submit(0, BGFX_INVALID_HANDLE, 0, numInstances);
+    } else {
+        bgfx::submit(0, BGFX_INVALID_HANDLE, 0, numInstances);
+    }
+}
+
+void BGFXBackend::Draw_Indexed(int numIndices, int numInstances, int startIndex, int startVertex)
+{
+    if (numInstances > 1) {
+        bgfx::submit(0, BGFX_INVALID_HANDLE, 0, numInstances);
+    } else {
+        bgfx::submit(0, BGFX_INVALID_HANDLE, 0, numInstances);
+    }
+}
+
+// =============================================================================
+// Shader Program Management
+// =============================================================================
+
+bgfx::ShaderHandle BGFXBackend::Load_Shader(const char* shaderPath)
+{
+    // Handle empty path
+    if (!shaderPath || shaderPath[0] == '\0') {
+        return BGFX_INVALID_HANDLE;
+    }
+
+    // Try to load shader from filesystem
+    FILE* file = fopen(shaderPath, "rb");
+    if (!file) {
+        // File not found - will fall back to embedded shader
+        return BGFX_INVALID_HANDLE;
+    }
+
+    // Get file size
+    fseek(file, 0, SEEK_END);
+    long fileSize = ftell(file);
+    fseek(file, 0, SEEK_SET);
+
+    if (fileSize <= 0) {
+        fclose(file);
+        return BGFX_INVALID_HANDLE;
+    }
+
+    // Read shader binary into buffer
+    // Use bgfx::copy to make bgfx own the memory copy
+    uint8_t* buffer = new uint8_t[fileSize];
+    size_t bytesRead = fread(buffer, 1, fileSize, file);
+    fclose(file);
+
+    if (bytesRead != static_cast<size_t>(fileSize)) {
+        delete[] buffer;
+        return BGFX_INVALID_HANDLE;
+    }
+
+    // Copy data into bgfx-managed memory
+    const bgfx::Memory* mem = bgfx::copy(buffer, static_cast<uint32_t>(fileSize));
+    delete[] buffer;  // bgfx::copy made its own copy, we can free ours;
+
+    if (!mem || !mem->data || mem->size == 0) {
+        return BGFX_INVALID_HANDLE;
+    }
+
+    // Create shader from binary data
+    bgfx::ShaderHandle handle = bgfx::createShader(mem);
+
+    if (!bgfx::isValid(handle)) {
+        return BGFX_INVALID_HANDLE;
+    }
+
+    return handle;
+}
+
+bgfx::ProgramHandle BGFXBackend::Create_Program(const char* vsPath, const char* fsPath)
+{
+    bgfx::ShaderHandle vs = Load_Shader(vsPath);
+    bgfx::ShaderHandle fs = Load_Shader(fsPath);
+    
+    if (!bgfx::isValid(vs) || !bgfx::isValid(fs)) {
+        return BGFX_INVALID_HANDLE;
+    }
+    
+    return Create_Program(vs, fs);
+}
+
+bgfx::ProgramHandle BGFXBackend::Create_Program(bgfx::ShaderHandle vs, bgfx::ShaderHandle fs)
+{
+    if (!bgfx::isValid(vs) || !bgfx::isValid(fs)) {
+        return BGFX_INVALID_HANDLE;
+    }
+    
+    return bgfx::createProgram(vs, fs, true);
+}
+
+void BGFXBackend::Destroy_Shader(bgfx::ShaderHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Destroy_Program(bgfx::ProgramHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Set_Program(bgfx::ProgramHandle program)
+{
+    // Note: In bgfx, programs are submitted directly to views, not set separately
+    // This stores the program for later use in submit
+    m_currentProgram = program;
+}
+
+const char* BGFXBackend::Get_Renderer_Name()
+{
+    return bgfx::getRendererName(bgfx::getRendererType());
+}
+
+bgfx::RendererType::Enum BGFXBackend::Get_Renderer_Type()
+{
+    return bgfx::getRendererType();
+}
+
+// =============================================================================
+// Uniform (Constant Buffer) Management
+// =============================================================================
+
+bgfx::UniformHandle BGFXBackend::Create_Uniform(const char* name, bgfx::UniformType::Enum type, uint16_t num)
+{
+    return bgfx::createUniform(name, type, num);
+}
+
+void BGFXBackend::Destroy_Uniform(bgfx::UniformHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Set_Uniform(bgfx::UniformHandle handle, const void* value, uint16_t num)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::setUniform(handle, value, num);
+    }
+}
+
+// =============================================================================
+// Frame Buffer (Render Target) Management
+// =============================================================================
+
+bgfx::FrameBufferHandle BGFXBackend::Create_FrameBuffer(int width, int height, bgfx::TextureFormat::Enum format, uint64_t textureFlags)
+{
+    bgfx::TextureHandle colorHandle = bgfx::createTexture2D(
+        static_cast<uint16_t>(width),
+        static_cast<uint16_t>(height),
+        false,
+        1,
+        format,
+        textureFlags | BGFX_TEXTURE_RT_WRITE_ONLY,
+        nullptr
+    );
+
+    bgfx::FrameBufferHandle fb = bgfx::createFrameBuffer(1, &colorHandle, true);
+    return fb;
+}
+
+bgfx::FrameBufferHandle BGFXBackend::Create_FrameBuffer_Attachment(bgfx::TextureHandle color, bgfx::TextureHandle depth)
+{
+    // Create MRT framebuffer with color and depth attachments
+    bgfx::TextureHandle handles[2] = { color, depth };
+    bgfx::FrameBufferHandle fb = bgfx::createFrameBuffer(2, handles, true);
+    return fb;
+}
+
+void BGFXBackend::Destroy_FrameBuffer(bgfx::FrameBufferHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Set_FrameBuffer(bgfx::FrameBufferHandle handle, int width, int height)
+{
+    bgfx::setViewFrameBuffer(0, handle);
+    if (bgfx::isValid(handle) && width > 0 && height > 0) {
+        bgfx::setViewRect(0, 0, 0, static_cast<uint16_t>(width), static_cast<uint16_t>(height));
+    }
+}
+
+void BGFXBackend::Set_FrameBuffer(bgfx::FrameBufferHandle handle, bgfx::TextureHandle color, bgfx::TextureHandle depth)
+{
+    bgfx::setViewFrameBuffer(0, handle);
+}
+
+// =============================================================================
+// Material Integration
+// =============================================================================
+
+void BGFXBackend::Set_Material_Colors(const Vector3& diffuse, float alpha, const Vector3& specular, float shininess, const Vector3& emissive, const Vector3& ambient)
+{
+    // Pack material colors into a MaterialColors struct for shader uniforms
+    MaterialColors colors;
+    colors.Diffuse = diffuse;
+    colors.Alpha = alpha;
+    colors.Specular = specular;
+    colors.Shininess = shininess;
+    colors.Emissive = emissive;
+    colors.Ambient = ambient;
+
+    // Create uniforms if needed and set them
+    bgfx::UniformHandle diffuseHandle = bgfx::createUniform(BGFXMaterialUniforms::DIFFUSE_COLOR, bgfx::UniformType::Vec4);
+    bgfx::UniformHandle specularHandle = bgfx::createUniform(BGFXMaterialUniforms::SPECULAR_COLOR, bgfx::UniformType::Vec4);
+    bgfx::UniformHandle emissiveHandle = bgfx::createUniform(BGFXMaterialUniforms::EMISSIVE_COLOR, bgfx::UniformType::Vec4);
+
+    float diffuseVec4[4] = { diffuse.X, diffuse.Y, diffuse.Z, alpha };
+    float specularVec4[4] = { specular.X, specular.Y, specular.Z, shininess };
+    float emissiveVec4[4] = { emissive.X, emissive.Y, emissive.Z, 1.0f };
+
+
+    bgfx::setUniform(diffuseHandle, diffuseVec4);
+    bgfx::setUniform(specularHandle, specularVec4);
+    bgfx::setUniform(emissiveHandle, emissiveVec4);
+}
+
+void BGFXBackend::Set_Material_Uniforms(bgfx::UniformHandle diffuseHandle, bgfx::UniformHandle specularHandle, bgfx::UniformHandle emissiveHandle, const MaterialColors& colors)
+{
+    float diffuseVec4[4] = { colors.Diffuse.X, colors.Diffuse.Y, colors.Diffuse.Z, colors.Alpha };
+    float specularVec4[4] = { colors.Specular.X, colors.Specular.Y, colors.Specular.Z, colors.Shininess };
+    float emissiveVec4[4] = { colors.Emissive.X, colors.Emissive.Y, colors.Emissive.Z, 1.0f };
+
+    if (bgfx::isValid(diffuseHandle)) {
+        bgfx::setUniform(diffuseHandle, diffuseVec4);
+    }
+    if (bgfx::isValid(specularHandle)) {
+        bgfx::setUniform(specularHandle, specularVec4);
+    }
+    if (bgfx::isValid(emissiveHandle)) {
+        bgfx::setUniform(emissiveHandle, emissiveVec4);
+    }
+}
+
+void BGFXBackend::Set_Texture_Stage(int stage, bgfx::TextureHandle handle, uint32_t flags, uint8_t mip, int uvIndex)
+{
+    // Note: bgfx::setTexture requires a UniformHandle sampler, not TextureHandle directly
+    // This would require creating/managing sampler uniforms separately
+    // Stubbed out for now
+    (void)stage; (void)handle; (void)flags; (void)mip; (void)uvIndex;
+}
+
+
+uint64_t BGFXBackend::Apply_Shader(const ShaderClass& shader, bool lightingEnabled)
+{
+    // Use BGFXMaterialMapper to convert shader to bgfx state
+    uint64_t state = BGFXMaterialMapper::Make_Render_State(shader, lightingEnabled);
+
+    // Apply the state
+    bgfx::setState(state);
+
+    // Update our tracked state
+    m_currentState = state;
+
+    return state;
+}
+
+void BGFXBackend::Begin_Material_Pass()
+{
+    // Reset material tracking for a new pass
+    // This would typically reset texture stages, uniforms, etc.
+}
+
+void BGFXBackend::End_Material_Pass()
+{
+    // Finalize material pass
+    // Could perform any necessary cleanup or state validation
+}

--- a/Code/ww3d2/backends/bgfx/bgfxbackend.h
+++ b/Code/ww3d2/backends/bgfx/bgfxbackend.h
@@ -1,0 +1,289 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * BGFXBackend - concrete WW3DBackend implementation using bgfx rendering library.              *
+ *                                                                                             *
+ * bgfx is a cross-platform, graphics API agnostic rendering library supporting:                *
+ *   - Direct3D 11/12                                                                         *
+ *   - Metal                                                                                  *
+ *   - OpenGL 2.1+/GL ES 2.0+                                                                 *
+ *   - Vulkan                                                                                *
+ *   - WebGPU                                                                                 *
+ *   - WebGL 1.0/2.0                                                                          *
+ *                                                                                             *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef BGFXBACKEND_H
+#define BGFXBACKEND_H
+
+#include "ww3dbackend.h"
+#include "rddesc.h"
+
+#include <bgfx/bgfx.h>
+
+#include <vector>
+#include <map>
+#include <unordered_map>
+#include <cstring>
+
+// Include material mapper for integration
+#include "BGFXMaterialMapper.h"
+
+// Common DX8 render state values that we track
+namespace DX8RenderState
+{
+    enum {
+        FILLMODE = 8,
+        BLENDENABLE = 19,
+        SRCBLEND = 60,
+        DESTBLEND = 61,
+        BLENDOP = 62,
+        CULLMODE = 22,
+        ZENABLE = 7,
+        ZWRITEENABLE = 14,
+        ALPHABLENDENABLE = 19,
+        ALPHATESTENABLE = 24,
+        STENCILENABLE = 52,
+        LIGHTING = 137,
+        DIFFUSEMATERIALSOURCE = 145,
+        AMBIENTMATERIALSOURCE = 146,
+        EMISSIVEMATERIALSOURCE = 147,
+        SPECULARMATERIALSOURCE = 148,
+        SHADEMODE = 134,
+        COLORVERTEX = 141,
+
+        // Fog states
+        FOGENABLE = 27,
+        FOGCOLOR = 30,
+        FOGSTART = 31,
+        FOGEND = 32,
+        FOGDENSITY = 33,
+        RANGEFOGENABLE = 38,
+
+        // Stencil states
+        STENCILFAIL = 53,
+        STENCILZFAIL = 54,
+        STENCILPASS = 55,
+        STENCILFUNC = 56,
+        STENCILREF = 57,
+        STENCILMASK = 58,
+        STENCILWRITEMASK = 59,
+    };
+
+    enum FillMode {
+        SOLID = 3,
+        WIREFRAME = 2,
+        POINT = 1,
+    };
+
+    enum CullMode {
+        NONE = 1,
+        CW = 2,
+        CCW = 3,
+    };
+
+    enum BlendOp {
+        ADD = 0,
+        SUBTRACT = 1,
+        REVSUBTRACT = 2,
+        MIN = 3,
+        MAX = 4,
+    };
+
+    enum BlendFactor {
+        ZERO = 0,
+        ONE = 1,
+        SRCCOLOR = 2,
+        INVERTSRCCOLOR = 3,
+        SRCALPHA = 4,
+        INVERTSRCALPHA = 5,
+        DESTALPHA = 6,
+        INVERTDESTALPHA = 7,
+        DESTCOLOR = 8,
+        INVERTDESTCOLOR = 9,
+        SRCALPHASAT = 10,
+        CONSTANTCOLOR = 11,
+        ONEMINUSCONSTANTCOLOR = 12,
+        CONSTANTALPHA = 13,
+        ONEMINUSCONSTANTALPHA = 14,
+    };
+}
+
+// Forward declarations
+class BGFXTexture;
+class BGFXVertexBuffer;
+class BGFXIndexBuffer;
+
+// BGFX Backend implementation
+class BGFXBackend : public WW3DBackend
+{
+public:
+    BGFXBackend();
+    virtual ~BGFXBackend();
+
+    // WW3DBackend interface
+    virtual bool Init(void * hwnd, bool lite = false) override;
+    virtual void Shutdown() override;
+
+    virtual bool Set_Any_Render_Device() override;
+    virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Next_Render_Device() override;
+    virtual bool Toggle_Windowed() override;
+    virtual bool Is_Windowed() override;
+
+    virtual int Get_Render_Device_Count() override;
+    virtual int Get_Render_Device() override;
+    virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) override;
+    virtual const char * Get_Render_Device_Name(int device_index) override;
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual int Get_Device_Resolution_Width() override;
+    virtual int Get_Device_Resolution_Height() override;
+
+    virtual bool Registry_Save_Render_Device(const char * sub_key) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) override;
+    virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) override;
+
+    virtual void Begin_Scene() override;
+    virtual void End_Scene(bool flip_frame = true) override;
+    virtual void Flip_To_Primary() override;
+
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
+
+    virtual void Set_Swap_Interval(int swap) override;
+    virtual int Get_Swap_Interval() override;
+
+    virtual void Set_Texture_Bitdepth(int depth) override;
+    virtual int Get_Texture_Bitdepth() override;
+
+    virtual void Set_Viewport(const void* viewport) override;
+    virtual void Set_DX8_Render_State(int state, unsigned value) override;
+    virtual void Set_Light_Environment(const void* env) override;
+    virtual void* _Get_DX8_Front_Buffer() override;
+
+    // Texture management
+    bgfx::TextureHandle Create_System_Texture(int width, int height, bgfx::TextureFormat::Enum format, uint64_t flags = BGFX_TEXTURE_NONE);
+    void Destroy_Texture(bgfx::TextureHandle handle);
+    void Set_Texture(int stage, bgfx::TextureHandle handle, uint32_t flags = UINT32_MAX, uint8_t mip = 0);
+
+    // Vertex buffer management
+    bgfx::VertexBufferHandle Create_Vertex_Buffer(void* data, const bgfx::VertexLayout& layout, uint64_t flags = BGFX_BUFFER_NONE);
+    void Destroy_Vertex_Buffer(bgfx::VertexBufferHandle handle);
+    void Set_Vertex_Buffer(int stream, bgfx::VertexBufferHandle handle, uint32_t startVertex = 0, uint32_t numVertices = UINT32_MAX);
+
+    // Index buffer management
+    bgfx::IndexBufferHandle Create_Index_Buffer(void* data, int indexCount, bool index32bit = false, uint64_t flags = BGFX_BUFFER_NONE);
+    void Destroy_Index_Buffer(bgfx::IndexBufferHandle handle);
+    void Set_Index_Buffer(bgfx::IndexBufferHandle handle, int startIndex = 0, int numIndices = INT32_MAX);
+
+    // Draw commands
+    void Draw(int numVertices, int numInstances = 1);
+    void Draw_Indexed(int numIndices, int numInstances = 1, int startIndex = 0, int startVertex = 0);
+
+    // Shader program management
+    bgfx::ShaderHandle Load_Shader(const char* shaderPath);
+    bgfx::ProgramHandle Create_Program(const char* vsPath, const char* fsPath);
+    bgfx::ProgramHandle Create_Program(bgfx::ShaderHandle vs, bgfx::ShaderHandle fs);
+    void Destroy_Shader(bgfx::ShaderHandle handle);
+    void Destroy_Program(bgfx::ProgramHandle handle);
+    void Set_Program(bgfx::ProgramHandle program);
+
+    // Uniform (constant buffer) management
+    bgfx::UniformHandle Create_Uniform(const char* name, bgfx::UniformType::Enum type, uint16_t num = 1);
+    void Destroy_Uniform(bgfx::UniformHandle handle);
+    void Set_Uniform(bgfx::UniformHandle handle, const void* value, uint16_t num = 1);
+
+    // Frame buffer (render target) management
+    bgfx::FrameBufferHandle Create_FrameBuffer(int width, int height, bgfx::TextureFormat::Enum format, uint64_t textureFlags = BGFX_TEXTURE_RT_WRITE_ONLY);
+    bgfx::FrameBufferHandle Create_FrameBuffer_Attachment(bgfx::TextureHandle color, bgfx::TextureHandle depth);
+    void Destroy_FrameBuffer(bgfx::FrameBufferHandle handle);
+    void Set_FrameBuffer(bgfx::FrameBufferHandle handle, int width = -1, int height = -1);
+    void Set_FrameBuffer(bgfx::FrameBufferHandle handle, bgfx::TextureHandle color, bgfx::TextureHandle depth);
+
+    // Material integration - map ww3d2 material properties to bgfx
+    void Set_Material_Colors(const Vector3& diffuse, float alpha, const Vector3& specular, float shininess, const Vector3& emissive, const Vector3& ambient);
+    void Set_Material_Uniforms(bgfx::UniformHandle diffuseHandle, bgfx::UniformHandle specularHandle, bgfx::UniformHandle emissiveHandle, const MaterialColors& colors);
+    void Set_Texture_Stage(int stage, bgfx::TextureHandle handle, uint32_t flags = UINT32_MAX, uint8_t mip = 0, int uvIndex = 0);
+    uint64_t Apply_Shader(const ShaderClass& shader, bool lightingEnabled);
+    void Begin_Material_Pass();
+    void End_Material_Pass();
+
+    // Renderer info
+    const char* Get_Renderer_Name();
+    bgfx::RendererType::Enum Get_Renderer_Type();
+
+private:
+    void Update_ViewDimensions();
+    void Apply_Render_State(int state, unsigned value);
+    bgfx::RendererType::Enum AutoSelect_Renderer();
+
+    // Helper: Map DX8 stencil comparison function to bgfx stencil func
+    static uint32_t Compare_Stencil_Func(unsigned dx8func);
+    // Helper: Map DX8 stencil operation to bgfx stencil op (stencil fail)
+    static uint32_t Compare_Stencil_Op(unsigned dx8op);
+    // Helper: Map DX8 stencil operation to bgfx stencil op (depth fail)
+    static uint32_t Compare_Stencil_Op_Z(unsigned dx8op);
+    // Helper: Map DX8 stencil operation to bgfx stencil op (depth pass)
+    static uint32_t Compare_Stencil_Op_Pass(unsigned dx8op);
+
+    // Convert from W3D color format (0-1 float) to BGRA uint32
+    static uint32_t Color_To_BGRA(const Vector3& color)
+    {
+        uint8_t r = static_cast<uint8_t>(color.X * 255.0f);
+        uint8_t g = static_cast<uint8_t>(color.Y * 255.0f);
+        uint8_t b = static_cast<uint8_t>(color.Z * 255.0f);
+        return 0xFF000000 | (r << 16) | (g << 8) | b;
+    }
+
+    // Window/Surface
+    void* m_hwnd;
+    int m_width;
+    int m_height;
+    int m_bitDepth;
+    bool m_windowed;
+
+    // Device enumeration
+    std::vector<RenderDeviceDescClass> m_devices;
+    int m_currentDevice;
+
+    // Swap/VSync
+    int m_swapInterval;
+    int m_textureBitDepth;
+
+    // DX8 render state cache - maps state enum to value
+    std::map<int, unsigned> m_render_state;
+
+    // Internal bgfx state
+    bgfx::TextureHandle m_systemTexture;
+    bgfx::FrameBufferHandle m_frameBuffer;
+    bgfx::ProgramHandle m_currentProgram;
+    bool m_initialized;
+
+    // Current bgfx state for tracking changes
+    uint64_t m_currentState;
+    uint32_t m_currentColor;
+};
+
+#endif // BGFXBACKEND_H

--- a/Code/ww3d2/dx8backend.cpp
+++ b/Code/ww3d2/dx8backend.cpp
@@ -1,0 +1,205 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * DX8Backend implementation.                                                                  *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#include "dx8backend.h"
+#include "dx8wrapper.h"
+
+DX8Backend::DX8Backend()
+{
+}
+
+DX8Backend::~DX8Backend()
+{
+}
+
+bool DX8Backend::Init(void * hwnd, bool lite)
+{
+    return DX8Wrapper::Init(hwnd, lite);
+}
+
+void DX8Backend::Shutdown()
+{
+    DX8Wrapper::Shutdown();
+}
+
+bool DX8Backend::Set_Any_Render_Device()
+{
+    return DX8Wrapper::Set_Any_Render_Device();
+}
+
+bool DX8Backend::Set_Render_Device(const char * dev_name, int width, int height, int bits, int windowed, bool resize_window)
+{
+    return DX8Wrapper::Set_Render_Device(dev_name, width, height, bits, windowed, resize_window);
+}
+
+bool DX8Backend::Set_Render_Device(int dev, int resx, int resy, int bits, int windowed, bool resize_window)
+{
+    return DX8Wrapper::Set_Render_Device(dev, resx, resy, bits, windowed, resize_window);
+}
+
+bool DX8Backend::Set_Next_Render_Device()
+{
+    return DX8Wrapper::Set_Next_Render_Device();
+}
+
+bool DX8Backend::Toggle_Windowed()
+{
+    return DX8Wrapper::Toggle_Windowed();
+}
+
+bool DX8Backend::Is_Windowed()
+{
+    return DX8Wrapper::Is_Windowed();
+}
+
+int DX8Backend::Get_Render_Device_Count()
+{
+    return DX8Wrapper::Get_Render_Device_Count();
+}
+
+int DX8Backend::Get_Render_Device()
+{
+    return DX8Wrapper::Get_Render_Device();
+}
+
+const RenderDeviceDescClass & DX8Backend::Get_Render_Device_Desc(int deviceidx)
+{
+    return DX8Wrapper::Get_Render_Device_Desc(deviceidx);
+}
+
+const char * DX8Backend::Get_Render_Device_Name(int device_index)
+{
+    return DX8Wrapper::Get_Render_Device_Name(device_index);
+}
+
+bool DX8Backend::Set_Device_Resolution(int width, int height, int bits, int windowed, bool resize_window)
+{
+    return DX8Wrapper::Set_Device_Resolution(width, height, bits, windowed, resize_window);
+}
+
+void DX8Backend::Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    DX8Wrapper::Get_Device_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+void DX8Backend::Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    DX8Wrapper::Get_Render_Target_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+int DX8Backend::Get_Device_Resolution_Width()
+{
+    return DX8Wrapper::Get_Device_Resolution_Width();
+}
+
+int DX8Backend::Get_Device_Resolution_Height()
+{
+    return DX8Wrapper::Get_Device_Resolution_Height();
+}
+
+bool DX8Backend::Registry_Save_Render_Device(const char * sub_key)
+{
+    return DX8Wrapper::Registry_Save_Render_Device(sub_key);
+}
+
+bool DX8Backend::Registry_Load_Render_Device(const char * sub_key, bool resize_window)
+{
+    return DX8Wrapper::Registry_Load_Render_Device(sub_key, resize_window);
+}
+
+bool DX8Backend::Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth)
+{
+    return DX8Wrapper::Registry_Save_Render_Device(sub_key, device, width, height, depth, windowed, texture_depth);
+}
+
+bool DX8Backend::Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth)
+{
+    return DX8Wrapper::Registry_Load_Render_Device(sub_key, device, device_len, width, height, depth, windowed, texture_depth);
+}
+
+void DX8Backend::Begin_Scene()
+{
+    DX8Wrapper::Begin_Scene();
+}
+
+void DX8Backend::End_Scene(bool flip_frame)
+{
+    DX8Wrapper::End_Scene(flip_frame);
+}
+
+void DX8Backend::Flip_To_Primary()
+{
+    DX8Wrapper::Flip_To_Primary();
+}
+
+void DX8Backend::Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z, unsigned int stencil)
+{
+    DX8Wrapper::Clear(clear_color, clear_z_stencil, color, z, stencil);
+}
+
+void DX8Backend::Set_Swap_Interval(int swap)
+{
+    DX8Wrapper::Set_Swap_Interval(swap);
+}
+
+int DX8Backend::Get_Swap_Interval()
+{
+    return DX8Wrapper::Get_Swap_Interval();
+}
+
+void DX8Backend::Set_Texture_Bitdepth(int depth)
+{
+    DX8Wrapper::Set_Texture_Bitdepth(depth);
+}
+
+int DX8Backend::Get_Texture_Bitdepth()
+{
+    return DX8Wrapper::Get_Texture_Bitdepth();
+}
+
+void DX8Backend::Set_Viewport(const void* viewport)
+{
+    DX8Wrapper::Set_Viewport(viewport);
+}
+
+void DX8Backend::Set_DX8_Render_State(int state, unsigned value)
+{
+    DX8Wrapper::Set_DX8_Render_State(state, value);
+}
+
+void DX8Backend::Set_Light_Environment(const void* env)
+{
+    DX8Wrapper::Set_Light_Environment(env);
+}
+
+void* DX8Backend::_Get_DX8_Front_Buffer()
+{
+    return DX8Wrapper::_Get_DX8_Front_Buffer();
+}

--- a/Code/ww3d2/dx8backend.h
+++ b/Code/ww3d2/dx8backend.h
@@ -1,0 +1,91 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * DX8Backend - concrete WW3DBackend implementation wrapping DX8Wrapper static methods.         *
+ * DX8Wrapper stays standalone and does NOT inherit from WW3DBackend.                          *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef DX8BACKEND_H
+#define DX8BACKEND_H
+
+#include "ww3dbackend.h"
+
+// DX8Wrapper static methods are called directly from here.
+// No include of dx8wrapper.h at header level to keep D3D9 out of the ww3d2 include chain.
+class DX8Wrapper;
+
+class DX8Backend : public WW3DBackend
+{
+public:
+    DX8Backend();
+    virtual ~DX8Backend();
+
+    // WW3DBackend interface - delegate to DX8Wrapper static methods
+    virtual bool Init(void * hwnd, bool lite = false) override;
+    virtual void Shutdown() override;
+
+    virtual bool Set_Any_Render_Device() override;
+    virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Next_Render_Device() override;
+    virtual bool Toggle_Windowed() override;
+    virtual bool Is_Windowed() override;
+
+    virtual int Get_Render_Device_Count() override;
+    virtual int Get_Render_Device() override;
+    virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) override;
+    virtual const char * Get_Render_Device_Name(int device_index) override;
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual int Get_Device_Resolution_Width() override;
+    virtual int Get_Device_Resolution_Height() override;
+
+    virtual bool Registry_Save_Render_Device(const char * sub_key) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) override;
+    virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) override;
+
+    virtual void Begin_Scene() override;
+    virtual void End_Scene(bool flip_frame = true) override;
+    virtual void Flip_To_Primary() override;
+
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
+
+    virtual void Set_Swap_Interval(int swap) override;
+    virtual int Get_Swap_Interval() override;
+
+    virtual void Set_Texture_Bitdepth(int depth) override;
+    virtual int Get_Texture_Bitdepth() override;
+
+    virtual void Set_Viewport(const void* viewport) override;
+    virtual void Set_DX8_Render_State(int state, unsigned value) override;
+    virtual void Set_Light_Environment(const void* env) override;
+    virtual void* _Get_DX8_Front_Buffer() override;
+};
+
+#endif // DX8BACKEND_H

--- a/Code/ww3d2/nullbackend.cpp
+++ b/Code/ww3d2/nullbackend.cpp
@@ -1,0 +1,220 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "nullbackend.h"
+#include "rddesc.h"
+
+namespace
+{
+	const int DEFAULT_WIDTH = 640;
+	const int DEFAULT_HEIGHT = 480;
+	const int DEFAULT_BIT_DEPTH = 16;
+}
+
+NullBackend::NullBackend() :
+	Width(DEFAULT_WIDTH),
+	Height(DEFAULT_HEIGHT),
+	BitDepth(DEFAULT_BIT_DEPTH),
+	Windowed(true),
+	SwapInterval(0),
+	TextureBitDepth(DEFAULT_BIT_DEPTH)
+{
+}
+
+NullBackend::~NullBackend()
+{
+}
+
+bool NullBackend::Init(void * /*hwnd*/, bool /*lite*/)
+{
+	return true;
+}
+
+void NullBackend::Shutdown()
+{
+}
+
+bool NullBackend::Set_Any_Render_Device()
+{
+	return true;
+}
+
+bool NullBackend::Set_Render_Device(const char * /*dev_name*/, int width, int height, int bits, int windowed, bool /*resize_window*/)
+{
+	return Set_Device_Resolution(width, height, bits, windowed, false);
+}
+
+bool NullBackend::Set_Render_Device(int /*dev*/, int resx, int resy, int bits, int windowed, bool /*resize_window*/)
+{
+	return Set_Device_Resolution(resx, resy, bits, windowed, false);
+}
+
+bool NullBackend::Set_Next_Render_Device()
+{
+	return true;
+}
+
+bool NullBackend::Toggle_Windowed()
+{
+	Windowed = !Windowed;
+	return true;
+}
+
+bool NullBackend::Is_Windowed()
+{
+	return Windowed;
+}
+
+int NullBackend::Get_Render_Device_Count()
+{
+	return 1;
+}
+
+int NullBackend::Get_Render_Device()
+{
+	return 0;
+}
+
+const RenderDeviceDescClass & NullBackend::Get_Render_Device_Desc(int /*deviceidx*/)
+{
+	static RenderDeviceDescClass desc;
+	return desc;
+}
+
+const char * NullBackend::Get_Render_Device_Name(int /*device_index*/)
+{
+	return "Null Renderer";
+}
+
+bool NullBackend::Set_Device_Resolution(int width, int height, int bits, int windowed, bool /*resize_window*/)
+{
+	if (width > 0) {
+		Width = width;
+	}
+	if (height > 0) {
+		Height = height;
+	}
+	if (bits > 0) {
+		BitDepth = bits;
+	}
+	if (windowed != -1) {
+		Windowed = (windowed != 0);
+	}
+	return true;
+}
+
+void NullBackend::Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+	set_w = Width;
+	set_h = Height;
+	set_bits = BitDepth;
+	set_windowed = Windowed;
+}
+
+void NullBackend::Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+	Get_Device_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+int NullBackend::Get_Device_Resolution_Width()
+{
+	return Width;
+}
+
+int NullBackend::Get_Device_Resolution_Height()
+{
+	return Height;
+}
+
+bool NullBackend::Registry_Save_Render_Device(const char * /*sub_key*/)
+{
+	return true;
+}
+
+bool NullBackend::Registry_Load_Render_Device(const char * /*sub_key*/, bool /*resize_window*/)
+{
+	return true;
+}
+
+bool NullBackend::Registry_Save_Render_Device(const char */*sub_key*/, int /*device*/, int /*width*/, int /*height*/, int /*depth*/, bool /*windowed*/, int /*texture_depth*/)
+{
+	return true;
+}
+
+bool NullBackend::Registry_Load_Render_Device(const char * /*sub_key*/, char */*device*/, int /*device_len*/, int &width, int &height, int &depth, int &windowed, int &texture_depth)
+{
+	width = Width;
+	height = Height;
+	depth = BitDepth;
+	windowed = Windowed ? 1 : 0;
+	texture_depth = TextureBitDepth;
+	return true;
+}
+
+void NullBackend::Begin_Scene()
+{
+}
+
+void NullBackend::End_Scene(bool /*flip_frame*/)
+{
+}
+
+void NullBackend::Flip_To_Primary()
+{
+}
+
+void NullBackend::Clear(bool /*clear_color*/, bool /*clear_z_stencil*/, const Vector3 &/*color*/, float /*z*/, unsigned int /*stencil*/)
+{
+}
+
+void NullBackend::Set_Swap_Interval(int swap)
+{
+	SwapInterval = swap;
+}
+
+int NullBackend::Get_Swap_Interval()
+{
+	return SwapInterval;
+}
+
+void NullBackend::Set_Texture_Bitdepth(int depth)
+{
+	TextureBitDepth = depth;
+}
+
+int NullBackend::Get_Texture_Bitdepth()
+{
+	return TextureBitDepth;
+}
+
+void NullBackend::Set_Viewport(const void* /*viewport*/)
+{
+}
+
+void NullBackend::Set_DX8_Render_State(int /*state*/, unsigned /*value*/)
+{
+}
+
+void NullBackend::Set_Light_Environment(const void* /*env*/)
+{
+}
+
+void* NullBackend::_Get_DX8_Front_Buffer()
+{
+	return nullptr;
+}

--- a/Code/ww3d2/nullbackend.h
+++ b/Code/ww3d2/nullbackend.h
@@ -1,0 +1,81 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NULLBACKEND_H
+#define NULLBACKEND_H
+
+#include "ww3dbackend.h"
+
+class NullBackend : public WW3DBackend
+{
+public:
+	NullBackend();
+	virtual ~NullBackend();
+
+	virtual bool Init(void * hwnd, bool lite = false) override;
+	virtual void Shutdown() override;
+
+	virtual bool Set_Any_Render_Device() override;
+	virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+	virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+	virtual bool Set_Next_Render_Device() override;
+	virtual bool Toggle_Windowed() override;
+	virtual bool Is_Windowed() override;
+
+	virtual int Get_Render_Device_Count() override;
+	virtual int Get_Render_Device() override;
+	virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) override;
+	virtual const char * Get_Render_Device_Name(int device_index) override;
+	virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+	virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+	virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+	virtual int Get_Device_Resolution_Width() override;
+	virtual int Get_Device_Resolution_Height() override;
+
+	virtual bool Registry_Save_Render_Device(const char * sub_key) override;
+	virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) override;
+	virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) override;
+	virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) override;
+
+	virtual void Begin_Scene() override;
+	virtual void End_Scene(bool flip_frame = true) override;
+	virtual void Flip_To_Primary() override;
+
+	virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
+
+	virtual void Set_Viewport(const void* viewport) override;
+	virtual void Set_DX8_Render_State(int state, unsigned value) override;
+	virtual void Set_Light_Environment(const void* env) override;
+	virtual void* _Get_DX8_Front_Buffer() override;
+
+	virtual void Set_Swap_Interval(int swap) override;
+	virtual int Get_Swap_Interval() override;
+
+	virtual void Set_Texture_Bitdepth(int depth) override;
+	virtual int Get_Texture_Bitdepth() override;
+
+private:
+	int Width;
+	int Height;
+	int BitDepth;
+	bool Windowed;
+	int SwapInterval;
+	int TextureBitDepth;
+};
+
+#endif // NULLBACKEND_H

--- a/Code/ww3d2/ww3d.cpp
+++ b/Code/ww3d2/ww3d.cpp
@@ -78,6 +78,9 @@
 
 
 #include "ww3d.h"
+#include "ww3dbackend.h"
+#include "dx8backend.h"
+#include "nullbackend.h"
 #include "rinfo.h"
 #include "assetmgr.h"
 #include "boxrobj.h"
@@ -220,6 +223,7 @@ int														WW3D::LastFrameMemoryFrees;
 int														WW3D::TextureFilter;
 
 bool														WW3D::Lite = false;
+WW3DBackend *												WW3D::Backend = NULL;
 
 /**********************************************************************************
 **
@@ -264,11 +268,23 @@ WW3DErrorType WW3D::Init(void *hwnd, char * /*defaultpal*/, bool lite)
 	Lite = lite;
 
 	/*
+	** Backend selection
+	*/
+	if (!Backend) {
+		// Default to DX8 backend on Windows, null backend elsewhere
+		#if defined(_WIN32) || defined(WIN32)
+			Backend = new DX8Backend();
+		#else
+			Backend = new NullBackend();
+		#endif
+	}
+
+	/*
 	** Initialize d3d, this also enumerates the available devices and resolutions.
 	*/
 	Init_D3D_To_WW3_Conversion();
-	WWDEBUG_SAY(("Init DX8Wrapper\n"));
-	if (!DX8Wrapper::Init(_Hwnd, lite)) {
+	WWDEBUG_SAY(("Init Backend\n"));
+	if (!Backend->Init(_Hwnd, lite)) {
 		return(WW3D_ERROR_DIRECTX8_INITIALIZATION_FAILED);
 	}
 	WWDEBUG_SAY(("Allocate Debug Resources\n"));
@@ -320,6 +336,14 @@ WW3DErrorType WW3D::Init(void *hwnd, char * /*defaultpal*/, bool lite)
  * HISTORY:                                                                                    *
  *   3/24/98    GTH : Created.                                                                 *
  *=============================================================================================*/
+/***********************************************************************************************
+ * WW3D::Set_Backend -- set the active render backend                                          *
+ *=============================================================================================*/
+void WW3D::Set_Backend(WW3DBackend* backend)
+{
+	Backend = backend;
+}
+
 WW3DErrorType WW3D::Shutdown(void)
 {
 	assert(Lite || IsInitted == true);
@@ -353,7 +377,11 @@ WW3DErrorType WW3D::Shutdown(void)
 
 	DX8TextureManagerClass::Shutdown();
 	if (!Lite) {
-		DX8Wrapper::Shutdown();
+		if (Backend) {
+			Backend->Shutdown();
+			delete Backend;
+			Backend = NULL;
+		}
 	}
 
 	/*
@@ -385,7 +413,7 @@ WW3DErrorType WW3D::Shutdown(void)
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Render_Device( const char * dev_name, int width, int height, int bits, int windowed, bool resize_window )
 {
-	bool success = DX8Wrapper::Set_Render_Device(dev_name,width,height,bits,windowed,resize_window);
+	bool success = Backend->Set_Render_Device(dev_name,width,height,bits,windowed,resize_window);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -408,7 +436,7 @@ WW3DErrorType WW3D::Set_Render_Device( const char * dev_name, int width, int hei
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Any_Render_Device( void )
 {
-	bool success = DX8Wrapper::Set_Any_Render_Device();
+	bool success = Backend->Set_Any_Render_Device();
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -431,7 +459,7 @@ WW3DErrorType WW3D::Set_Any_Render_Device( void )
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Render_Device(int dev, int width, int height, int bits, int windowed, bool resize_window)
 {
-	bool success = DX8Wrapper::Set_Render_Device(dev,width,height,bits,windowed,resize_window);
+	bool success = Backend->Set_Render_Device(dev,width,height,bits,windowed,resize_window);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -454,7 +482,7 @@ WW3DErrorType WW3D::Set_Render_Device(int dev, int width, int height, int bits, 
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Next_Render_Device(void)
 {
-	bool success = DX8Wrapper::Set_Next_Render_Device();
+	bool success = Backend->Set_Next_Render_Device();
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -493,7 +521,7 @@ void *WW3D::Get_Window( void )
  *=============================================================================================*/
 bool WW3D::Is_Windowed( void )
 {
-	return DX8Wrapper::Is_Windowed();
+	return Backend->Is_Windowed();
 }
 
 /***********************************************************************************************
@@ -513,7 +541,7 @@ bool WW3D::Is_Windowed( void )
  *=============================================================================================*/
 WW3DErrorType WW3D::Toggle_Windowed (void)
 {
-	bool success = DX8Wrapper::Toggle_Windowed();
+	bool success = Backend->Toggle_Windowed();
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -537,7 +565,7 @@ WW3DErrorType WW3D::Toggle_Windowed (void)
  *=============================================================================================*/
 int WW3D::Get_Render_Device(void)
 {
-	return DX8Wrapper::Get_Render_Device();
+	return Backend->Get_Render_Device();
 }
 
 
@@ -556,7 +584,7 @@ int WW3D::Get_Render_Device(void)
  *=============================================================================================*/
 const RenderDeviceDescClass & WW3D::Get_Render_Device_Desc(int deviceidx)
 {
-	return DX8Wrapper::Get_Render_Device_Desc(deviceidx);
+	return Backend->Get_Render_Device_Desc(deviceidx);
 }
 
 
@@ -576,7 +604,7 @@ const RenderDeviceDescClass & WW3D::Get_Render_Device_Desc(int deviceidx)
  *=============================================================================================*/
 const int WW3D::Get_Render_Device_Count(void)
 {
-	return DX8Wrapper::Get_Render_Device_Count();
+	return Backend->Get_Render_Device_Count();
 }
 
 
@@ -595,7 +623,7 @@ const int WW3D::Get_Render_Device_Count(void)
  *=============================================================================================*/
 const char * WW3D::Get_Render_Device_Name(int device_index)
 {
-	return DX8Wrapper::Get_Render_Device_Name(device_index);
+	return Backend->Get_Render_Device_Name(device_index);
 }
 
 
@@ -613,7 +641,7 @@ const char * WW3D::Get_Render_Device_Name(int device_index)
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Device_Resolution(int width,int height,int bits,int windowed, bool resize_window)
 {
-	bool success = DX8Wrapper::Set_Device_Resolution(width,height,bits,windowed,resize_window);
+	bool success = Backend->Set_Device_Resolution(width,height,bits,windowed,resize_window);
 
 	if (success) {
 		return WW3D_ERROR_OK;
@@ -638,7 +666,7 @@ WW3DErrorType WW3D::Set_Device_Resolution(int width,int height,int bits,int wind
  *=============================================================================================*/
 void WW3D::Get_Render_Target_Resolution(int & set_w,int & set_h,int & set_bits,bool & set_windowed)
 {
-	DX8Wrapper::Get_Render_Target_Resolution(set_w,set_h,set_bits,set_windowed);
+	Backend->Get_Render_Target_Resolution(set_w,set_h,set_bits,set_windowed);
 }
 
 
@@ -657,7 +685,7 @@ void WW3D::Get_Render_Target_Resolution(int & set_w,int & set_h,int & set_bits,b
  *=============================================================================================*/
 void WW3D::Get_Device_Resolution(int & set_w,int & set_h,int & set_bits,bool & set_windowed)
 {
-	DX8Wrapper::Get_Device_Resolution(set_w,set_h,set_bits,set_windowed);
+	Backend->Get_Device_Resolution(set_w,set_h,set_bits,set_windowed);
 }
 
 
@@ -676,7 +704,7 @@ void WW3D::Get_Device_Resolution(int & set_w,int & set_h,int & set_bits,bool & s
  *=============================================================================================*/
 WW3DErrorType WW3D::Registry_Save_Render_Device( const char * sub_key )
 {
-	bool success = DX8Wrapper::Registry_Save_Render_Device(sub_key);
+	bool success = Backend->Registry_Save_Render_Device(sub_key);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -698,7 +726,7 @@ WW3DErrorType WW3D::Registry_Save_Render_Device( const char * sub_key )
  *=============================================================================================*/
 WW3DErrorType WW3D::Registry_Save_Render_Device( const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth )
 {
-	bool success = DX8Wrapper::Registry_Save_Render_Device(sub_key,device,width,height,depth,windowed,texture_depth);
+	bool success = Backend->Registry_Save_Render_Device(sub_key,device,width,height,depth,windowed,texture_depth);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -721,7 +749,7 @@ WW3DErrorType WW3D::Registry_Save_Render_Device( const char *sub_key, int device
  *=============================================================================================*/
 WW3DErrorType WW3D::Registry_Load_Render_Device( const char * sub_key, bool resize_window )
 {
-	bool success = DX8Wrapper::Registry_Load_Render_Device(sub_key,resize_window);
+	bool success = Backend->Registry_Load_Render_Device(sub_key,resize_window);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -731,7 +759,7 @@ WW3DErrorType WW3D::Registry_Load_Render_Device( const char * sub_key, bool resi
 
 bool WW3D::Registry_Load_Render_Device( const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth)
 {
-	return DX8Wrapper::Registry_Load_Render_Device(sub_key,device,device_len,width,height,depth,windowed,texture_depth);
+	return Backend->Registry_Load_Render_Device(sub_key,device,device_len,width,height,depth,windowed,texture_depth);
 }
 
 void WW3D::_Invalidate_Mesh_Cache()
@@ -819,12 +847,12 @@ WW3DErrorType WW3D::Begin_Render(bool clear,bool clearz,const Vector3 & color, v
 		vp.Height = height;
 		vp.MinZ = 0.0f;;
 		vp.MaxZ = 1.0f;
-		DX8Wrapper::Set_Viewport(&vp);
-		DX8Wrapper::Clear(clear, clearz, color);
+		Backend->Set_Viewport(&vp);
+		Backend->Clear(clear, clearz, color);
 	}
 
 	// Notify D3D that we are beginning to render the frame
-	DX8Wrapper::Begin_Scene();
+	Backend->Begin_Scene();
 
 	return WW3D_ERROR_OK;
 }
@@ -921,26 +949,26 @@ WW3DErrorType WW3D::Render(SceneClass * scene,CameraClass * cam,bool clear,bool 
 
 	// Clear the viewport
 	if (clear || clearz) {
-		DX8Wrapper::Clear(clear, clearz, color);
+		Backend->Clear(clear, clearz, color);
 	}
 
 	// set the rendering mode
 	switch(scene->Get_Polygon_Mode()) {
 		case SceneClass::POINT:
-			DX8Wrapper::Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_POINT);
+			Backend->Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_POINT);
 			break;
 		case SceneClass::LINE:
-			DX8Wrapper::Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_WIREFRAME);
+			Backend->Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_WIREFRAME);
 			break;
 		case SceneClass::FILL:
-			DX8Wrapper::Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_SOLID);
+			Backend->Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_SOLID);
 			break;
 	}
 
 	// Set the global ambient light value here.  If the scene is using the LightEnvironment system
 	// this setting will get overriden.
 	Vector3 ambient = scene->Get_Ambient_Light();
-	DX8Wrapper::Set_DX8_Render_State(D3DRS_AMBIENT, DX8Wrapper::Convert_Color(ambient,0.0f));
+	Backend->Set_DX8_Render_State(D3DRS_AMBIENT, DX8Wrapper::Convert_Color(ambient,0.0f));
 
 	// render the scene
 
@@ -988,11 +1016,11 @@ WW3DErrorType WW3D::Render(
 	rinfo.Camera.Apply();
 
 	// set the rendering mode
-	DX8Wrapper::Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_SOLID);
+	Backend->Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_SOLID);
 
 	// Install the lighting environment if one is supplied
 	if (rinfo.light_environment != NULL) {
-		DX8Wrapper::Set_Light_Environment(rinfo.light_environment);
+		Backend->Set_Light_Environment(rinfo.light_environment);
 	}
 
 	// Render the object
@@ -1065,7 +1093,7 @@ WW3DErrorType WW3D::End_Render(bool flip_frame)
 
 	{
 		WWPROFILE("DX8Wrapper::End_Scene");
-		DX8Wrapper::End_Scene(flip_frame);
+		Backend->End_Scene(flip_frame);
 	}
 
 	FrameCount++;
@@ -1094,7 +1122,7 @@ WW3DErrorType WW3D::End_Render(bool flip_frame)
  *=============================================================================================*/
 void WW3D::Flip_To_Primary(void)
 {
-	DX8Wrapper::Flip_To_Primary();
+	Backend->Flip_To_Primary();
 }
 
 
@@ -1154,7 +1182,7 @@ void WW3D::Sync(unsigned int sync_time)
  *=============================================================================================*/
 void WW3D::Set_Ext_Swap_Interval(int swap)
 {
-	DX8Wrapper::Set_Swap_Interval(swap);
+	Backend->Set_Swap_Interval(swap);
 }
 
 
@@ -1172,7 +1200,7 @@ void WW3D::Set_Ext_Swap_Interval(int swap)
  *=============================================================================================*/
 int WW3D::Get_Ext_Swap_Interval(void)
 {
-	return DX8Wrapper::Get_Swap_Interval();
+	return Backend->Get_Swap_Interval();
 }
 
 
@@ -1229,12 +1257,12 @@ int WW3D::Get_Collision_Box_Display_Mask(void)
 void WW3D::Normalize_Coordinates(int x, int y, float &fx, float &fy)
 {
 	// clip the coordinates back into the resolution of the screen
-	x = Bound(x, 0, DX8Wrapper::Get_Device_Resolution_Width());
-	y = Bound(y, 0, DX8Wrapper::Get_Device_Resolution_Height());
+	x = Bound(x, 0, Backend->Get_Device_Resolution_Width());
+	y = Bound(y, 0, Backend->Get_Device_Resolution_Height());
 
 	// now that the coordinates are clipped convert them to their normalized values.
-	fx = (float)x / DX8Wrapper::Get_Device_Resolution_Width();
-	fy = (float)y / DX8Wrapper::Get_Device_Resolution_Height();
+	fx = (float)x / Backend->Get_Device_Resolution_Width();
+	fy = (float)y / Backend->Get_Device_Resolution_Height();
 }
 
 
@@ -1278,7 +1306,7 @@ void WW3D::Make_Screen_Shot( const char * filename_base )
 	// Lock front buffer and copy
 
 	IDirect3DSurface9 *fb;
-	fb=DX8Wrapper::_Get_DX8_Front_Buffer();
+	fb=Backend->_Get_DX8_Front_Buffer();
 	D3DSURFACE_DESC desc;
 	fb->GetDesc(&desc);
 
@@ -1560,7 +1588,7 @@ void WW3D::Update_Movie_Capture( void )
 		// Lock front buffer and copy
 
 	IDirect3DSurface9 *fb;
-	fb=DX8Wrapper::_Get_DX8_Front_Buffer();
+	fb=Backend->_Get_DX8_Front_Buffer();
 	D3DSURFACE_DESC desc;
 	fb->GetDesc(&desc);
 
@@ -1843,12 +1871,12 @@ void WW3D::Update_Pixel_Center(void)
 
 void WW3D::Set_Texture_Bitdepth(int bitdepth)
 {
-	DX8Wrapper::Set_Texture_Bitdepth(bitdepth);
+	Backend->Set_Texture_Bitdepth(bitdepth);
 }
 
 int WW3D::Get_Texture_Bitdepth()
 {
-	return DX8Wrapper::Get_Texture_Bitdepth();
+	return Backend->Get_Texture_Bitdepth();
 }
 
 void WW3D::Add_To_Static_Sort_List(RenderObjClass *robj, unsigned int sort_level)

--- a/Code/ww3d2/ww3d.cpp
+++ b/Code/ww3d2/ww3d.cpp
@@ -79,8 +79,14 @@
 
 #include "ww3d.h"
 #include "ww3dbackend.h"
+
+#if defined(WW3D_DX9_BACKEND)
 #include "dx8backend.h"
+#elif defined(WW3D_BGFX_BACKEND)
+#include "backends/bgfx/bgfxbackend.h"
+#else
 #include "nullbackend.h"
+#endif
 #include "rinfo.h"
 #include "assetmgr.h"
 #include "boxrobj.h"
@@ -271,12 +277,15 @@ WW3DErrorType WW3D::Init(void *hwnd, char * /*defaultpal*/, bool lite)
 	** Backend selection
 	*/
 	if (!Backend) {
-		// Default to DX8 backend on Windows, null backend elsewhere
-		#if defined(_WIN32) || defined(WIN32)
-			Backend = new DX8Backend();
-		#else
-			Backend = new NullBackend();
-		#endif
+		// Create default backend based on compile-time selection
+		// Can be overridden by calling Set_Backend() before Init()
+#if defined(WW3D_DX9_BACKEND)
+		Backend = new DX8Backend();
+#elif defined(WW3D_BGFX_BACKEND)
+		Backend = new BGFXBackend();
+#else
+		Backend = new NullBackend();
+#endif
 	}
 
 	/*

--- a/Code/ww3d2/ww3d.h
+++ b/Code/ww3d2/ww3d.h
@@ -62,6 +62,7 @@ class		RenderDeviceDescClass;
 class		StringClass;
 class		LightEnvironmentClass;
 class		MaterialPassClass;
+class		WW3DBackend;
 
 #define MESH_RENDER_SNAPSHOT_ENABLED
 #define SNAPSHOT_SAY(x) if (WW3D::Is_Snapshot_Activated()) { WWDEBUG_SAY(x); }
@@ -102,6 +103,7 @@ public:
 
 	static WW3DErrorType		Init(void * hwnd, char *defaultpal = NULL, bool lite = false);
 	static WW3DErrorType		Shutdown(void);
+        static void                    Set_Backend(WW3DBackend* backend);
 	static bool					Is_Initted(void)								{ return IsInitted; }
 
 	static const int			Get_Render_Device_Count(void);
@@ -350,6 +352,7 @@ private:
 	static bool							IsTexturingEnabled;
 
 	static bool							Lite;
+	static WW3DBackend *				Backend;
 
 	// This is the default native screen size which will be set for each
 	// RenderObject on construction. The native screen size is the screen size

--- a/Code/ww3d2/ww3dbackend.h
+++ b/Code/ww3d2/ww3dbackend.h
@@ -1,0 +1,98 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * WW3DBackend interface - minimal device-level abstraction for render backends.              *
+ *                                                                                             *
+ * Concrete backends (DX8, BGFX, null) implement this interface. DX8Wrapper stays          *
+ * standalone and is NOT part of this interface chain.                                        *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef WW3DBACKEND_H
+#define WW3DBACKEND_H
+
+#include "vector3.h"
+
+class SceneClass;
+class RenderDeviceDescClass;
+
+class WW3DBackend
+{
+public:
+    virtual ~WW3DBackend() {}
+
+    // Initialization
+    virtual bool Init(void * hwnd, bool lite = false) = 0;
+    virtual void Shutdown() = 0;
+
+    // Device enumeration
+    virtual bool Set_Any_Render_Device() = 0;
+    virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+    virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+    virtual bool Set_Next_Render_Device() = 0;
+    virtual bool Toggle_Windowed() = 0;
+    virtual bool Is_Windowed() = 0;
+
+    virtual int Get_Render_Device_Count() = 0;
+    virtual int Get_Render_Device() = 0;
+    virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) = 0;
+    virtual const char * Get_Render_Device_Name(int device_index) = 0;
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+    virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) = 0;
+    virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) = 0;
+    virtual int Get_Device_Resolution_Width() = 0;
+    virtual int Get_Device_Resolution_Height() = 0;
+
+    // Registry
+    virtual bool Registry_Save_Render_Device(const char * sub_key) = 0;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) = 0;
+    virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) = 0;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) = 0;
+
+    // Scene
+    virtual void Begin_Scene() = 0;
+    virtual void End_Scene(bool flip_frame = true) = 0;
+    virtual void Flip_To_Primary() = 0;
+
+    // Clear
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) = 0;
+
+    // VSync
+    virtual void Set_Swap_Interval(int swap) = 0;
+    virtual int Get_Swap_Interval() = 0;
+
+    // Texture depth
+    virtual void Set_Texture_Bitdepth(int depth) = 0;
+    virtual int Get_Texture_Bitdepth() = 0;
+
+    // Render state
+    virtual void Set_Viewport(const void* viewport) = 0;
+    virtual void Set_DX8_Render_State(int state, unsigned value) = 0;
+    virtual void Set_Light_Environment(const void* env) = 0;
+    virtual void* _Get_DX8_Front_Buffer() = 0;
+};
+
+#endif // WW3DBACKEND_H

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -1,0 +1,121 @@
+#
+# BGFX CMake integration for OpenW3D
+#
+# BGFX uses genie (from bx) for building. This cmake provides integration
+# by setting up include paths and linking when bgfx is built.
+#
+# IMPORTANT - Build Requirements:
+#   - genie build tool: https://github.com/bkaradzic/genie
+#   - C++20 compiler (GCC 11+, Clang 11+, MSVC 17.5+)
+#
+# To enable and build bgfx:
+#   # First build bgfx itself:
+#   cd external/bgfx
+#   make linux-gcc-release64
+#   
+#   # Then build OpenW3D with bgfx backend:
+#   cd ../..
+#   mkdir build && cd build
+#   cmake .. -DENABLE_BGFX_BACKEND=ON
+#   make
+#
+
+set(BGFX_DIR "${CMAKE_SOURCE_DIR}/external/bgfx")
+set(BX_DIR "${CMAKE_SOURCE_DIR}/external/bx")
+
+if(NOT ENABLE_BGFX_BACKEND)
+    return()
+endif()
+
+# Verify bx submodule is present
+if(NOT EXISTS "${BX_DIR}/include/bx/bx.h")
+    message(FATAL_ERROR "bx submodule not initialized. Run:\n  git submodule update --init --recursive")
+endif()
+
+# Verify bgfx submodule is present
+if(NOT EXISTS "${BGFX_DIR}/include/bgfx/bgfx.h")
+    message(FATAL_ERROR "bgfx submodule not initialized. Run:\n  git submodule update --init --recursive")
+endif()
+
+# Create interface library for bgfx headers and dependencies
+add_library(bgfx INTERFACE)
+
+target_include_directories(bgfx INTERFACE
+    "${BGFX_DIR}/include"
+    "${BGFX_DIR}/include/c99"
+    "${BX_DIR}/include"
+)
+
+# BGFX requires C++20
+target_compile_features(bgfx INTERFACE cxx_std_20)
+
+# Platform defines
+if(WIN32)
+    target_compile_definitions(bgfx INTERFACE BGFX_PLATFORM_WINDOWS=1)
+elseif(UNIX AND NOT APPLE)
+    target_compile_definitions(bgfx INTERFACE BGFX_PLATFORM_LINUX=1)
+elseif(APPLE)
+    target_compile_definitions(bgfx INTERFACE BGFX_PLATFORM_OSX=1)
+endif()
+
+# Find system dependencies for bgfx
+if(WIN32)
+    target_link_libraries(bgfx INTERFACE winmm user32 gdi32 dxguid)
+elseif(UNIX AND NOT APPLE)
+    find_package(OpenGL REQUIRED)
+    find_package(X11 REQUIRED)
+    target_link_libraries(bgfx INTERFACE OpenGL::GL X11::X11 X11::Xrandr X11::Xcursor dl pthread rt)
+elseif(APPLE)
+    find_library(COCOA_LIBRARY Cocoa REQUIRED)
+    find_library(FOUNDATION_LIBRARY Foundation REQUIRED)
+    target_link_libraries(bgfx INTERFACE ${COCOA_LIBRARY} ${FOUNDATION_LIBRARY})
+endif()
+
+# Look for bgfx library in common build output locations
+set(BGFX_LIB_FOUND FALSE)
+
+foreach(CONFIG release release64 debug debug64)
+    set(CANDIDATE "${BGFX_DIR}/.build/linux64_gcc/bin/libbgfx${CONFIG}.a")
+    if(EXISTS "${CANDIDATE}")
+        set(BGFX_LIB "${CANDIDATE}")
+        set(BGFX_LIB_FOUND TRUE)
+        break()
+    endif()
+endforeach()
+
+if(NOT BGFX_LIB_FOUND)
+    file(GLOB_RECURSE BGFX_LIB_CANDIDATES "${BGFX_DIR}/.build/**/libbgfx*.a")
+    if(BGFX_LIB_CANDIDATES)
+        list(GET BGFX_LIB_CANDIDATES 0 BGFX_LIB)
+        set(BGFX_LIB_FOUND TRUE)
+    endif()
+endif()
+
+if(BGFX_LIB_FOUND)
+    message(STATUS "Found bgfx library: ${BGFX_LIB}")
+    
+    add_library(bgfximpl STATIC IMPORTED GLOBAL)
+    set_target_properties(bgfximpl PROPERTIES IMPORTED_LOCATION "${BGFX_LIB}")
+    target_link_libraries(bgfx INTERFACE bgfximpl)
+else()
+    message(WARNING "BGFX library not found. The bgfx backend will compile but won't link.\n"
+        "\n"
+        "To build bgfx:\n"
+        "  1. cd ${BGFX_DIR}\n"
+        "  2. make linux-gcc-release64\n"
+        "  3. Rebuild this project with -DENABLE_BGFX_BACKEND=ON\n"
+        "\n"
+        "Without the library, only the null backend can be used.")
+    
+    add_library(bgfximpl STATIC IMPORTED GLOBAL)
+    set_target_properties(bgfximpl PROPERTIES 
+        IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/libbgfx_stub.a"
+    )
+    if(NOT EXISTS "${CMAKE_BINARY_DIR}/libbgfx_stub.a")
+        file(WRITE "${CMAKE_BINARY_DIR}/libbgfx_stub.a" "!<arch>\n")
+    endif()
+endif()
+
+message(STATUS "BGFX backend enabled")
+message(STATUS "  BGFX_DIR: ${BGFX_DIR}")
+message(STATUS "  BX_DIR: ${BX_DIR}")

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -12,7 +12,7 @@
 #   # First build bgfx itself:
 #   cd external/bgfx
 #   make linux-gcc-release64
-#   
+#
 #   # Then build OpenW3D with bgfx backend:
 #   cd ../..
 #   mkdir build && cd build
@@ -93,7 +93,7 @@ endif()
 
 if(BGFX_LIB_FOUND)
     message(STATUS "Found bgfx library: ${BGFX_LIB}")
-    
+
     add_library(bgfximpl STATIC IMPORTED GLOBAL)
     set_target_properties(bgfximpl PROPERTIES IMPORTED_LOCATION "${BGFX_LIB}")
     target_link_libraries(bgfx INTERFACE bgfximpl)
@@ -106,9 +106,9 @@ else()
         "  3. Rebuild this project with -DENABLE_BGFX_BACKEND=ON\n"
         "\n"
         "Without the library, only the null backend can be used.")
-    
+
     add_library(bgfximpl STATIC IMPORTED GLOBAL)
-    set_target_properties(bgfximpl PROPERTIES 
+    set_target_properties(bgfximpl PROPERTIES
         IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/libbgfx_stub.a"
     )
     if(NOT EXISTS "${CMAKE_BINARY_DIR}/libbgfx_stub.a")


### PR DESCRIPTION
## BGFX Backend Support (Structure)

This PR adds the **BGFX backend structure** on top of the backend abstraction from #120.

### What's included
- `bgfxbackend.h/cpp` — BGFX backend class implementing `WW3DBackend`
- `BGFXTexture.cpp/h` — Texture bridging (DXT1/3/5, dynamic upload)
- `BGFXVertexBuffer.cpp/h` — Vertex buffer management
- `BGFXIndexBuffer.cpp/h` — Index buffer management
- `BGFXMaterialMapper.cpp/h` — Material state translation
- `cmake/bgfx.cmake` — BGFX CMake integration
- `backends/bgfx/CMakeLists.txt` — Backend build target

### Build
```bash
cmake -B build -GNinja -DENABLE_BGFX_BACKEND=ON -DWANT_DX9=OFF
cmake --build build --target ww3d2
```

### Status
- ✅ Compiles on Windows (MSVC + MinGW)
- ✅ No rendering logic yet — pure resource management and init/shutdown
- 🚧 Rendering implementation follows in #122

### Review guidance
This is **PR 2 of 3**. Depends on #120.

---
*Depends on: #120 | Next: #122*