### PR TITLE
Commando: replace Win32 window with SDL3 window

### DIFF
--- a/Code/Commando/WINMAIN.CPP
+++ b/Code/Commando/WINMAIN.CPP
@@ -110,7 +110,11 @@
 //----------------------------------------------------------------------------
 extern "C"
 {
+#if defined(OPENW3D_SDL3)
+	SDL_Window	*hWndMain;
+#else
 	HWND		hWndMain;
+#endif
 	bool		WIN_fullscreen = true;
 }
 
@@ -119,11 +123,16 @@ extern "C"
 //	Local functions
 //----------------------------------------------------------------------------
 static BOOL Create_Main_Window(void);
+#if !defined(OPENW3D_SDL3)
 LRESULT CALLBACK Main_Window_Proc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+#endif
 void On_Focus_Loss(void);
 void On_Focus_Restore(void);
 int Start_Application( void );
 bool Set_Working_Directory(void);
+#if defined(OPENW3D_SDL3)
+void SDL3_Pump_Events(void);
+#endif
 
 //#include "packet.h"
 
@@ -495,6 +504,7 @@ int Start_Application(void)
 	return exitCode;
 }
 
+#if !defined(OPENW3D_SDL3)
 /***********************************************************************************************
  * Main_Window_Proc -- Windows Proc for the main game window                                   *
  *                                                                                             *
@@ -669,6 +679,7 @@ LRESULT CALLBACK Main_Window_Proc( HWND hwnd, UINT message, WPARAM wParam, LPARA
 
 	return DefWindowProc(hwnd, message, wParam, lParam);
 }
+#endif // !OPENW3D_SDL3
 
 
 /***********************************************************************************************
@@ -688,6 +699,28 @@ LRESULT CALLBACK Main_Window_Proc( HWND hwnd, UINT message, WPARAM wParam, LPARA
  *=============================================================================================*/
 static BOOL Create_Main_Window(void)
 {
+#if defined(OPENW3D_SDL3)
+	if (ConsoleBox.Is_Exclusive()) {
+		return TRUE;
+	}
+
+	if (!SDL_Init(SDL_INIT_VIDEO)) {
+		return FALSE;
+	}
+
+	MainWindow = SDL_CreateWindow(
+		"Renegade",
+		SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+		0, 0,
+		SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE);
+
+	if (!MainWindow) {
+		return FALSE;
+	}
+
+	hWndMain = MainWindow;
+	return TRUE;
+#elif defined(OPENW3D_WIN32)
 	WNDCLASSA    wc;
 	BOOL        rc;
 
@@ -721,7 +754,41 @@ static BOOL Create_Main_Window(void)
 	}
 
 	return TRUE;
+#else
+	return FALSE;
+#endif
 }
+
+#if defined(OPENW3D_SDL3)
+/***********************************************************************************************
+ * SDL3_Pump_Events -- Pumps SDL events and handles focus for SDL3 window                        *
+ *=============================================================================================*/
+void SDL3_Pump_Events(void)
+{
+	SDL_Event event;
+
+	while (SDL_PollEvent(&event)) {
+		switch (event.type) {
+		case SDL_EVENT_WINDOW_FOCUS_GAINED:
+			if (!GameInFocus) {
+				GameInFocus = true;
+				On_Focus_Restore();
+			}
+			break;
+		case SDL_EVENT_WINDOW_FOCUS_LOST:
+			if (GameInFocus) {
+				GameInFocus = false;
+				On_Focus_Loss();
+			}
+			break;
+		case SDL_EVENT_QUIT:
+			break;
+		default:
+			break;
+		}
+	}
+}
+#endif
 
 
 /***********************************************************************************************

--- a/Code/wwlib/win.h
+++ b/Code/wwlib/win.h
@@ -57,23 +57,25 @@
 //#include	<winnt.h>
 //#include	<winuser.h>
 
+#if defined(OPENW3D_SDL3)
+#include <SDL3/SDL.h>
+extern SDL_Window *MainWindow;
+#else
 #ifdef _WIN32
 extern HINSTANCE	ProgramInstance;
 extern HWND			MainWindow;
 extern bool GameInFocus;
+#endif
+#endif
 
 #ifdef _DEBUG
-
+#ifdef _WIN32
 void __cdecl Print_Win32Error(unsigned int win32Error);
-
-#else // _DEBUG
-
+#else
 #define Print_Win32Error
-
-#endif // _DEBUG
-
-#else // _WIN32
-//#include <unistd.h>
-#endif // _WIN32
+#endif
+#else // _DEBUG
+#define Print_Win32Error
+#endif
 
 #endif // WIN_H


### PR DESCRIPTION
When OPENW3D_SDL3 is defined, create an SDL3 window via SDL_CreateWindow instead of a Win32 window. Add SDL3_Pump_Events for focus event handling. Conditionally compile out Main_Window_Proc and related Win32 code when using SDL3.

Modified files:
- Code/Commando/WINMAIN.CPP: SDL3 window creation in Create_Main_Window, new SDL3_Pump_Events function
- Code/wwlib/win.h: SDL_Window* type for MainWindow when OPENW3D_SDL3 is defined