### PR TITLE
feat(bgfx): implement BGFX renderer backend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "external/bgfx"]
+	path = external/bgfx
+	url = https://github.com/bkaradzic/bgfx.git
+[submodule "external/bx"]
+	path = external/bx
+	url = https://github.com/bkaradzic/bx.git
+[submodule "external/bimg"]
+	path = external/bimg
+	url = https://github.com/bkaradzic/bimg.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ endif()
 
 project(commando LANGUAGES C CXX)
 
+# Match BGFX external libs which are built with static CRT (/MT)
+if(MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>" CACHE STRING "Use static CRT to match BGFX libs" FORCE)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 # This file handles extra settings wanted/needed for different compilers.
@@ -27,6 +32,10 @@ add_feature_info(OpenW3DClient W3D_CLIENT "Build OpenW3D game client")
 
 option(W3D_FDS "Build as headless server." ON)
 add_feature_info(OpenW3DHeadless W3D_FDS "Build OpenW3D headless server")
+
+# Enable DX9/DXVK renderer on Linux
+option(WANT_DX9 "Enable DX9 renderer via DXVK (Linux only, for cross-compile testing)." ON)
+add_feature_info(DX9Renderer WANT_DX9 "Enable DX9/DXVK renderer")
 
 # Do we want to build extra SDK stuff or just the game binary?
 option(W3D_TOOLS "Build additional tools." ON)
@@ -106,7 +115,17 @@ else()
     include(icu)
 endif()
 
-include(dx9)
+if(WANT_DX9)
+    include(dx9)
+endif()
+
+# BGFX backend option
+option(ENABLE_BGFX_BACKEND "Enable BGFX cross-platform rendering backend." OFF)
+add_feature_info(BGFXBackend ENABLE_BGFX_BACKEND "Build with BGFX rendering backend")
+
+if(ENABLE_BGFX_BACKEND)
+    include(bgfx)
+endif()
 
 include(gamespy)
 

--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -46,10 +46,24 @@ target_include_directories(wwcommon INTERFACE
     .
 )
 
+# DirectX SDK include path (required for D3DX9 headers)
+if(WIN32)
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/DirectX/Include")
+        target_include_directories(wwcommon INTERFACE DirectX/Include)
+    elseif(DEFINED ENV{DXSDK_DIR})
+        target_include_directories(wwcommon INTERFACE "$ENV{DXSDK_DIR}/Include")
+    endif()
+endif()
+
 target_link_libraries(wwcommon INTERFACE
     gamespy
-    d3d9lib
 )
+
+if(WANT_DX9)
+    target_link_libraries(wwcommon INTERFACE
+        d3d9lib
+    )
+endif()
 
 if(TARGET ffmpeg)
     target_link_libraries(wwcommon INTERFACE ffmpeg)
@@ -86,6 +100,10 @@ add_subdirectory(wwutil)
 
 # Final targets
 add_subdirectory(BandTest)
+option(W3D_BUILD_RENDER_COMPARE "Build the RenderCompare diagnostic harness." OFF)
+if(W3D_BUILD_RENDER_COMPARE)
+    add_subdirectory(Tests/RenderCompare)
+endif()
 add_subdirectory(Launcher)
 add_subdirectory(Scripts)
 add_subdirectory(Commando)

--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -224,8 +224,30 @@ set(WW3D2_SRC
     nullbackend.h
 )
 
+if(ENABLE_BGFX_BACKEND)
+    list(APPEND WW3D2_SRC
+        backends/bgfx/bgfxbackend.cpp
+        backends/bgfx/bgfxbackend.h
+        backends/bgfx/BGFXMaterialMapper.h
+        backends/bgfx/BGFXMaterialMapper.cpp
+        backends/bgfx/BGFXVertexBuffer.h
+        backends/bgfx/BGFXVertexBuffer.cpp
+        backends/bgfx/BGFXIndexBuffer.h
+        backends/bgfx/BGFXIndexBuffer.cpp
+        backends/bgfx/BGFXTexture.h
+        backends/bgfx/BGFXTexture.cpp
+        backends/bgfx/ShaderKey.h
+        backends/bgfx/ShaderVariantCache.h
+        backends/bgfx/ShaderVariantCache.cpp
+    )
+endif()
+
 # Targets to build.
 add_library(ww3d2 STATIC)
+
+if(ENABLE_BGFX_BACKEND)
+    add_subdirectory(backends/bgfx)
+endif()
 
 target_link_libraries(ww3d2 PRIVATE
     wwcommon
@@ -233,6 +255,26 @@ target_link_libraries(ww3d2 PRIVATE
     vfw32
     winmm
 )
+
+if(ENABLE_BGFX_BACKEND)
+    target_link_libraries(ww3d2 PRIVATE bgfx)
+    # Required for bx headers (bgfx dependency)
+    if(MSVC)
+        target_compile_options(ww3d2 PRIVATE /Zc:preprocessor)
+    endif()
+endif()
+
+# Backend selection defines
+if(ENABLE_BGFX_BACKEND)
+    target_compile_definitions(ww3d2 PRIVATE WW3D_BGFX_BACKEND=1)
+elseif(WIN32 AND WANT_DX9)
+    target_compile_definitions(ww3d2 PRIVATE WW3D_DX9_BACKEND=1)
+else()
+    if(WIN32)
+        message(WARNING "WW3D: No backend enabled on Windows; falling back to NullBackend. Set WANT_DX9=ON or ENABLE_BGFX_BACKEND=ON.")
+    endif()
+    target_compile_definitions(ww3d2 PRIVATE WW3D_NULL_BACKEND=1)
+endif()
 
 target_sources(ww3d2 PRIVATE ${WW3D2_SRC})
 
@@ -246,6 +288,19 @@ if (W3D_TOOLS)
         vfw32
         winmm
     )
+
+    if(ENABLE_BGFX_BACKEND)
+        target_link_libraries(ww3d2e PRIVATE bgfx)
+        target_include_directories(ww3d2e PRIVATE
+            "${BGFX_DIR}/include"
+            "${BX_DIR}/include"
+            "${BX_DIR}/include/compat/msvc"
+        )
+        # Required for bx headers (bgfx dependency)
+        if(MSVC)
+            target_compile_options(ww3d2e PRIVATE /Zc:preprocessor)
+        endif()
+    endif()
 
     target_compile_definitions(ww3d2e PRIVATE PARAM_EDITING_ON)
 

--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -102,6 +102,8 @@ set(WW3D2_SRC
     w3d_util.cpp
     ww3d.cpp
     ww3dformat.cpp
+    dx8backend.cpp
+    nullbackend.cpp
     aabtree.h
     aabtreebuilder.h
     agg_def.h
@@ -217,6 +219,9 @@ set(WW3D2_SRC
     ww3dformat.h
     ww3dids.h
     ww3dtrig.h
+    ww3dbackend.h
+    dx8backend.h
+    nullbackend.h
 )
 
 # Targets to build.

--- a/Code/ww3d2/backends/bgfx/BGFXIndexBuffer.cpp
+++ b/Code/ww3d2/backends/bgfx/BGFXIndexBuffer.cpp
@@ -1,0 +1,50 @@
+// BGFXIndexBuffer.cpp - OpenW3D render backend
+
+#include "backends/bgfx/BGFXIndexBuffer.h"
+
+BGFXIndexBuffer::BGFXIndexBuffer()
+    : m_handle(BGFX_INVALID_HANDLE)
+    , m_indexCount(0)
+    , m_index32bit(false)
+{
+}
+
+BGFXIndexBuffer::~BGFXIndexBuffer()
+{
+    Destroy();
+}
+
+bool BGFXIndexBuffer::Create(void* data, int indexCount, bool index32bit, uint64_t flags)
+{
+    Destroy();
+
+    if (!data || indexCount <= 0) {
+        return false;
+    }
+
+    m_indexCount = indexCount;
+    m_index32bit = index32bit;
+
+    const uint32_t indexSize = index32bit ? 4 : 2;
+    const uint32_t size = indexCount * indexSize;
+
+    const bgfx::Memory* mem = bgfx::copy(data, size);
+
+    if (index32bit) {
+        m_handle = bgfx::createIndexBuffer(mem, flags | BGFX_BUFFER_INDEX32);
+    } else {
+        m_handle = bgfx::createIndexBuffer(mem, flags);
+    }
+
+    return bgfx::isValid(m_handle);
+}
+
+void BGFXIndexBuffer::Destroy()
+{
+    if (bgfx::isValid(m_handle)) {
+        bgfx::destroy(m_handle);
+        m_handle = BGFX_INVALID_HANDLE;
+    }
+    m_indexCount = 0;
+    m_index32bit = false;
+}

--- a/Code/ww3d2/backends/bgfx/BGFXIndexBuffer.h
+++ b/Code/ww3d2/backends/bgfx/BGFXIndexBuffer.h
@@ -1,0 +1,39 @@
+// BGFXIndexBuffer.h - OpenW3D render backend
+
+#ifndef BGFXINDEXBUFFER_H
+#define BGFXINDEXBUFFER_H
+
+#include "bgfx/bgfx.h"
+
+// BGFXIndexBuffer - wraps a bgfx index buffer
+class BGFXIndexBuffer
+{
+public:
+    BGFXIndexBuffer();
+    ~BGFXIndexBuffer();
+
+    // Create from raw data
+    bool Create(void* data, int indexCount, bool index32bit = false, uint64_t flags = BGFX_BUFFER_NONE);
+
+    // Destroy the buffer
+    void Destroy();
+
+    // Check if buffer is valid
+    bool Is_Valid() const { return bgfx::isValid(m_handle); }
+
+    // Get the bgfx handle
+    bgfx::IndexBufferHandle Get_Handle() const { return m_handle; }
+
+    // Get index count
+    int Get_Index_Count() const { return m_indexCount; }
+
+    // Check if using 32-bit indices
+    bool Is_32Bit() const { return m_index32bit; }
+
+private:
+    bgfx::IndexBufferHandle m_handle;
+    int m_indexCount;
+    bool m_index32bit;
+};
+
+#endif // BGFXINDEXBUFFER_H

--- a/Code/ww3d2/backends/bgfx/BGFXMaterialMapper.cpp
+++ b/Code/ww3d2/backends/bgfx/BGFXMaterialMapper.cpp
@@ -1,0 +1,7 @@
+// BGFXMaterialMapper.cpp - OpenW3D render backend
+
+#include "backends/bgfx/BGFXMaterialMapper.h"
+
+// BGFXMaterialMapper implementation stub.
+// All mapping methods are inline in BGFXMaterialMapper.h; this file ensures the
+// translation unit compiles when the build system expects a matching .cpp.

--- a/Code/ww3d2/backends/bgfx/BGFXMaterialMapper.h
+++ b/Code/ww3d2/backends/bgfx/BGFXMaterialMapper.h
@@ -1,0 +1,201 @@
+// BGFXMaterialMapper.h - OpenW3D render backend
+
+#ifndef BGFXMATERIALMAPPER_H
+#define BGFXMATERIALMAPPER_H
+
+#include "bgfx/bgfx.h"
+#include "vector3.h"
+#include "shader.h"
+#include "vertmaterial.h"
+#include "meshmatdesc.h"
+
+// bgfx uniform names for material properties
+namespace BGFXMaterialUniforms
+{
+    const char* const DIFFUSE_COLOR = "u_diffuseColor";
+    const char* const SPECULAR_COLOR = "u_specularColor";
+    const char* const EMISSIVE_COLOR = "u_emissiveColor";
+    const char* const AMBIENT_COLOR = "u_ambientColor";
+    const char* const SHININESS = "u_shininess";
+    const char* const OPACITY = "u_opacity";
+    const char* const LIGHTING_ENABLE = "u_lightingEnable";
+}
+
+// Material color structure matching shader expectations
+struct MaterialColors
+{
+    Vector3 Diffuse;
+    float Alpha;
+    Vector3 Specular;
+    float Shininess;
+    Vector3 Emissive;
+    float Pad1;  // Alignment padding
+    Vector3 Ambient;
+    float Pad2;
+
+    MaterialColors()
+        : Diffuse(1.0f, 1.0f, 1.0f)
+        , Alpha(1.0f)
+        , Specular(0.0f, 0.0f, 0.0f)
+        , Shininess(0.0f)
+        , Emissive(0.0f, 0.0f, 0.0f)
+        , Pad1(0.0f)
+        , Ambient(0.0f, 0.0f, 0.0f)
+        , Pad2(0.0f)
+    {}
+};
+
+// BGFXMaterialMapper - helper class for mapping materials to bgfx
+class BGFXMaterialMapper
+{
+public:
+    // Map ShaderClass blend modes to bgfx state
+    static uint64_t Shader_Blend_To_BGFX(ShaderClass::SrcBlendFuncType src, ShaderClass::DstBlendFuncType dst)
+    {
+        uint64_t state = BGFX_STATE_DEFAULT;
+
+        // Source blend
+        uint64_t srcBlend = Src_Blend_To_BGFX(src);
+
+        // Destination blend
+        uint64_t dstBlend = Dst_Blend_To_BGFX(dst);
+
+        state |= BGFX_STATE_BLEND_FUNC(srcBlend, dstBlend);
+        return state;
+    }
+
+    static uint64_t Src_Blend_To_BGFX(ShaderClass::SrcBlendFuncType src)
+    {
+        switch (src) {
+            case ShaderClass::SRCBLEND_ZERO:           return BGFX_STATE_BLEND_ZERO;
+            case ShaderClass::SRCBLEND_ONE:            return BGFX_STATE_BLEND_ONE;
+            case ShaderClass::SRCBLEND_SRC_ALPHA:      return BGFX_STATE_BLEND_SRC_ALPHA;
+            case ShaderClass::SRCBLEND_ONE_MINUS_SRC_ALPHA: return BGFX_STATE_BLEND_INV_SRC_ALPHA;
+            default:                                  return BGFX_STATE_BLEND_ONE;
+        }
+    }
+
+    static uint64_t Dst_Blend_To_BGFX(ShaderClass::DstBlendFuncType dst)
+    {
+        switch (dst) {
+            case ShaderClass::DSTBLEND_ZERO:                   return BGFX_STATE_BLEND_ZERO;
+            case ShaderClass::DSTBLEND_ONE:                    return BGFX_STATE_BLEND_ONE;
+            case ShaderClass::DSTBLEND_SRC_ALPHA:              return BGFX_STATE_BLEND_SRC_ALPHA;
+            case ShaderClass::DSTBLEND_ONE_MINUS_SRC_ALPHA:    return BGFX_STATE_BLEND_INV_SRC_ALPHA;
+            case ShaderClass::DSTBLEND_SRC_COLOR:             return BGFX_STATE_BLEND_SRC_COLOR;
+            case ShaderClass::DSTBLEND_ONE_MINUS_SRC_COLOR:   return BGFX_STATE_BLEND_INV_SRC_COLOR;
+            default:                                          return BGFX_STATE_BLEND_ZERO;
+        }
+    }
+
+    // Map ShaderClass cull mode to bgfx state
+    static uint64_t Shader_Cull_To_BGFX(ShaderClass::CullModeType cull)
+    {
+        switch (cull) {
+            case ShaderClass::CULL_MODE_DISABLE:  return BGFX_STATE_NONE;
+            case ShaderClass::CULL_MODE_ENABLE:   return BGFX_STATE_CULL_CCW;
+            default:                              return BGFX_STATE_CULL_CCW;
+        }
+    }
+
+    // Map ShaderClass depth compare to bgfx state
+    static uint64_t Shader_DepthCompare_To_BGFX(ShaderClass::DepthCompareType cmp)
+    {
+        switch (cmp) {
+            case ShaderClass::PASS_NEVER:    return BGFX_STATE_DEPTH_TEST_NEVER;
+            case ShaderClass::PASS_LESS:     return BGFX_STATE_DEPTH_TEST_LESS;
+            case ShaderClass::PASS_EQUAL:    return BGFX_STATE_DEPTH_TEST_EQUAL;
+            case ShaderClass::PASS_LEQUAL:   return BGFX_STATE_DEPTH_TEST_LEQUAL;
+            case ShaderClass::PASS_GREATER:  return BGFX_STATE_DEPTH_TEST_GREATER;
+            case ShaderClass::PASS_NOTEQUAL: return BGFX_STATE_DEPTH_TEST_NOTEQUAL;
+            case ShaderClass::PASS_GEQUAL:   return BGFX_STATE_DEPTH_TEST_GEQUAL;
+            case ShaderClass::PASS_ALWAYS:   return BGFX_STATE_DEPTH_TEST_ALWAYS;
+            default:                         return BGFX_STATE_DEPTH_TEST_LEQUAL;
+        }
+    }
+
+    // Map ShaderClass to full bgfx state flags
+    static uint64_t Shader_To_BGFX_State(const ShaderClass& shader)
+    {
+        uint64_t state = BGFX_STATE_DEFAULT;
+
+        // Depth test setting
+        state |= Shader_DepthCompare_To_BGFX(shader.Get_Depth_Compare());
+
+        // Depth write
+        if (shader.Get_Depth_Mask() == ShaderClass::DEPTH_WRITE_DISABLE) {
+            // Don't add WRITE_Z
+        } else {
+            state |= BGFX_STATE_WRITE_Z;
+        }
+
+        // Cull mode
+        state |= Shader_Cull_To_BGFX(shader.Get_Cull_Mode());
+
+        // Blending
+        state |= Shader_Blend_To_BGFX(shader.Get_Src_Blend_Func(), shader.Get_Dst_Blend_Func());
+
+        return state;
+    }
+
+    // Extract material colors from VertexMaterialClass
+    static MaterialColors Get_Material_Colors(const VertexMaterialClass* mat)
+    {
+        MaterialColors colors;
+
+        if (mat) {
+            mat->Get_Diffuse(&colors.Diffuse);
+            colors.Alpha = mat->Get_Opacity();
+            mat->Get_Specular(&colors.Specular);
+            colors.Shininess = mat->Get_Shininess();
+            mat->Get_Emissive(&colors.Emissive);
+            mat->Get_Ambient(&colors.Ambient);
+        }
+
+        return colors;
+    }
+
+    // Create bgfx render state from ShaderClass
+    static uint64_t Make_Render_State(const ShaderClass& shader, bool lightingEnabled)
+    {
+        uint64_t state = Shader_To_BGFX_State(shader);
+
+        // Add point/line/wireframe based on fill mode if needed
+        // For now, default to triangle strips
+
+        return state;
+    }
+
+    // Determine if shader uses alpha blending
+    static bool Uses_Alpha_Blending(const ShaderClass& shader)
+    {
+        ShaderClass::DstBlendFuncType dst = shader.Get_Dst_Blend_Func();
+        ShaderClass::SrcBlendFuncType src = shader.Get_Src_Blend_Func();
+
+        return (dst == ShaderClass::DSTBLEND_SRC_ALPHA ||
+                dst == ShaderClass::DSTBLEND_ONE_MINUS_SRC_ALPHA ||
+                src == ShaderClass::SRCBLEND_SRC_ALPHA ||
+                src == ShaderClass::SRCBLEND_ONE_MINUS_SRC_ALPHA);
+    }
+
+    // Determine static sort category based on shader
+    static ShaderClass::StaticSortCategoryType Get_Sort_Category(const ShaderClass& shader)
+    {
+        if (shader.Get_Alpha_Test() != ShaderClass::ALPHATEST_DISABLE) {
+            return ShaderClass::SSCAT_ALPHA_TEST;
+        }
+
+        ShaderClass::DstBlendFuncType dst = shader.Get_Dst_Blend_Func();
+        ShaderClass::SrcBlendFuncType src = shader.Get_Src_Blend_Func();
+        if (dst == ShaderClass::DSTBLEND_ONE && src == ShaderClass::SRCBLEND_ONE) {
+            return ShaderClass::SSCAT_ADDITIVE;
+        }
+        if (dst == ShaderClass::DSTBLEND_SRC_ALPHA || dst == ShaderClass::DSTBLEND_ONE) {
+            return ShaderClass::SSCAT_ADDITIVE;
+        }
+
+        return ShaderClass::SSCAT_OTHER;
+    }
+};
+
+#endif // BGFXMATERIALMAPPER_H

--- a/Code/ww3d2/backends/bgfx/BGFXTexture.cpp
+++ b/Code/ww3d2/backends/bgfx/BGFXTexture.cpp
@@ -1,0 +1,252 @@
+// BGFXTexture.cpp - OpenW3D render backend
+
+#include "backends/bgfx/BGFXTexture.h"
+#include "ww3dformat.h"
+
+BGFXTexture::BGFXTexture()
+    : m_handle(BGFX_INVALID_HANDLE)
+    , m_width(0)
+    , m_height(0)
+    , m_format(bgfx::TextureFormat::RGBA8)
+    , m_mipCount(1)
+    , m_flags(BGFX_TEXTURE_NONE)
+{
+}
+
+BGFXTexture::~BGFXTexture()
+{
+    Destroy();
+}
+
+bool BGFXTexture::Create(int width, int height, BGFXTextureFormat format, void* data, int mipCount)
+{
+    bgfx::TextureFormat::Enum bgfxFormat = bgfx::TextureFormat::RGBA8;
+    switch (format) {
+        case BGFXTextureFormat::RGBA8:      bgfxFormat = bgfx::TextureFormat::RGBA8; break;
+        case BGFXTextureFormat::RGB8:       bgfxFormat = bgfx::TextureFormat::RGB8; break;
+        case BGFXTextureFormat::BGRA8:      bgfxFormat = bgfx::TextureFormat::BGRA8; break;
+        case BGFXTextureFormat::RGBA16F:    bgfxFormat = bgfx::TextureFormat::RGBA16F; break;
+        case BGFXTextureFormat::RGBA32F:    bgfxFormat = bgfx::TextureFormat::RGBA32F; break;
+        case BGFXTextureFormat::BC1:        bgfxFormat = bgfx::TextureFormat::BC1; break;
+        case BGFXTextureFormat::BC2:        bgfxFormat = bgfx::TextureFormat::BC2; break;
+        case BGFXTextureFormat::BC3:        bgfxFormat = bgfx::TextureFormat::BC3; break;
+        case BGFXTextureFormat::R8:         bgfxFormat = bgfx::TextureFormat::R8; break;
+        case BGFXTextureFormat::R16F:       bgfxFormat = bgfx::TextureFormat::R16F; break;
+        case BGFXTextureFormat::Depth16:    bgfxFormat = bgfx::TextureFormat::D16; break;
+        case BGFXTextureFormat::Depth24:    bgfxFormat = bgfx::TextureFormat::D24; break;
+        case BGFXTextureFormat::Depth32F:   bgfxFormat = bgfx::TextureFormat::D32F; break;
+        default:                            bgfxFormat = bgfx::TextureFormat::RGBA8; break;
+    }
+    return Create(width, height, bgfxFormat, data, mipCount, BGFX_TEXTURE_NONE);
+}
+
+bool BGFXTexture::Create(int width, int height, bgfx::TextureFormat::Enum format, void* data, int mipCount, uint64_t flags)
+{
+    Destroy();
+
+    if (width <= 0 || height <= 0) {
+        return false;
+    }
+
+    m_width = width;
+    m_height = height;
+    m_format = format;
+    m_mipCount = mipCount;
+    m_flags = flags;
+
+    const bgfx::Memory* mem = nullptr;
+    if (data) {
+        // Calculate size based on format
+        uint32_t size = Get_Texture_Data_Size(width, height, format);
+        mem = bgfx::copy(data, size);
+    }
+
+    m_handle = bgfx::createTexture2D(
+        static_cast<uint16_t>(width),
+        static_cast<uint16_t>(height),
+        false,  // hasMips - we'll handle mips separately
+        1,      // numLayers
+        format,
+        flags,
+        mem
+    );
+
+    return bgfx::isValid(m_handle);
+}
+
+bool BGFXTexture::Create_Render_Target(int width, int height, bgfx::TextureFormat::Enum format, uint64_t flags)
+{
+    return Create(width, height, format, nullptr, 1, flags | BGFX_TEXTURE_RT_WRITE_ONLY);
+}
+
+bool BGFXTexture::Create_Depth(int width, int height, bgfx::TextureFormat::Enum format, uint64_t flags)
+{
+    return Create(width, height, format, nullptr, 1, flags | BGFX_TEXTURE_RT_WRITE_ONLY);
+}
+
+void BGFXTexture::Destroy()
+{
+    if (bgfx::isValid(m_handle)) {
+        bgfx::destroy(m_handle);
+        m_handle = BGFX_INVALID_HANDLE;
+    }
+    m_width = 0;
+    m_height = 0;
+    m_mipCount = 1;
+}
+
+void BGFXTexture::Update(int x, int y, int width, int height, void* data)
+{
+    if (!bgfx::isValid(m_handle) || !data) {
+        return;
+    }
+
+    uint32_t size = Get_Texture_Data_Size(width, height, m_format);
+    const bgfx::Memory* mem = bgfx::copy(data, size);
+
+    bgfx::updateTexture2D(
+        m_handle,
+        0,  // mip level
+        0,  // layer
+        static_cast<uint16_t>(x),
+        static_cast<uint16_t>(y),
+        static_cast<uint16_t>(width),
+        static_cast<uint16_t>(height),
+        mem
+    );
+}
+
+void BGFXTexture::Generate_Mips()
+{
+    // bgfx handles mip generation internally for most formats
+    // This is a placeholder for explicit mip generation if needed
+}
+
+void BGFXTexture::Set_Sampler_State(const BGFXSamplerState& state)
+{
+    m_samplerState = state;
+}
+
+uint32_t BGFXSamplerState::To_BGFX_Flags() const
+{
+    uint32_t flags = 0;
+
+    // Min filter
+    switch (MinFilter) {
+        case Point:        flags |= BGFX_SAMPLER_MIN_POINT; break;
+        case Linear:       flags |= BGFX_SAMPLER_MIN_ANISOTROPIC; break;  // Use anisotropic for linear
+        case Anisotropic:  flags |= BGFX_SAMPLER_MIN_ANISOTROPIC; break;
+    }
+
+    // Mag filter
+    switch (MagFilter) {
+        case Point:        flags |= BGFX_SAMPLER_MAG_POINT; break;
+        case Linear:       break;  // Linear is default
+        case Anisotropic:  break;  // Linear is default for mag
+    }
+
+    // Mip filter
+    switch (MipFilter) {
+        case Point:        flags |= BGFX_SAMPLER_MIP_POINT; break;
+        case Linear:       break;  // Linear mip is default
+        case Anisotropic:  break;  // Linear mip is default
+    }
+
+    // Address modes
+    switch (AddressU) {
+        case Wrap:     break;  // Wrap is default (no flag needed)
+        case Clamp:    flags |= BGFX_SAMPLER_U_CLAMP; break;
+        case Mirror:   flags |= BGFX_SAMPLER_U_MIRROR; break;
+        case Border:   flags |= BGFX_SAMPLER_U_BORDER; break;
+    }
+
+    switch (AddressV) {
+        case Wrap:     break;  // Wrap is default (no flag needed)
+        case Clamp:    flags |= BGFX_SAMPLER_V_CLAMP; break;
+        case Mirror:   flags |= BGFX_SAMPLER_V_MIRROR; break;
+        case Border:   flags |= BGFX_SAMPLER_V_BORDER; break;
+    }
+
+    switch (AddressW) {
+        case Wrap:     break;  // Wrap is default (no flag needed)
+        case Clamp:    flags |= BGFX_SAMPLER_W_CLAMP; break;
+        case Mirror:   flags |= BGFX_SAMPLER_W_MIRROR; break;
+        case Border:   flags |= BGFX_SAMPLER_W_BORDER; break;
+    }
+
+    return flags;
+}
+
+bgfx::TextureFormat::Enum BGFXTexture::WW3D_To_BGFX_Format(int ww3dFormat)
+{
+    switch (static_cast<WW3DFormat>(ww3dFormat)) {
+        case WW3D_FORMAT_R8G8B8:        return bgfx::TextureFormat::RGB8;
+        case WW3D_FORMAT_A8R8G8B8:      return bgfx::TextureFormat::BGRA8;   // Same memory layout on LE
+        case WW3D_FORMAT_X8R8G8B8:      return bgfx::TextureFormat::BGRA8;   // Alpha ignored
+        case WW3D_FORMAT_R5G6B5:        return bgfx::TextureFormat::R5G6B5;
+        case WW3D_FORMAT_X1R5G5B5:      return bgfx::TextureFormat::R5G6B5;  // Closest available
+        case WW3D_FORMAT_A1R5G5B5:      return bgfx::TextureFormat::R5G6B5;  // Closest available
+        case WW3D_FORMAT_A4R4G4B4:      return bgfx::TextureFormat::RGBA4;   // 4444 → 4444
+        case WW3D_FORMAT_R3G3B2:        return bgfx::TextureFormat::RGB8;    // Upcast
+        case WW3D_FORMAT_A8:            return bgfx::TextureFormat::R8;      // Single channel
+        case WW3D_FORMAT_A8R3G3B2:      return bgfx::TextureFormat::BGRA8;   // Upcast
+        case WW3D_FORMAT_X4R4G4B4:      return bgfx::TextureFormat::RGBA4;   // 4444 → 4444
+        case WW3D_FORMAT_A8P8:          return bgfx::TextureFormat::RG8;     // 2 channels
+        case WW3D_FORMAT_P8:            return bgfx::TextureFormat::R8;      // Paletted → grayscale
+        case WW3D_FORMAT_L8:            return bgfx::TextureFormat::R8;      // Luminance
+        case WW3D_FORMAT_A8L8:          return bgfx::TextureFormat::RG8;     // LA → RG
+        case WW3D_FORMAT_A4L4:          return bgfx::TextureFormat::RG8;     // Upcast
+        case WW3D_FORMAT_U8V8:          return bgfx::TextureFormat::RG8;     // Bumpmap UV
+        case WW3D_FORMAT_L6V5U5:        return bgfx::TextureFormat::RGB8;    // Bumpmap, upcast
+        case WW3D_FORMAT_X8L8V8U8:      return bgfx::TextureFormat::BGRA8;   // Bumpmap, upcast
+        case WW3D_FORMAT_DXT1:          return bgfx::TextureFormat::BC1;
+        case WW3D_FORMAT_DXT2:          return bgfx::TextureFormat::BC2;     // Premultiplied alpha
+        case WW3D_FORMAT_DXT3:          return bgfx::TextureFormat::BC2;
+        case WW3D_FORMAT_DXT4:          return bgfx::TextureFormat::BC3;     // Premultiplied alpha
+        case WW3D_FORMAT_DXT5:          return bgfx::TextureFormat::BC3;
+        case WW3D_FORMAT_UNKNOWN:
+        default:
+            WWDEBUG_SAY(("BGFXTexture: Unmapped WW3D format %d, falling back to RGBA8\n", ww3dFormat));
+            return bgfx::TextureFormat::RGBA8;
+    }
+}
+
+int BGFXTexture::Get_Bytes_Per_Pixel(bgfx::TextureFormat::Enum format)
+{
+    switch (format) {
+        case bgfx::TextureFormat::R8:       return 1;
+        case bgfx::TextureFormat::RG8:      return 2;
+        case bgfx::TextureFormat::RGB8:     return 3;
+        case bgfx::TextureFormat::RGBA8:    return 4;
+        case bgfx::TextureFormat::BGRA8:    return 4;
+        case bgfx::TextureFormat::R5G6B5:   return 2;
+        case bgfx::TextureFormat::RGBA4:    return 2;
+        case bgfx::TextureFormat::R16F:     return 2;
+        case bgfx::TextureFormat::RG16F:    return 4;
+        case bgfx::TextureFormat::RGBA16F:  return 8;
+        case bgfx::TextureFormat::R32F:     return 4;
+        case bgfx::TextureFormat::RG32F:    return 8;
+        case bgfx::TextureFormat::RGBA32F:  return 16;
+        case bgfx::TextureFormat::D16:      return 2;
+        case bgfx::TextureFormat::D24:      return 3;
+        case bgfx::TextureFormat::D24S8:    return 4;
+        case bgfx::TextureFormat::D32F:     return 4;
+        case bgfx::TextureFormat::BC1:      return 0;  // Compressed
+        case bgfx::TextureFormat::BC2:      return 0;  // Compressed
+        case bgfx::TextureFormat::BC3:      return 0;  // Compressed
+        default:                            return 4;
+    }
+}
+
+uint32_t BGFXTexture::Get_Texture_Data_Size(int width, int height, bgfx::TextureFormat::Enum format)
+{
+    switch (format) {
+        case bgfx::TextureFormat::BC1:
+            return ((width + 3) / 4) * ((height + 3) / 4) * 8;
+        case bgfx::TextureFormat::BC2:
+        case bgfx::TextureFormat::BC3:
+            return ((width + 3) / 4) * ((height + 3) / 4) * 16;
+        default:
+            return width * height * Get_Bytes_Per_Pixel(format);
+    }
+}

--- a/Code/ww3d2/backends/bgfx/BGFXTexture.h
+++ b/Code/ww3d2/backends/bgfx/BGFXTexture.h
@@ -1,0 +1,143 @@
+// BGFXTexture.h - OpenW3D render backend
+
+#ifndef BGFXTEXTURE_H
+#define BGFXTEXTURE_H
+
+#include "bgfx/bgfx.h"
+#include "vector3.h"
+
+// Texture format enumeration matching common WW3D usage
+enum class BGFXTextureFormat
+{
+    RGBA8,
+    RGB8,
+    BGRA8,
+    RGBA16F,
+    RGBA32F,
+    BC1,    // DXT1
+    BC2,    // DXT3
+    BC3,    // DXT5
+    R8,
+    R16F,
+    Depth16,
+    Depth24,
+    Depth32F,
+};
+
+// Sampler state flags
+struct BGFXSamplerState
+{
+    enum Filter
+    {
+        Point = 0,
+        Linear = 1,
+        Anisotropic = 2,
+    };
+
+    enum AddressMode
+    {
+        Wrap = 0,
+        Clamp = 1,
+        Mirror = 2,
+        Border = 3,
+    };
+
+    Filter MinFilter;
+    Filter MagFilter;
+    Filter MipFilter;
+    AddressMode AddressU;
+    AddressMode AddressV;
+    AddressMode AddressW;
+    int MaxAnisotropy;
+    Vector3 BorderColor;
+    float MipLODBias;
+
+    BGFXSamplerState()
+        : MinFilter(Linear)
+        , MagFilter(Linear)
+        , MipFilter(Linear)
+        , AddressU(Wrap)
+        , AddressV(Wrap)
+        , AddressW(Wrap)
+        , MaxAnisotropy(1)
+        , BorderColor(0.0f, 0.0f, 0.0f)
+        , MipLODBias(0.0f)
+    {}
+
+    // Convert to bgfx sampler flags
+    uint32_t To_BGFX_Flags() const;
+};
+
+// BGFXTexture - wraps a bgfx texture
+class BGFXTexture
+{
+public:
+    BGFXTexture();
+    ~BGFXTexture();
+
+    BGFXTexture(const BGFXTexture&) = delete;
+    BGFXTexture& operator=(const BGFXTexture&) = delete;
+    BGFXTexture(BGFXTexture&&) = delete;
+    BGFXTexture& operator=(BGFXTexture&&) = delete;
+
+    // Create from raw pixel data
+    bool Create(int width, int height, BGFXTextureFormat format, void* data, int mipCount = 1);
+
+    // Create from raw pixel data with explicit bgfx format
+    bool Create(int width, int height, bgfx::TextureFormat::Enum format, void* data, int mipCount = 1, uint64_t flags = BGFX_TEXTURE_NONE);
+
+    // Create as render target
+    bool Create_Render_Target(int width, int height, bgfx::TextureFormat::Enum format, uint64_t flags = BGFX_TEXTURE_RT_WRITE_ONLY);
+
+    // Create depth buffer
+    bool Create_Depth(int width, int height, bgfx::TextureFormat::Enum format = bgfx::TextureFormat::D24S8, uint64_t flags = BGFX_TEXTURE_RT_WRITE_ONLY);
+
+    // Destroy the texture
+    void Destroy();
+
+    // Check if texture is valid
+    bool Is_Valid() const { return bgfx::isValid(m_handle); }
+
+    // Get the bgfx handle
+    bgfx::TextureHandle Get_Handle() const { return m_handle; }
+
+    // Get dimensions
+    int Get_Width() const { return m_width; }
+    int Get_Height() const { return m_height; }
+
+    // Get format
+    bgfx::TextureFormat::Enum Get_Format() const { return m_format; }
+
+    // Update texture data (for dynamic textures)
+    void Update(int x, int y, int width, int height, void* data);
+
+    // Generate mipmaps
+    void Generate_Mips();
+
+    // Set sampler state
+    void Set_Sampler_State(const BGFXSamplerState& state);
+    BGFXSamplerState Get_Sampler_State() const { return m_samplerState; }
+
+    // Get current sampler flags
+    uint32_t Get_Sampler_Flags() const { return m_samplerState.To_BGFX_Flags(); }
+
+    // Static helper: Convert WW3D surface format to bgfx texture format
+    static bgfx::TextureFormat::Enum WW3D_To_BGFX_Format(int ww3dFormat);
+
+    // Static helper: Get bytes per pixel for a format
+    static int Get_Bytes_Per_Pixel(bgfx::TextureFormat::Enum format);
+
+    // Static helper: Get total data size for a texture (handles compressed formats)
+    static uint32_t Get_Texture_Data_Size(int width, int height, bgfx::TextureFormat::Enum format);
+
+private:
+    bgfx::TextureHandle m_handle;
+    int m_width;
+    int m_height;
+    bgfx::TextureFormat::Enum m_format;
+    int m_mipCount;
+    BGFXSamplerState m_samplerState;
+    uint64_t m_flags;
+};
+
+#endif // BGFXTEXTURE_H

--- a/Code/ww3d2/backends/bgfx/BGFXVertexBuffer.cpp
+++ b/Code/ww3d2/backends/bgfx/BGFXVertexBuffer.cpp
@@ -1,0 +1,92 @@
+// BGFXVertexBuffer.cpp - OpenW3D render backend
+
+#include "backends/bgfx/BGFXVertexBuffer.h"
+
+BGFXVertexBuffer::BGFXVertexBuffer()
+    : m_handle(BGFX_INVALID_HANDLE)
+    , m_vertexCount(0)
+{
+}
+
+BGFXVertexBuffer::~BGFXVertexBuffer()
+{
+    Destroy();
+}
+
+bool BGFXVertexBuffer::Create(void* data, int vertexCount, WW3DVertexFormat format, uint64_t flags)
+{
+    bgfx::VertexLayout layout = Make_Layout(format);
+    return Create(data, vertexCount, layout, flags);
+}
+
+bool BGFXVertexBuffer::Create(void* data, int vertexCount, const bgfx::VertexLayout& layout, uint64_t flags)
+{
+    Destroy();
+
+    if (!data || vertexCount <= 0) {
+        return false;
+    }
+
+    m_layout = layout;
+    m_vertexCount = vertexCount;
+
+    const uint32_t stride = layout.getStride();
+    const uint32_t size = vertexCount * stride;
+
+    const bgfx::Memory* mem = bgfx::copy(data, size);
+    m_handle = bgfx::createVertexBuffer(mem, layout, flags);
+
+    return bgfx::isValid(m_handle);
+}
+
+void BGFXVertexBuffer::Destroy()
+{
+    if (bgfx::isValid(m_handle)) {
+        bgfx::destroy(m_handle);
+        m_handle = BGFX_INVALID_HANDLE;
+    }
+    m_vertexCount = 0;
+}
+
+bgfx::VertexLayout BGFXVertexBuffer::Make_Layout(WW3DVertexFormat format)
+{
+    bgfx::VertexLayout layout;
+    layout.begin();
+
+    // Position is always present
+    layout.add(bgfx::Attrib::Position, 3, bgfx::AttribType::Float);
+
+    // Normal
+    if (format == WW3D_FORMAT_XYZNV1 || format == WW3D_FORMAT_XYZNDV1 ||
+        format == WW3D_FORMAT_XYZNV2 || format == WW3D_FORMAT_XYZNDV2 ||
+        format == WW3D_FORMAT_XYZNDUV1 || format == WW3D_FORMAT_XYZNDUV2) {
+        layout.add(bgfx::Attrib::Normal, 3, bgfx::AttribType::Float);
+    }
+
+    // Diffuse color
+    if (format == WW3D_FORMAT_XYZDUV1 || format == WW3D_FORMAT_XYZDUV2 ||
+        format == WW3D_FORMAT_XYZNDUV1 || format == WW3D_FORMAT_XYZNDUV2) {
+        layout.add(bgfx::Attrib::Color0, 4, bgfx::AttribType::Uint8, true);
+    }
+
+    // Texture coordinates
+    if (format == WW3D_FORMAT_XYZUV1 || format == WW3D_FORMAT_XYZDUV1 ||
+        format == WW3D_FORMAT_XYZNDUV1 || format == WW3D_FORMAT_XYZNV1) {
+        layout.add(bgfx::Attrib::TexCoord0, 2, bgfx::AttribType::Float);
+    }
+
+    if (format == WW3D_FORMAT_XYZUV2 || format == WW3D_FORMAT_XYZDUV2 ||
+        format == WW3D_FORMAT_XYZNDUV2 || format == WW3D_FORMAT_XYZNV2) {
+        layout.add(bgfx::Attrib::TexCoord0, 2, bgfx::AttribType::Float);
+        layout.add(bgfx::Attrib::TexCoord1, 2, bgfx::AttribType::Float);
+    }
+
+    layout.end();
+    return layout;
+}
+
+int BGFXVertexBuffer::Get_Stride(WW3DVertexFormat format)
+{
+    bgfx::VertexLayout layout = Make_Layout(format);
+    return layout.getStride();
+}

--- a/Code/ww3d2/backends/bgfx/BGFXVertexBuffer.h
+++ b/Code/ww3d2/backends/bgfx/BGFXVertexBuffer.h
@@ -1,0 +1,63 @@
+// BGFXVertexBuffer.h - OpenW3D render backend
+
+#ifndef BGFXVERTEXBUFFER_H
+#define BGFXVERTEXBUFFER_H
+
+#include "bgfx/bgfx.h"
+
+// Vertex format enumeration for DX8-style FVF vertex layouts
+enum WW3DVertexFormat {
+    WW3D_FORMAT_XYZ,         // XYZ only
+    WW3D_FORMAT_XYZUV1,      // XYZ + 1 UV set
+    WW3D_FORMAT_XYZUV2,      // XYZ + 2 UV sets
+    WW3D_FORMAT_XYZDUV1,     // XYZ + Diffuse + 1 UV set
+    WW3D_FORMAT_XYZDUV2,     // XYZ + Diffuse + 2 UV sets
+    WW3D_FORMAT_XYZNV1,      // XYZ + Normal + 1 UV set
+    WW3D_FORMAT_XYZNV2,      // XYZ + Normal + 2 UV sets
+    WW3D_FORMAT_XYZNDV1,     // XYZ + Normal + Diffuse + 1 UV set
+    WW3D_FORMAT_XYZNDV2,     // XYZ + Normal + Diffuse + 2 UV sets
+    WW3D_FORMAT_XYZNDUV1,    // XYZ + Normal + Diffuse + 1 UV set (alias)
+    WW3D_FORMAT_XYZNDUV2,    // XYZ + Normal + Diffuse + 2 UV sets (alias)
+};
+
+// BGFXVertexBuffer - wraps a bgfx vertex buffer with WW3D format support
+class BGFXVertexBuffer
+{
+public:
+    BGFXVertexBuffer();
+    ~BGFXVertexBuffer();
+
+    // Create from raw data with a specific vertex format
+    bool Create(void* data, int vertexCount, WW3DVertexFormat format, uint64_t flags = BGFX_BUFFER_NONE);
+
+    // Create from raw data with a bgfx vertex layout
+    bool Create(void* data, int vertexCount, const bgfx::VertexLayout& layout, uint64_t flags = BGFX_BUFFER_NONE);
+
+    // Destroy the buffer
+    void Destroy();
+
+    // Check if buffer is valid
+    bool Is_Valid() const { return bgfx::isValid(m_handle); }
+
+    // Get the bgfx handle
+    bgfx::VertexBufferHandle Get_Handle() const { return m_handle; }
+
+    // Get vertex count
+    int Get_Vertex_Count() const { return m_vertexCount; }
+
+    // Get vertex layout
+    const bgfx::VertexLayout& Get_Layout() const { return m_layout; }
+
+    // Static helper: Create bgfx vertex layout from vertex format
+    static bgfx::VertexLayout Make_Layout(WW3DVertexFormat format);
+
+    // Static helper: Get stride (bytes per vertex) for a vertex format
+    static int Get_Stride(WW3DVertexFormat format);
+
+private:
+    bgfx::VertexBufferHandle m_handle;
+    bgfx::VertexLayout m_layout;
+    int m_vertexCount;
+};
+
+#endif // BGFXVERTEXBUFFER_H

--- a/Code/ww3d2/backends/bgfx/CMakeLists.txt
+++ b/Code/ww3d2/backends/bgfx/CMakeLists.txt
@@ -1,0 +1,220 @@
+# BGFX Shader Build Rules - CMake integration for shader compilation.
+#
+# This CMakeLists.txt handles:
+#   - Build-time shader compilation using shaderc
+#   - Runtime fallback for loading pre-compiled shaders
+#   - Hot-reload support for development
+
+# Shader compilation setup
+set(BGFX_SHADER_DIR "${CMAKE_CURRENT_SOURCE_DIR}/shaders")
+set(BGFX_SHADER_SOURCE_DIR "${BGFX_SHADER_DIR}/source")
+set(BGFX_SHADER_EMBED_DIR "${BGFX_SHADER_DIR}/embed")
+set(BGFX_SHADER_VARYING_DEF "${BGFX_SHADER_DIR}/varying.def.sc")
+set(BGFX_SHADER_OUTPUT_DIR "${CMAKE_BINARY_DIR}/shaders")
+
+# Find shaderc compiler
+find_program(SHADERC_EXECUTABLE
+    NAMES shaderc shadercRelease
+    PATHS
+        "${BGFX_DIR}/.build/linux64_gcc/bin"
+        "${BGFX_DIR}/.build/win64_vs2022/bin"
+        "${BGFX_DIR}/.build/osx64_clang/bin"
+    DOC "bgfx shader compiler"
+)
+
+if(NOT SHADERC_EXECUTABLE)
+    message(WARNING "shaderc not found. Skipping shader compilation. Shaders must be provided pre-compiled in the output directory.")
+    # Create empty shader output directory so the build doesn't fail
+    file(MAKE_DIRECTORY ${BGFX_SHADER_OUTPUT_DIR})
+    return()
+endif()
+
+# Shader profiles for different renderers
+if(WIN32)
+    set(SHADER_PROFILES
+        "s_5_0"     # Direct3D 11 / 12
+    )
+    set(SHADER_PLATFORM "windows")
+else()
+    set(SHADER_PROFILES
+        "120"       # OpenGL 2.1 / GLES 2.0
+        "spirv"     # Vulkan
+    )
+    set(SHADER_PLATFORM "linux")
+endif()
+
+# Source shaders
+set(SHADER_SOURCES
+    "${BGFX_SHADER_SOURCE_DIR}/vs_mesh.sc"
+    "${BGFX_SHADER_SOURCE_DIR}/fs_mesh.sc"
+)
+
+# Function to compile a shader
+function(compile_bgfx_shader input_file output_file type profile)
+    if(NOT SHADERC_EXECUTABLE)
+        return()
+    endif()
+
+    get_filename_component(filename ${input_file} NAME)
+
+    add_custom_command(
+        OUTPUT ${output_file}
+        COMMAND ${SHADERC_EXECUTABLE}
+            -f ${input_file}
+            -o ${output_file}
+            --type ${type}
+            --platform ${SHADER_PLATFORM}
+            --profile ${profile}
+            --varyingdef ${BGFX_SHADER_VARYING_DEF}
+            -i "${BGFX_SHADER_SOURCE_DIR}"
+            -i "${BGFX_DIR}/src"
+            -i "${BGFX_DIR}/include"
+            -i "${BGFX_DIR}/examples/common"
+        DEPENDS ${input_file} ${BGFX_SHADER_VARYING_DEF}
+        COMMENT "Compiling bgfx shader: ${filename}"
+        VERBATIM
+    )
+endfunction()
+
+# Compile all shaders
+set(COMPILED_SHADERS)
+
+foreach(SHADER_SRC ${SHADER_SOURCES})
+    get_filename_component(SHADER_NAME ${SHADER_SRC} NAME_WE)
+    get_filename_component(SHADER_EXT ${SHADER_SRC} EXT)
+
+    # Determine shader type from extension
+    if(SHADER_EXT STREQUAL ".sc")
+        if(SHADER_NAME MATCHES "^vs_")
+            set(SHADER_TYPE "vertex")
+        elseif(SHADER_NAME MATCHES "^fs_")
+            set(SHADER_TYPE "fragment")
+        elseif(SHADER_NAME MATCHES "^cs_")
+            set(SHADER_TYPE "compute")
+        else()
+            set(SHADER_TYPE "vertex")
+        endif()
+    endif()
+
+    # Compile for each profile
+    foreach(PROFILE ${SHADER_PROFILES})
+        set(OUTPUT_FILE "${BGFX_SHADER_OUTPUT_DIR}/${SHADER_NAME}_${PROFILE}.bin")
+        compile_bgfx_shader(${SHADER_SRC} ${OUTPUT_FILE} ${SHADER_TYPE} ${PROFILE})
+        list(APPEND COMPILED_SHADERS ${OUTPUT_FILE})
+    endforeach()
+endforeach()
+
+# Create shader output directory
+file(MAKE_DIRECTORY ${BGFX_SHADER_OUTPUT_DIR})
+
+# Add custom target for shader compilation (only if shaders were compiled)
+if(COMPILED_SHADERS)
+    add_custom_target(bgfx-shaders ALL DEPENDS ${COMPILED_SHADERS})
+endif()
+
+# Copy embedded shaders if they exist
+if(EXISTS ${BGFX_SHADER_EMBED_DIR})
+    file(GLOB EMBEDDED_SHADERS "${BGFX_SHADER_EMBED_DIR}/*.bin")
+    if(EMBEDDED_SHADERS)
+        foreach(EMBED ${EMBEDDED_SHADERS})
+            get_filename_component(EMBED_NAME ${EMBED} NAME)
+            set(OUTPUT "${BGFX_SHADER_OUTPUT_DIR}/${EMBED_NAME}")
+            add_custom_command(
+                OUTPUT ${OUTPUT}
+                COMMAND ${CMAKE_COMMAND} -E copy ${EMBED} ${OUTPUT}
+                DEPENDS ${EMBED}
+                COMMENT "Copying embedded shader: ${EMBED_NAME}"
+            )
+            list(APPEND COMPILED_SHADERS ${OUTPUT})
+        endforeach()
+    endif()
+endif()
+
+# Export shader directory for use by the main build
+set(BGFX_SHADER_OUTPUT_DIR "${BGFX_SHADER_OUTPUT_DIR}" PARENT_SCOPE)
+
+message(STATUS "BGFX shader output: ${BGFX_SHADER_OUTPUT_DIR}")
+
+# ─────────────────────────────────────────────────────────────────────
+# Uber shader compilation pipeline (vs_uber.sc / fs_uber.sc → D3D11)
+# ─────────────────────────────────────────────────────────────────────
+
+set(UBER_SHADER_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/shaders/source")
+set(UBER_SHADER_OUTPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/shaders/d3d11")
+
+# Find shaderc executable (preferred: prebuilt binaries from bgfx)
+find_program(UBER_SHADERC_EXECUTABLE
+    NAMES shaderc shaderc.exe shadercRelease shadercRelease.exe
+    PATHS
+        "${BGFX_DIR}/tools/bin/windows"
+        "${BGFX_DIR}/.build/win64_vs2022/bin"
+        "${BGFX_DIR}/.build/win32_vs2022/bin"
+        "${BGFX_DIR}/.build/linux64_gcc/bin"
+    DOC "bgfx shader compiler for uber shaders"
+    NO_DEFAULT_PATH
+)
+
+# Fallback: search PATH
+if(NOT UBER_SHADERC_EXECUTABLE)
+    find_program(UBER_SHADERC_EXECUTABLE NAMES shaderc shaderc.exe shadercRelease shadercRelease.exe)
+endif()
+
+if(NOT UBER_SHADERC_EXECUTABLE)
+    message(WARNING "shaderc not found. Skipping uber shader compilation. Pre-compiled .bin files may be used.")
+else()
+    message(STATUS "Found shaderc: ${UBER_SHADERC_EXECUTABLE}")
+
+    # Ensure output directory exists
+    file(MAKE_DIRECTORY "${UBER_SHADER_OUTPUT_DIR}")
+
+    # Vertex shader: vs_uber.sc → vs_uber.bin
+    set(UBER_VS_SRC "${UBER_SHADER_SOURCE_DIR}/vs_uber.sc")
+    set(UBER_VS_OUT "${UBER_SHADER_OUTPUT_DIR}/vs_uber.bin")
+
+    add_custom_command(
+        OUTPUT "${UBER_VS_OUT}"
+        COMMAND "${UBER_SHADERC_EXECUTABLE}"
+            -f "${UBER_VS_SRC}"
+            -o "${UBER_VS_OUT}"
+            --type vertex
+            --platform windows
+            --profile s_5_0
+            --varyingdef "${CMAKE_CURRENT_SOURCE_DIR}/shaders/varying.def.sc"
+            -i "${UBER_SHADER_SOURCE_DIR}"
+            -i "${BGFX_DIR}/src"
+        DEPENDS "${UBER_VS_SRC}" "${CMAKE_CURRENT_SOURCE_DIR}/shaders/varying.def.sc"
+        COMMENT "Compiling uber vertex shader: vs_uber.sc → vs_uber.bin"
+        VERBATIM
+    )
+
+    # Fragment shader: fs_uber.sc → fs_uber.bin
+    set(UBER_FS_SRC "${UBER_SHADER_SOURCE_DIR}/fs_uber.sc")
+    set(UBER_FS_OUT "${UBER_SHADER_OUTPUT_DIR}/fs_uber.bin")
+
+    add_custom_command(
+        OUTPUT "${UBER_FS_OUT}"
+        COMMAND "${UBER_SHADERC_EXECUTABLE}"
+            -f "${UBER_FS_SRC}"
+            -o "${UBER_FS_OUT}"
+            --type fragment
+            --platform windows
+            --profile s_5_0
+            --varyingdef "${CMAKE_CURRENT_SOURCE_DIR}/shaders/varying.def.sc"
+            -i "${UBER_SHADER_SOURCE_DIR}"
+            -i "${BGFX_DIR}/src"
+        DEPENDS "${UBER_FS_SRC}" "${CMAKE_CURRENT_SOURCE_DIR}/shaders/varying.def.sc"
+        COMMENT "Compiling uber fragment shader: fs_uber.sc → fs_uber.bin"
+        VERBATIM
+    )
+
+    # Custom target that depends on all compiled uber shaders
+    add_custom_target(bgfx_shaders
+        DEPENDS
+            "${UBER_VS_OUT}"
+            "${UBER_FS_OUT}"
+        COMMENT "Building bgfx uber shaders"
+    )
+
+    # Ensure uber shaders are compiled before the ww3d2 library
+    add_dependencies(ww3d2 bgfx_shaders)
+endif()

--- a/Code/ww3d2/backends/bgfx/ShaderKey.h
+++ b/Code/ww3d2/backends/bgfx/ShaderKey.h
@@ -1,0 +1,95 @@
+#pragma once
+#include "shader.h"
+#include <cstddef>
+#include <functional>
+
+struct ShaderKey {
+    uint8_t depthCompare : 3;     // PASS_NEVER..PASS_ALWAYS
+    uint8_t depthWrite   : 1;     // 0=disable, 1=enable
+    uint8_t blendMode    : 4;     // 0=opaque, 1=additive, 2=alpha, 3=mult, 4=screen
+    uint8_t alphaTest    : 1;     // 0=off, 1=on
+    uint8_t fogMode      : 2;     // 0=off, 1=linear, 2=exp, 3=exp2
+    uint8_t texturing    : 1;     // 0=solid color, 1=texture
+    uint8_t priGradient  : 3;     // 0=off, 1=modulate, 2=add, 3=bump, 4=bumplum, 5=dot3
+    uint8_t secGradient  : 1;     // 0=off, 1=on
+    uint8_t lighting     : 1;     // 0=unlit, 1=lit
+    uint8_t texStageCount: 3;     // 0-8 active texture stages
+    uint8_t detailColor  : 4;     // DETAILCOLOR_* function
+    uint8_t detailAlpha  : 3;     // DETAILALPHA_* function
+
+    bool operator==(const ShaderKey& o) const {
+        return std::memcmp(this, &o, sizeof(ShaderKey)) == 0;
+    }
+    bool operator!=(const ShaderKey& o) const { return !(*this == o); }
+};
+
+namespace std {
+    template<> struct hash<ShaderKey> {
+        size_t operator()(const ShaderKey& k) const {
+            // Pack into a 64-bit value for hashing
+            const uint8_t* p = reinterpret_cast<const uint8_t*>(&k);
+            size_t h = 0;
+            for (size_t i = 0; i < sizeof(ShaderKey); ++i)
+                h = h * 31 + p[i];
+            return h;
+        }
+    };
+}
+
+inline ShaderKey ShaderKey_From_DX8(const ShaderClass& shader) {
+    ShaderKey key = {};
+
+    // Depth
+    key.depthCompare = static_cast<uint8_t>(shader.Get_Depth_Compare());
+    key.depthWrite   = (shader.Get_Depth_Mask() == ShaderClass::DEPTH_WRITE_ENABLE) ? 1 : 0;
+
+    // Blend mode mapping (src+dst blend combo -> enum)
+    auto srcBlend = shader.Get_Src_Blend_Func();
+    auto dstBlend = shader.Get_Dst_Blend_Func();
+    if (srcBlend == ShaderClass::SRCBLEND_ONE && dstBlend == ShaderClass::DSTBLEND_ZERO)
+        key.blendMode = 0; // opaque
+    else if (srcBlend == ShaderClass::SRCBLEND_ONE && dstBlend == ShaderClass::DSTBLEND_ONE)
+        key.blendMode = 1; // additive
+    else if (srcBlend == ShaderClass::SRCBLEND_SRC_ALPHA && dstBlend == ShaderClass::DSTBLEND_ONE_MINUS_SRC_ALPHA)
+        key.blendMode = 2; // alpha
+    else if (srcBlend == ShaderClass::SRCBLEND_ZERO && dstBlend == ShaderClass::DSTBLEND_SRC_COLOR)
+        key.blendMode = 3; // multiplicative
+    else if (srcBlend == ShaderClass::SRCBLEND_SRC_ALPHA && dstBlend == ShaderClass::DSTBLEND_ONE)
+        key.blendMode = 4; // screen-like (additive with alpha)
+    else
+        key.blendMode = 5; // other/custom
+
+    // Alpha test
+    key.alphaTest = (shader.Get_Alpha_Test() != ShaderClass::ALPHATEST_DISABLE) ? 1 : 0;
+
+    // Fog
+    switch (shader.Get_Fog_Func()) {
+        case ShaderClass::FOG_DISABLE:    key.fogMode = 0; break;
+        case ShaderClass::FOG_ENABLE:     key.fogMode = 1; break;
+        case ShaderClass::FOG_SCALE_FRAGMENT: key.fogMode = 2; break;
+        case ShaderClass::FOG_WHITE:      key.fogMode = 3; break;
+        default: key.fogMode = 0; break;
+    }
+
+    // Texturing
+    key.texturing = (shader.Get_Texturing() != ShaderClass::TEXTURING_DISABLE) ? 1 : 0;
+
+    // Primary gradient
+    key.priGradient = static_cast<uint8_t>(shader.Get_Primary_Gradient());
+
+    // Secondary gradient
+    key.secGradient = (shader.Get_Secondary_Gradient() != ShaderClass::SECONDARY_GRADIENT_DISABLE) ? 1 : 0;
+
+    // Post-detail functions (detail maps)
+    key.detailColor = static_cast<uint8_t>(shader.Get_Post_Detail_Color_Func());
+    key.detailAlpha = static_cast<uint8_t>(shader.Get_Post_Detail_Alpha_Func());
+
+    // Lighting: infer from gradient — if gradient is modulate, lighting is active
+    key.lighting = (key.priGradient == ShaderClass::GRADIENT_MODULATE ||
+                    key.priGradient == ShaderClass::GRADIENT_ADD) ? 1 : 0;
+
+    // Texture stages — start with 1, will be set by texture binding code
+    key.texStageCount = key.texturing ? 1 : 0;
+
+    return key;
+}

--- a/Code/ww3d2/backends/bgfx/ShaderVariantCache.cpp
+++ b/Code/ww3d2/backends/bgfx/ShaderVariantCache.cpp
@@ -1,0 +1,146 @@
+#include "ShaderVariantCache.h"
+#include <bx/file.h>
+#include <cstdio>
+#include <cstdlib>
+
+// Release callback for bgfx::makeRef — frees memory allocated with malloc
+static void ReleaseShaderMemory(void* _ptr, void* _userData)
+{
+    free(_ptr);
+    (void)_userData;
+}
+
+bgfx::ShaderHandle ShaderVariantCache::LoadShader(const std::string& path)
+{
+    bx::FileReader reader;
+    if (!bx::open(&reader, path.c_str()))
+    {
+        return BGFX_INVALID_HANDLE;
+    }
+
+    const uint32_t size = static_cast<uint32_t>(bx::getSize(&reader));
+    if (size == 0)
+    {
+        bx::close(&reader);
+        return BGFX_INVALID_HANDLE;
+    }
+
+    // Allocate buffer that will persist until bgfx releases it
+    void* buffer = malloc(size);
+    if (!buffer)
+    {
+        bx::close(&reader);
+        return BGFX_INVALID_HANDLE;
+    }
+
+    bx::read(&reader, buffer, size, bx::ErrorAssert{});
+    bx::close(&reader);
+
+    // Create bgfx memory reference with release callback
+    const bgfx::Memory* mem = bgfx::makeRef(buffer, size, ReleaseShaderMemory, nullptr);
+    if (!mem || !mem->data)
+    {
+        free(buffer);
+        return BGFX_INVALID_HANDLE;
+    }
+
+    bgfx::ShaderHandle handle = bgfx::createShader(mem);
+    if (!bgfx::isValid(handle))
+    {
+        return BGFX_INVALID_HANDLE;
+    }
+
+    return handle;
+}
+
+std::string ShaderVariantCache::GetShaderPath(const ShaderKey& key, bool vertex)
+{
+    if (vertex)
+    {
+        return "shaders/d3d11/vs_uber.bin";
+    }
+    else
+    {
+        return "shaders/d3d11/fs_uber.bin";
+    }
+}
+
+const ShaderVariantCache::ShaderVariant* ShaderVariantCache::GetOrCreate(const ShaderKey& key)
+{
+    auto it = m_cache.find(key);
+    if (it != m_cache.end())
+    {
+        it->second.uses++;
+        return &it->second;
+    }
+
+    // Create new variant
+    ShaderVariant variant = LoadOrCreateProgram(key);
+    if (!bgfx::isValid(variant.program))
+    {
+        return nullptr;
+    }
+
+    variant.uses = 1;
+    auto result = m_cache.emplace(key, std::move(variant));
+    return &result.first->second;
+}
+
+ShaderVariantCache::ShaderVariant ShaderVariantCache::LoadOrCreateProgram(const ShaderKey& key)
+{
+    ShaderVariant variant;
+
+    std::string vsPath = GetShaderPath(key, true);
+    std::string fsPath = GetShaderPath(key, false);
+
+    variant.vs = LoadShader(vsPath);
+    if (!bgfx::isValid(variant.vs))
+    {
+        return variant;
+    }
+
+    variant.fs = LoadShader(fsPath);
+    if (!bgfx::isValid(variant.fs))
+    {
+        bgfx::destroy(variant.vs);
+        variant.vs = BGFX_INVALID_HANDLE;
+        return variant;
+    }
+
+    variant.program = bgfx::createProgram(variant.vs, variant.fs, true /* destroy shaders when program is destroyed */);
+    if (!bgfx::isValid(variant.program))
+    {
+        variant.vs = BGFX_INVALID_HANDLE;
+        variant.fs = BGFX_INVALID_HANDLE;
+        return variant;
+    }
+
+    // Since createProgram was called with _destroyShaders=true,
+    // bgfx owns the shader handles now — clear them from our struct
+    // so we don't double-destroy in Clear().
+    variant.vs = BGFX_INVALID_HANDLE;
+    variant.fs = BGFX_INVALID_HANDLE;
+
+    return variant;
+}
+
+void ShaderVariantCache::Clear()
+{
+    for (auto& pair : m_cache)
+    {
+        ShaderVariant& variant = pair.second;
+        if (bgfx::isValid(variant.program))
+        {
+            bgfx::destroy(variant.program);
+        }
+        if (bgfx::isValid(variant.vs))
+        {
+            bgfx::destroy(variant.vs);
+        }
+        if (bgfx::isValid(variant.fs))
+        {
+            bgfx::destroy(variant.fs);
+        }
+    }
+    m_cache.clear();
+}

--- a/Code/ww3d2/backends/bgfx/ShaderVariantCache.h
+++ b/Code/ww3d2/backends/bgfx/ShaderVariantCache.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "ShaderKey.h"
+#include <bgfx/bgfx.h>
+#include <unordered_map>
+#include <string>
+
+class ShaderVariantCache {
+public:
+    struct ShaderVariant {
+        bgfx::ProgramHandle program = BGFX_INVALID_HANDLE;
+        bgfx::ShaderHandle vs = BGFX_INVALID_HANDLE;
+        bgfx::ShaderHandle fs = BGFX_INVALID_HANDLE;
+        uint32_t uses = 0;
+    };
+
+    const ShaderVariant* GetOrCreate(const ShaderKey& key);
+    void Clear();
+
+private:
+    std::unordered_map<ShaderKey, ShaderVariant> m_cache;
+    ShaderVariant LoadOrCreateProgram(const ShaderKey& key);
+    bgfx::ShaderHandle LoadShader(const std::string& path);
+    std::string GetShaderPath(const ShaderKey& key, bool vertex);
+};

--- a/Code/ww3d2/backends/bgfx/bgfxbackend.cpp
+++ b/Code/ww3d2/backends/bgfx/bgfxbackend.cpp
@@ -1,0 +1,2261 @@
+// bgfxbackend.cpp - OpenW3D render backend
+
+#include "backends/bgfx/bgfxbackend.h"
+#include "backends/bgfx/ShaderKey.h"
+#include "backends/bgfx/ShaderVariantCache.h"
+#include "rddesc.h"
+#include "dx8wrapper.h"
+#include "shader.h"
+#include "texture.h"
+#include "vertmaterial.h"
+#include "lightenvironment.h"
+#include "dx8vertexbuffer.h"
+#include "dx8indexbuffer.h"
+#include "matrix4.h"
+#include "matrix3d.h"
+#include "surfaceclass.h"
+#include "ww3dformat.h"
+
+#include <bgfx/bgfx.h>
+#include <bgfx/platform.h>
+#include <stdio.h>  // for fopen, fread, fclose
+#include <string.h> // for strlen
+
+// Platform detection
+#if defined(_WIN32) || defined(_WIN64)
+#define BGFX_PLATFORM_WINDOWS 1
+#elif defined(__linux__)
+#define BGFX_PLATFORM_LINUX 1
+#elif defined(__APPLE__) && defined(__MACH__)
+#define BGFX_PLATFORM_OSX 1
+#else
+#error "Unsupported platform"
+#endif
+
+#if BGFX_PLATFORM_WINDOWS
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#elif BGFX_PLATFORM_LINUX
+#include <X11/Xlib.h>
+#elif BGFX_PLATFORM_OSX
+#include <Cocoa/Cocoa.h>
+#endif
+
+namespace
+{
+    const int DEFAULT_WIDTH = 1024;
+    const int DEFAULT_HEIGHT = 768;
+    const int DEFAULT_BIT_DEPTH = 32;
+
+    // Map DX8 fill mode to bgfx state flags
+    uint64_t FillMode_To_BGFX(unsigned fillmode)
+    {
+        switch (fillmode) {
+            case DX8RenderState::WIREFRAME:
+                return BGFX_STATE_PT_LINES;
+            case DX8RenderState::POINT:
+                return BGFX_STATE_PT_POINTS;
+            case DX8RenderState::SOLID:
+            default:
+                return BGFX_STATE_NONE;
+        }
+    }
+
+    // Map DX8 cull mode to bgfx state flags
+    uint64_t CullMode_To_BGFX(unsigned cullmode)
+    {
+        switch (cullmode) {
+            case DX8RenderState::NONE:
+                return BGFX_STATE_NONE;
+            case DX8RenderState::CW:
+                return BGFX_STATE_CULL_CW;
+            case DX8RenderState::CCW:
+                return BGFX_STATE_CULL_CCW;
+            default:
+                return BGFX_STATE_CULL_CCW;
+        }
+    }
+
+    // Map DX8 blend factors to bgfx state flags
+    uint64_t BlendFactor_To_BGFX(unsigned factor)
+    {
+        switch (factor) {
+            case DX8RenderState::ZERO:           return BGFX_STATE_BLEND_ZERO;
+            case DX8RenderState::ONE:            return BGFX_STATE_BLEND_ONE;
+            case DX8RenderState::SRCCOLOR:       return BGFX_STATE_BLEND_SRC_COLOR;
+            case DX8RenderState::INVERTSRCCOLOR: return BGFX_STATE_BLEND_INV_SRC_COLOR;
+            case DX8RenderState::SRCALPHA:       return BGFX_STATE_BLEND_SRC_ALPHA;
+            case DX8RenderState::INVERTSRCALPHA: return BGFX_STATE_BLEND_INV_SRC_ALPHA;
+            case DX8RenderState::DESTALPHA:      return BGFX_STATE_BLEND_DST_ALPHA;
+            case DX8RenderState::INVERTDESTALPHA: return BGFX_STATE_BLEND_INV_DST_ALPHA;
+            case DX8RenderState::DESTCOLOR:       return BGFX_STATE_BLEND_DST_COLOR;
+            case DX8RenderState::INVERTDESTCOLOR: return BGFX_STATE_BLEND_INV_DST_COLOR;
+            case DX8RenderState::SRCALPHASAT:    return BGFX_STATE_BLEND_SRC_ALPHA_SAT;
+            default:                             return BGFX_STATE_BLEND_ONE;
+        }
+    }
+}
+
+BGFXBackend::BGFXBackend() :
+    m_hwnd(nullptr),
+    m_nativeDisplay(nullptr),
+    m_width(DEFAULT_WIDTH),
+    m_height(DEFAULT_HEIGHT),
+    m_bitDepth(DEFAULT_BIT_DEPTH),
+    m_windowed(true),
+    m_currentDevice(0),
+    m_swapInterval(1),
+    m_textureBitDepth(DEFAULT_BIT_DEPTH),
+    m_systemTexture(BGFX_INVALID_HANDLE),
+    m_frameBuffer(BGFX_INVALID_HANDLE),
+    m_currentProgram(BGFX_INVALID_HANDLE),
+    m_whiteTexture(BGFX_INVALID_HANDLE),
+    m_initialized(false),
+    m_currentState(BGFX_STATE_DEFAULT),
+    m_currentColor(0xFF000000),
+    m_viewportX(0),
+    m_viewportY(0),
+    m_viewportWidth(DEFAULT_WIDTH),
+    m_viewportHeight(DEFAULT_HEIGHT),
+    m_viewportMinZ(0.0f),
+    m_viewportMaxZ(1.0f),
+    m_scissorEnabled(false),
+    m_scissorX(0),
+    m_scissorY(0),
+    m_scissorWidth(0),
+    m_scissorHeight(0),
+    m_activeFrameBuffer(BGFX_INVALID_HANDLE),
+    m_diffuseUniform(BGFX_INVALID_HANDLE),
+    m_specularUniform(BGFX_INVALID_HANDLE),
+    m_emissiveUniform(BGFX_INVALID_HANDLE),
+    m_ambientUniform(BGFX_INVALID_HANDLE),
+    m_opacityUniform(BGFX_INVALID_HANDLE),
+    m_lightingEnableUniform(BGFX_INVALID_HANDLE),
+    m_alphaTestUniform(BGFX_INVALID_HANDLE),
+    m_ambientLightUniform(BGFX_INVALID_HANDLE),
+    m_fogColorUniform(BGFX_INVALID_HANDLE),
+    m_fogParamsUniform(BGFX_INVALID_HANDLE),
+    m_lightDirUniform(BGFX_INVALID_HANDLE),
+    m_lightDiffuseUniform(BGFX_INVALID_HANDLE),
+    m_modelUniform(BGFX_INVALID_HANDLE),
+    m_viewProjUniform(BGFX_INVALID_HANDLE),
+    m_camPosUniform(BGFX_INVALID_HANDLE),
+    m_defaultProgram(BGFX_INVALID_HANDLE),
+    m_worldDirty(false),
+    m_viewDirty(false),
+    m_projectionDirty(false),
+    m_currentVB(nullptr),
+    m_currentIB(nullptr),
+    m_currentIBOffset(0),
+    m_currentMaterial(nullptr),
+    m_currentLightEnv(nullptr),
+    m_shaderModeUniform(BGFX_INVALID_HANDLE),
+    m_shaderFlagsUniform(BGFX_INVALID_HANDLE),
+    m_detailFuncUniform(BGFX_INVALID_HANDLE),
+    m_activeTextureStages(0)
+{
+    m_samplerUniforms.fill(BGFX_INVALID_HANDLE);
+    m_boundTextures.fill(BGFX_INVALID_HANDLE);
+    m_textureFlags.fill(UINT32_MAX);
+    m_textureMipLevels.fill(0);
+    m_textureUvIndices.fill(0);
+
+    // Populate device enumeration
+    // Device 0: Auto-detect
+    // Device 1: Vulkan
+    // Device 2: OpenGL
+    // Device 3: Direct3D 11
+    // Device 4: Direct3D 12
+    m_deviceNames.emplace_back("Auto");
+    m_deviceNames.emplace_back("Vulkan");
+    m_deviceNames.emplace_back("OpenGL");
+#if defined(_WIN32) || defined(_WIN64)
+    m_deviceNames.emplace_back("Direct3D 11");
+    m_deviceNames.emplace_back("Direct3D 12");
+#endif
+}
+
+BGFXBackend::~BGFXBackend()
+{
+    Shutdown();
+}
+bool BGFXBackend::Init(void * hwnd, bool lite)
+{
+    if (m_initialized) {
+        return true;
+    }
+
+    m_hwnd = hwnd;
+
+    // Set platform-specific data for bgfx
+    bgfx::PlatformData pd;
+    memset(&pd, 0, sizeof(pd));
+
+#if BGFX_PLATFORM_WINDOWS
+    pd.ndt = nullptr;
+    pd.nwh = hwnd;
+    pd.type = bgfx::NativeWindowHandleType::Default;
+#elif BGFX_PLATFORM_LINUX
+    if (!m_nativeDisplay) {
+        m_nativeDisplay = XOpenDisplay(nullptr);
+    }
+    pd.ndt = m_nativeDisplay;
+    pd.nwh = (void*)nullptr;
+    pd.type = bgfx::NativeWindowHandleType::Default;
+#elif BGFX_PLATFORM_OSX
+    pd.ndt = nullptr;
+    pd.nwh = hwnd;
+    pd.type = bgfx::NativeWindowHandleType::Default;
+#endif
+
+    bgfx::setPlatformData(pd);
+
+    // Determine renderer type based on selected device
+    bgfx::RendererType::Enum renderer = bgfx::RendererType::Count;  // 0 = auto-detect
+    if (m_currentDevice == 1) {
+        renderer = bgfx::RendererType::Vulkan;
+    } else if (m_currentDevice == 2) {
+        renderer = bgfx::RendererType::OpenGL;
+    } else if (m_currentDevice == 3) {
+        renderer = bgfx::RendererType::Direct3D11;
+    } else if (m_currentDevice == 4) {
+        renderer = bgfx::RendererType::Direct3D12;
+    }
+
+    bgfx::Init init;
+    init.type = renderer;
+    init.vendorId = BGFX_PCI_ID_NONE;
+    init.deviceId = 0;
+    init.debug = false;
+    init.profile = false;
+    init.resolution.width = static_cast<uint32_t>(m_width);
+    init.resolution.height = static_cast<uint32_t>(m_height);
+    init.resolution.reset = BGFX_RESET_VSYNC;
+    init.resolution.maxFrameLatency = 1;
+
+    if (!bgfx::init(init)) {
+        return false;
+    }
+
+    m_initialized = true;
+
+    m_samplerUniforms[0] = bgfx::createUniform("s_diffuse", bgfx::UniformType::Sampler);
+    for (int stage = 1; stage < MAX_TEXTURE_STAGES; ++stage) {
+        char samplerName[16];
+        snprintf(samplerName, sizeof(samplerName), "s_tex%d", stage);
+        m_samplerUniforms[stage] = bgfx::createUniform(samplerName, bgfx::UniformType::Sampler);
+    }
+
+    m_diffuseUniform = bgfx::createUniform(BGFXMaterialUniforms::DIFFUSE_COLOR, bgfx::UniformType::Vec4);
+    m_specularUniform = bgfx::createUniform(BGFXMaterialUniforms::SPECULAR_COLOR, bgfx::UniformType::Vec4);
+    m_emissiveUniform = bgfx::createUniform(BGFXMaterialUniforms::EMISSIVE_COLOR, bgfx::UniformType::Vec4);
+    m_ambientUniform = bgfx::createUniform(BGFXMaterialUniforms::AMBIENT_COLOR, bgfx::UniformType::Vec4);
+    m_opacityUniform = bgfx::createUniform(BGFXMaterialUniforms::OPACITY, bgfx::UniformType::Vec4);
+    m_lightingEnableUniform = bgfx::createUniform(BGFXMaterialUniforms::LIGHTING_ENABLE, bgfx::UniformType::Vec4);
+    m_alphaTestUniform = bgfx::createUniform("u_alphaTest", bgfx::UniformType::Vec4);
+
+    // Fog uniforms
+    m_fogColorUniform = bgfx::createUniform("u_fogColor", bgfx::UniformType::Vec4);
+    m_fogParamsUniform = bgfx::createUniform("u_fogParams", bgfx::UniformType::Vec4);
+
+    // Light environment uniforms (arrays of 4)
+    m_ambientLightUniform = bgfx::createUniform("u_ambientLight", bgfx::UniformType::Vec4);
+    m_lightDirUniform = bgfx::createUniform("u_lightDir", bgfx::UniformType::Vec4, 4);
+    m_lightDiffuseUniform = bgfx::createUniform("u_lightDiffuse", bgfx::UniformType::Vec4, 4);
+    m_lightPosUniform = bgfx::createUniform("u_lightPos", bgfx::UniformType::Vec4, 4);
+
+    // Transform uniforms (mat4 arrays for bgfx)
+    m_modelUniform = bgfx::createUniform("u_uberModel", bgfx::UniformType::Vec4, 4);
+    m_viewProjUniform = bgfx::createUniform("u_uberViewProj", bgfx::UniformType::Vec4, 4);
+    m_camPosUniform = bgfx::createUniform("u_uberCamPos", bgfx::UniformType::Vec4);
+
+    // Ubershader uniforms
+    m_shaderModeUniform = bgfx::createUniform("u_shaderMode", bgfx::UniformType::Vec4);
+    m_shaderFlagsUniform = bgfx::createUniform("u_shaderFlags", bgfx::UniformType::Vec4);
+    m_detailFuncUniform = bgfx::createUniform("u_detailFunc", bgfx::UniformType::Vec4);
+
+    // Load default mesh shader program
+    {
+        const char* suffix = "120"; // default to OpenGL/D3D11
+        bgfx::RendererType::Enum rt = bgfx::getRendererType();
+        switch (rt) {
+            case bgfx::RendererType::Vulkan:       suffix = "spirv"; break;
+            case bgfx::RendererType::Metal:        suffix = "metal"; break;
+            case bgfx::RendererType::OpenGLES:     suffix = "120";   break;
+            case bgfx::RendererType::Direct3D11:   suffix = "s_5_0"; break;
+            case bgfx::RendererType::Direct3D12:   suffix = "s_5_0"; break;
+            case bgfx::RendererType::OpenGL:       suffix = "120";   break;
+            default:                               suffix = "120";   break;
+        }
+        char vsPath[512];
+        char fsPath[512];
+        const char* shaderDirs[] = {
+            "./shaders/",
+            "../shaders/",
+            "shaders/",
+            "../../shaders/",
+            nullptr
+        };
+        bgfx::ShaderHandle vs = BGFX_INVALID_HANDLE;
+        bgfx::ShaderHandle fs = BGFX_INVALID_HANDLE;
+        for (int i = 0; shaderDirs[i] && !bgfx::isValid(vs); ++i) {
+            snprintf(vsPath, sizeof(vsPath), "%svs_mesh_%s.bin", shaderDirs[i], suffix);
+            snprintf(fsPath, sizeof(fsPath), "%sfs_mesh_%s.bin", shaderDirs[i], suffix);
+            vs = Load_Shader(vsPath);
+            if (bgfx::isValid(vs)) {
+                fs = Load_Shader(fsPath);
+            }
+            if (bgfx::isValid(vs) && bgfx::isValid(fs)) {
+                WWDEBUG_SAY(("BGFXBackend: Loaded shaders from %s\n", shaderDirs[i]));
+                break;
+            }
+            vs = BGFX_INVALID_HANDLE;
+            fs = BGFX_INVALID_HANDLE;
+        }
+        if (bgfx::isValid(vs) && bgfx::isValid(fs)) {
+            m_defaultProgram = bgfx::createProgram(vs, fs, true); // destroy shaders when program is destroyed
+        } else {
+            WWDEBUG_SAY(("BGFXBackend: Failed to load default mesh shaders (suffix: %s)\n", suffix));
+            WWDEBUG_SAY(("BGFXBackend: Tried paths: ./shaders/, ../shaders/, shaders/, ../../shaders/\n"));
+        }
+    }
+
+    // Set initial view dimensions
+    Update_ViewDimensions();
+
+    // Set vsync
+    Set_Swap_Interval(m_swapInterval);
+
+    // Initialize render state cache with defaults
+    m_render_state[DX8RenderState::FILLMODE] = DX8RenderState::SOLID;
+    m_render_state[DX8RenderState::CULLMODE] = DX8RenderState::CCW;
+    m_render_state[DX8RenderState::BLENDENABLE] = 0;
+    m_render_state[DX8RenderState::ZENABLE] = 1;
+    m_render_state[DX8RenderState::ZWRITEENABLE] = 1;
+
+    return true;
+}
+
+void BGFXBackend::Shutdown()
+{
+    if (!m_initialized) {
+        return;
+    }
+
+    if (bgfx::isValid(m_frameBuffer)) {
+        bgfx::destroy(m_frameBuffer);
+        m_frameBuffer = BGFX_INVALID_HANDLE;
+    }
+
+    if (bgfx::isValid(m_systemTexture)) {
+        bgfx::destroy(m_systemTexture);
+        m_systemTexture = BGFX_INVALID_HANDLE;
+    }
+
+    for (bgfx::UniformHandle& sampler : m_samplerUniforms) {
+        if (bgfx::isValid(sampler)) {
+            bgfx::destroy(sampler);
+            sampler = BGFX_INVALID_HANDLE;
+        }
+    }
+
+    bgfx::UniformHandle uniforms[] = {
+        m_diffuseUniform,
+        m_specularUniform,
+        m_emissiveUniform,
+        m_ambientUniform,
+        m_opacityUniform,
+        m_lightingEnableUniform,
+        m_alphaTestUniform,
+        m_ambientLightUniform,
+        m_lightDirUniform,
+        m_lightDiffuseUniform,
+        m_lightPosUniform,
+        m_fogColorUniform,
+        m_fogParamsUniform,
+        m_modelUniform,
+        m_viewProjUniform,
+        m_camPosUniform,
+        m_shaderModeUniform,
+        m_shaderFlagsUniform,
+        m_detailFuncUniform,
+    };
+
+    for (bgfx::UniformHandle uniform : uniforms) {
+        if (bgfx::isValid(uniform)) {
+            bgfx::destroy(uniform);
+        }
+    }
+
+    m_diffuseUniform = BGFX_INVALID_HANDLE;
+    m_specularUniform = BGFX_INVALID_HANDLE;
+    m_emissiveUniform = BGFX_INVALID_HANDLE;
+    m_ambientUniform = BGFX_INVALID_HANDLE;
+    m_opacityUniform = BGFX_INVALID_HANDLE;
+    m_lightingEnableUniform = BGFX_INVALID_HANDLE;
+    m_alphaTestUniform = BGFX_INVALID_HANDLE;
+    m_ambientLightUniform = BGFX_INVALID_HANDLE;
+    m_lightDirUniform = BGFX_INVALID_HANDLE;
+    m_lightDiffuseUniform = BGFX_INVALID_HANDLE;
+    m_lightPosUniform = BGFX_INVALID_HANDLE;
+    m_fogColorUniform = BGFX_INVALID_HANDLE;
+    m_fogParamsUniform = BGFX_INVALID_HANDLE;
+    m_modelUniform = BGFX_INVALID_HANDLE;
+    m_viewProjUniform = BGFX_INVALID_HANDLE;
+    m_camPosUniform = BGFX_INVALID_HANDLE;
+    m_shaderModeUniform = BGFX_INVALID_HANDLE;
+    m_shaderFlagsUniform = BGFX_INVALID_HANDLE;
+    m_detailFuncUniform = BGFX_INVALID_HANDLE;
+
+    if (bgfx::isValid(m_defaultProgram)) {
+        bgfx::destroy(m_defaultProgram);
+        m_defaultProgram = BGFX_INVALID_HANDLE;
+    }
+
+    if (bgfx::isValid(m_whiteTexture)) {
+        bgfx::destroy(m_whiteTexture);
+        m_whiteTexture = BGFX_INVALID_HANDLE;
+    }
+
+    Clear_Resource_Caches();
+    m_shaderCache.Clear();
+    bgfx::shutdown();
+    m_initialized = false;
+
+#if BGFX_PLATFORM_LINUX
+    if (m_nativeDisplay) {
+        XCloseDisplay(static_cast<Display*>(m_nativeDisplay));
+        m_nativeDisplay = nullptr;
+    }
+#endif
+}
+
+bool BGFXBackend::Set_Any_Render_Device()
+{
+    m_currentDevice = 0;
+    if (m_initialized) {
+        Clear_Resource_Caches();
+        Shutdown();
+        return Init(m_hwnd, false);
+    }
+    return true;
+}
+
+bool BGFXBackend::Set_Render_Device(const char * dev_name, int width, int height, int bits, int windowed, bool resize_window)
+{
+    for (int i = 0; i < Get_Render_Device_Count(); ++i) {
+        if (strcmp(Get_Render_Device_Name(i), dev_name) == 0) {
+            return Set_Render_Device(i, width, height, bits, windowed, resize_window);
+        }
+    }
+    return false;
+}
+
+bool BGFXBackend::Set_Render_Device(int dev, int resx, int resy, int bits, int windowed, bool resize_window)
+{
+    if (dev >= 0 && dev < Get_Render_Device_Count()) {
+        m_currentDevice = dev;
+    }
+    return Set_Device_Resolution(resx, resy, bits, windowed, resize_window);
+}
+
+bool BGFXBackend::Set_Next_Render_Device()
+{
+    int count = Get_Render_Device_Count();
+    if (count <= 0) {
+        return false;
+    }
+    m_currentDevice = (m_currentDevice + 1) % count;
+    if (m_initialized) {
+        Clear_Resource_Caches();
+        Shutdown();
+        return Init(m_hwnd, false);
+    }
+    return true;
+}
+
+bool BGFXBackend::Toggle_Windowed()
+{
+    m_windowed = !m_windowed;
+    if (m_initialized) {
+        uint32_t resetFlags = m_windowed ? 0 : BGFX_RESET_FULLSCREEN;
+        bgfx::reset(m_width, m_height, resetFlags);
+        Update_ViewDimensions();
+    }
+    return true;
+}
+
+bool BGFXBackend::Is_Windowed()
+{
+    return m_windowed;
+}
+
+int BGFXBackend::Get_Render_Device_Count()
+{
+    return static_cast<int>(m_deviceNames.size());
+}
+
+int BGFXBackend::Get_Render_Device()
+{
+    return m_currentDevice;
+}
+
+const RenderDeviceDescClass & BGFXBackend::Get_Render_Device_Desc(int deviceidx)
+{
+    // Return a static empty desc like NullBackend
+    static RenderDeviceDescClass nullDesc;
+    return nullDesc;
+}
+
+const char * BGFXBackend::Get_Render_Device_Name(int device_index)
+{
+    if (device_index >= 0 && device_index < Get_Render_Device_Count()) {
+        return m_deviceNames[device_index].c_str();
+    }
+    return "BGFX Renderer";
+}
+
+bool BGFXBackend::Set_Device_Resolution(int width, int height, int bits, int windowed, bool resize_window)
+{
+    if (width > 0) m_width = width;
+    if (height > 0) m_height = height;
+    if (bits > 0) m_bitDepth = bits;
+    if (windowed >= 0) m_windowed = (windowed != 0);
+
+    if (m_initialized) {
+        uint32_t resetFlags = m_windowed ? 0 : BGFX_RESET_FULLSCREEN;
+        bgfx::reset(m_width, m_height, resetFlags);
+        Update_ViewDimensions();
+
+        // If we have an active off-screen framebuffer, it needs to be recreated
+        // by the caller since bgfx framebuffers are tied to texture dimensions.
+        // We reset to default framebuffer on resize.
+        if (bgfx::isValid(m_activeFrameBuffer)) {
+            Set_Default_FrameBuffer();
+        }
+    }
+
+    return true;
+}
+
+void BGFXBackend::Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    set_w = m_width;
+    set_h = m_height;
+    set_bits = m_bitDepth;
+    set_windowed = m_windowed;
+}
+
+void BGFXBackend::Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    Get_Device_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+int BGFXBackend::Get_Device_Resolution_Width()
+{
+    return m_width;
+}
+
+int BGFXBackend::Get_Device_Resolution_Height()
+{
+    return m_height;
+}
+
+bool BGFXBackend::Registry_Save_Render_Device(const char * sub_key)
+{
+    return false;
+}
+
+bool BGFXBackend::Registry_Load_Render_Device(const char * sub_key, bool resize_window)
+{
+    return false;
+}
+
+bool BGFXBackend::Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth)
+{
+    return false;
+}
+
+bool BGFXBackend::Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth)
+{
+    return false;
+}
+
+void BGFXBackend::Begin_Scene()
+{
+    // Reset view to full viewport at start of each scene
+    bgfx::setViewRect(0, 0, 0, static_cast<uint16_t>(m_width), static_cast<uint16_t>(m_height));
+    bgfx::setViewMode(0, bgfx::ViewMode::Sequential);
+
+    // Touch view to ensure it's rendered even if no draw calls
+    bgfx::touch(0);
+
+    // Reset texture stage tracking for the new frame
+    m_activeTextureStages = 0;
+}
+
+void BGFXBackend::End_Scene(bool flip_frame)
+{
+    // Bind all active texture stages before frame submission
+    for (int i = 0; i < m_activeTextureStages; ++i) {
+        if (bgfx::isValid(m_boundTextures[i]) && bgfx::isValid(m_samplerUniforms[i])) {
+            bgfx::setTexture(static_cast<uint8_t>(i), m_samplerUniforms[i], m_boundTextures[i]);
+        }
+    }
+
+    if (flip_frame) {
+        bgfx::frame(true); // Block until rendering is complete
+    }
+}
+
+void BGFXBackend::Flip_To_Primary()
+{
+    bgfx::frame(true);
+}
+
+void BGFXBackend::Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z, unsigned int stencil)
+{
+    uint16_t flags = 0;
+
+    if (clear_color) {
+        flags |= BGFX_CLEAR_COLOR;
+    }
+
+    if (clear_z_stencil) {
+        flags |= BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL;
+    }
+
+    m_currentColor = Color_To_ABGR(color);
+
+    // Set view clear - this will be applied when the view is submitted
+    bgfx::setViewClear(0, flags, m_currentColor, 1.0f, 0);
+
+    // Ensure the view rect is set for the clear to apply
+    bgfx::setViewRect(0, 0, 0, static_cast<uint16_t>(m_width), static_cast<uint16_t>(m_height));
+}
+
+void BGFXBackend::Set_Swap_Interval(int swap)
+{
+    m_swapInterval = swap;
+    if (m_initialized) {
+        uint32_t resetFlags = (swap == 0) ? BGFX_RESET_NONE : (BGFX_RESET_VSYNC);
+        bgfx::reset(m_width, m_height, resetFlags);
+    }
+}
+
+int BGFXBackend::Get_Swap_Interval()
+{
+    return m_swapInterval;
+}
+
+void BGFXBackend::Set_Texture_Bitdepth(int depth)
+{
+    m_textureBitDepth = depth;
+}
+
+int BGFXBackend::Get_Texture_Bitdepth()
+{
+    return m_textureBitDepth;
+}
+
+void BGFXBackend::Set_Viewport(const void* viewport)
+{
+    if (!viewport) {
+        // Reset to full screen viewport
+        Set_Viewport(0, 0, m_width, m_height, 0.0f, 1.0f);
+        return;
+    }
+
+    // Unpack D3DVIEWPORT9 struct: { X, Y, Width, Height, MinZ, MaxZ }
+    // The struct layout is: DWORD X, Y, Width, Height; float MinZ, MaxZ;
+    const uint8_t* vp = static_cast<const uint8_t*>(viewport);
+    uint32_t x = *reinterpret_cast<const uint32_t*>(vp + 0);
+    uint32_t y = *reinterpret_cast<const uint32_t*>(vp + 4);
+    uint32_t width = *reinterpret_cast<const uint32_t*>(vp + 8);
+    uint32_t height = *reinterpret_cast<const uint32_t*>(vp + 12);
+    float minZ = *reinterpret_cast<const float*>(vp + 16);
+    float maxZ = *reinterpret_cast<const float*>(vp + 20);
+
+    Set_Viewport(static_cast<int>(x), static_cast<int>(y),
+                 static_cast<int>(width), static_cast<int>(height),
+                 minZ, maxZ);
+}
+
+void BGFXBackend::Set_Viewport(int x, int y, int width, int height, float minZ, float maxZ)
+{
+    m_viewportX = x;
+    m_viewportY = y;
+    m_viewportWidth = width;
+    m_viewportHeight = height;
+    m_viewportMinZ = minZ;
+    m_viewportMaxZ = maxZ;
+
+    // Clamp to device resolution
+    if (m_viewportWidth > m_width) m_viewportWidth = m_width;
+    if (m_viewportHeight > m_height) m_viewportHeight = m_height;
+    if (m_viewportX < 0) m_viewportX = 0;
+    if (m_viewportY < 0) m_viewportY = 0;
+
+    // Set bgfx view rect for position/size
+    bgfx::setViewRect(0,
+                      static_cast<uint16_t>(m_viewportX),
+                      static_cast<uint16_t>(m_viewportY),
+                      static_cast<uint16_t>(m_viewportWidth),
+                      static_cast<uint16_t>(m_viewportHeight));
+
+    // Set scissor if enabled, otherwise scissor matches viewport
+    if (m_scissorEnabled) {
+        bgfx::setViewScissor(0,
+                             static_cast<uint16_t>(m_scissorX),
+                             static_cast<uint16_t>(m_scissorY),
+                             static_cast<uint16_t>(m_scissorWidth),
+                             static_cast<uint16_t>(m_scissorHeight));
+    } else {
+        bgfx::setViewScissor(0,
+                             static_cast<uint16_t>(m_viewportX),
+                             static_cast<uint16_t>(m_viewportY),
+                             static_cast<uint16_t>(m_viewportWidth),
+                             static_cast<uint16_t>(m_viewportHeight));
+    }
+
+    // Note: minZ/maxZ are not directly mapped in bgfx (bgfx uses 0-1 depth range by default).
+    // If non-default depth range is needed, it would require shader-side handling or
+    // bgfx::setViewMode with custom projection matrices.
+}
+
+// =============================================================================
+// Scissor Rect Management
+// =============================================================================
+
+void BGFXBackend::Enable_Scissor(bool enable)
+{
+    m_scissorEnabled = enable;
+
+    // Update scissor to match current viewport state
+    if (m_scissorEnabled) {
+        bgfx::setViewScissor(0,
+                             static_cast<uint16_t>(m_scissorX),
+                             static_cast<uint16_t>(m_scissorY),
+                             static_cast<uint16_t>(m_scissorWidth),
+                             static_cast<uint16_t>(m_scissorHeight));
+    } else {
+        // Disable scissor by setting it to viewport bounds
+        bgfx::setViewScissor(0,
+                             static_cast<uint16_t>(m_viewportX),
+                             static_cast<uint16_t>(m_viewportY),
+                             static_cast<uint16_t>(m_viewportWidth),
+                             static_cast<uint16_t>(m_viewportHeight));
+    }
+}
+
+void BGFXBackend::Set_Scissor(int x, int y, int width, int height)
+{
+    m_scissorX = x;
+    m_scissorY = y;
+    m_scissorWidth = width;
+    m_scissorHeight = height;
+
+    if (m_scissorEnabled) {
+        bgfx::setViewScissor(0,
+                             static_cast<uint16_t>(m_scissorX),
+                             static_cast<uint16_t>(m_scissorY),
+                             static_cast<uint16_t>(m_scissorWidth),
+                             static_cast<uint16_t>(m_scissorHeight));
+    }
+}
+
+bool BGFXBackend::Is_Scissor_Enabled() const
+{
+    return m_scissorEnabled;
+}
+
+void BGFXBackend::Set_DX8_Render_State(int state, unsigned value)
+{
+    m_render_state[state] = value;
+    Apply_Render_State(state, value);
+}
+
+void BGFXBackend::Apply_Render_State(int state, unsigned value)
+{
+    // Update cached state
+    m_render_state[state] = value;
+
+    // Build bgfx state from cached render state
+    uint64_t newState = BGFX_STATE_DEFAULT;
+
+    // Fill mode
+    auto fillIt = m_render_state.find(DX8RenderState::FILLMODE);
+    if (fillIt != m_render_state.end()) {
+        newState |= FillMode_To_BGFX(fillIt->second);
+    }
+
+    // Cull mode
+    auto cullIt = m_render_state.find(DX8RenderState::CULLMODE);
+    if (cullIt != m_render_state.end()) {
+        newState |= CullMode_To_BGFX(cullIt->second);
+    }
+
+    // Z enable - use proper depth test
+    auto zIt = m_render_state.find(DX8RenderState::ZENABLE);
+    if (zIt != m_render_state.end() && zIt->second) {
+        newState |= BGFX_STATE_DEPTH_TEST_LEQUAL;
+    } else {
+        newState |= BGFX_STATE_DEPTH_TEST_ALWAYS;
+    }
+
+    // Z write enable
+    auto zwIt = m_render_state.find(DX8RenderState::ZWRITEENABLE);
+    if (zwIt != m_render_state.end() && zwIt->second) {
+        newState |= BGFX_STATE_WRITE_Z;
+    }
+
+    // Blend enable with proper src/dst factors
+    auto blendEnableIt = m_render_state.find(DX8RenderState::BLENDENABLE);
+    bool blendEnabled = (blendEnableIt != m_render_state.end() && blendEnableIt->second);
+    if (blendEnabled) {
+        auto srcBlendIt = m_render_state.find(DX8RenderState::SRCBLEND);
+        auto dstBlendIt = m_render_state.find(DX8RenderState::DESTBLEND);
+        auto blendOpIt  = m_render_state.find(DX8RenderState::BLENDOP);
+
+        uint64_t srcFactor = (srcBlendIt != m_render_state.end())
+            ? BlendFactor_To_BGFX(srcBlendIt->second) : BGFX_STATE_BLEND_ONE;
+        uint64_t dstFactor = (dstBlendIt != m_render_state.end())
+            ? BlendFactor_To_BGFX(dstBlendIt->second) : BGFX_STATE_BLEND_ZERO;
+
+        newState |= BGFX_STATE_BLEND_FUNC(srcFactor, dstFactor);
+
+        // Blend operation
+        if (blendOpIt != m_render_state.end()) {
+            switch (blendOpIt->second) {
+                case DX8RenderState::ADD:         newState |= BGFX_STATE_BLEND_EQUATION_ADD; break;
+                case DX8RenderState::SUBTRACT:    newState |= BGFX_STATE_BLEND_EQUATION_SUB; break;
+                case DX8RenderState::REVSUBTRACT: newState |= BGFX_STATE_BLEND_EQUATION_REVSUB; break;
+                case DX8RenderState::MIN:         newState |= BGFX_STATE_BLEND_EQUATION_MIN; break;
+                case DX8RenderState::MAX:         newState |= BGFX_STATE_BLEND_EQUATION_MAX; break;
+            }
+        }
+    }
+
+    // Alpha test (D3DRS_ALPHATESTENABLE) — handled in shader via uniform
+    auto alphaTestIt = m_render_state.find(DX8RenderState::ALPHATESTENABLE);
+    bool alphaTestEnabled = (alphaTestIt != m_render_state.end() && alphaTestIt->second);
+    if (alphaTestEnabled) {
+        auto alphaRefIt = m_render_state.find(DX8RenderState::ALPHAREF);
+        float threshold = (alphaRefIt != m_render_state.end())
+            ? ((alphaRefIt->second & 0x000000FF) / 255.0f) : 0.5f;
+        float alphaTestVal[4] = { 1.0f, threshold, 0.0f, 0.0f };
+        bgfx::setUniform(m_alphaTestUniform, alphaTestVal);
+    }
+
+    // Fog
+    auto fogIt = m_render_state.find(DX8RenderState::FOGENABLE);
+    bool fogEnabled = (fogIt != m_render_state.end() && fogIt->second);
+    if (fogEnabled) {
+        auto fogStartIt = m_render_state.find(DX8RenderState::FOGSTART);
+        auto fogEndIt   = m_render_state.find(DX8RenderState::FOGEND);
+        auto fogColorIt = m_render_state.find(DX8RenderState::FOGCOLOR);
+        auto fogDensityIt = m_render_state.find(DX8RenderState::FOGDENSITY);
+
+        float fogVal[4];
+        fogVal[0] = (fogStartIt != m_render_state.end()) ? *reinterpret_cast<const float*>(&fogStartIt->second) : 0.0f;
+        fogVal[1] = (fogEndIt   != m_render_state.end()) ? *reinterpret_cast<const float*>(&fogEndIt->second)   : 100.0f;
+        fogVal[2] = (fogDensityIt != m_render_state.end()) ? *reinterpret_cast<const float*>(&fogDensityIt->second) : 1.0f;
+        fogVal[3] = 1.0f; // enable flag
+
+        uint32_t fogColorU32 = (fogColorIt != m_render_state.end()) ? fogColorIt->second : 0xFFFFFFFF;
+        float fogColor[4];
+        fogColor[0] = ((fogColorU32 >> 16) & 0xFF) / 255.0f; // R
+        fogColor[1] = ((fogColorU32 >> 8)  & 0xFF) / 255.0f; // G
+        fogColor[2] = ((fogColorU32 >> 0)  & 0xFF) / 255.0f; // B
+        fogColor[3] = ((fogColorU32 >> 24) & 0xFF) / 255.0f; // A
+        bgfx::setUniform(m_fogColorUniform, fogColor);
+        bgfx::setUniform(m_fogParamsUniform, fogVal);
+    }
+
+    // Depth bias (SLOPESCALEDEPTHBIAS, DEPTHBIAS)
+    auto slopeBiasIt = m_render_state.find(DX8RenderState::SLOPESCALEDEPTHBIAS);
+    auto constBiasIt = m_render_state.find(DX8RenderState::DEPTHBIAS);
+    if (slopeBiasIt != m_render_state.end() || constBiasIt != m_render_state.end()) {
+        float slopeBias = (slopeBiasIt != m_render_state.end()) ? *reinterpret_cast<const float*>(&slopeBiasIt->second) : 0.0f;
+        float constBias = (constBiasIt != m_render_state.end()) ? *reinterpret_cast<const float*>(&constBiasIt->second) : 0.0f;
+        // bgfx supports depth bias via BGFX_STATE_DEPTH_BIAS but it's renderer-dependent
+        // Most renderers handle this via rasterizer state; skip for now
+        (void)slopeBias;
+        (void)constBias;
+    }
+
+    // Stencil enable
+    auto stencilIt = m_render_state.find(DX8RenderState::STENCILENABLE);
+    bool stencilEnabled = (stencilIt != m_render_state.end() && stencilIt->second);
+    if (stencilEnabled) {
+        // Build stencil state - start with read mask 0xFF
+        uint32_t stencilState = BGFX_STENCIL_TEST_ALWAYS;
+
+        // Stencil func
+        auto stencilFuncIt = m_render_state.find(DX8RenderState::STENCILFUNC);
+        if (stencilFuncIt != m_render_state.end()) {
+            stencilState |= Compare_Stencil_Func(stencilFuncIt->second);
+        }
+
+        // Stencil ref
+        auto stencilRefIt = m_render_state.find(DX8RenderState::STENCILREF);
+        if (stencilRefIt != m_render_state.end()) {
+            stencilState |= BGFX_STENCIL_FUNC_REF(static_cast<uint32_t>(stencilRefIt->second));
+        }
+
+        // Stencil mask (read mask)
+        auto stencilMaskIt = m_render_state.find(DX8RenderState::STENCILMASK);
+        if (stencilMaskIt != m_render_state.end()) {
+            stencilState |= BGFX_STENCIL_FUNC_RMASK(static_cast<uint32_t>(stencilMaskIt->second));
+        }
+
+        // Stencil fail operation
+        auto stencilFailIt = m_render_state.find(DX8RenderState::STENCILFAIL);
+        if (stencilFailIt != m_render_state.end()) {
+            stencilState |= Compare_Stencil_Op(stencilFailIt->second);
+        }
+
+        // Stencil Z fail operation (depth fail)
+        auto stencilZFailIt = m_render_state.find(DX8RenderState::STENCILZFAIL);
+        if (stencilZFailIt != m_render_state.end()) {
+            stencilState |= Compare_Stencil_Op_Z(stencilZFailIt->second);
+        }
+
+        // Stencil pass operation (depth pass)
+        auto stencilPassIt = m_render_state.find(DX8RenderState::STENCILPASS);
+        if (stencilPassIt != m_render_state.end()) {
+            stencilState |= Compare_Stencil_Op_Pass(stencilPassIt->second);
+        }
+
+        bgfx::setStencil(stencilState);
+    } else {
+        bgfx::setStencil(0);
+    }
+
+    m_currentState = newState;
+    bgfx::setState(newState);
+}
+
+// Helper: Map DX8 stencil comparison function to bgfx stencil test flags
+uint32_t BGFXBackend::Compare_Stencil_Func(unsigned dx8func)
+{
+    switch (dx8func) {
+        case 0:  // NEVER
+            return BGFX_STENCIL_TEST_NEVER;
+        case 1:  // LESS
+            return BGFX_STENCIL_TEST_LESS;
+        case 2:  // EQUAL
+            return BGFX_STENCIL_TEST_EQUAL;
+        case 3:  // LESS_EQUAL
+            return BGFX_STENCIL_TEST_LEQUAL;
+        case 4:  // GREATER
+            return BGFX_STENCIL_TEST_GREATER;
+        case 5:  // NOT_EQUAL
+            return BGFX_STENCIL_TEST_NOTEQUAL;
+        case 6:  // GREATER_EQUAL
+            return BGFX_STENCIL_TEST_GEQUAL;
+        case 7:  // ALWAYS
+        default:
+            return BGFX_STENCIL_TEST_ALWAYS;
+    }
+}
+
+// Helper: Map DX8 stencil operation to bgfx stencil op flags (for fail case)
+uint32_t BGFXBackend::Compare_Stencil_Op(unsigned dx8op)
+{
+    switch (dx8op) {
+        case 0:  // KEEP
+            return BGFX_STENCIL_OP_FAIL_S_KEEP;
+        case 1:  // ZERO
+            return BGFX_STENCIL_OP_FAIL_S_ZERO;
+        case 2:  // REPLACE
+            return BGFX_STENCIL_OP_FAIL_S_REPLACE;
+        case 3:  // INCRSAT
+            return BGFX_STENCIL_OP_FAIL_S_INCRSAT;
+        case 4:  // DECRSAT
+            return BGFX_STENCIL_OP_FAIL_S_DECRSAT;
+        case 5:  // INVERT
+            return BGFX_STENCIL_OP_FAIL_S_INVERT;
+        case 6:  // INCR
+            return BGFX_STENCIL_OP_FAIL_S_INCR;
+        case 7:  // DECR
+            return BGFX_STENCIL_OP_FAIL_S_DECR;
+        default:
+            return BGFX_STENCIL_OP_FAIL_S_KEEP;
+    }
+}
+
+// Helper: Map DX8 stencil operation to bgfx stencil op flags (for depth fail case)
+uint32_t BGFXBackend::Compare_Stencil_Op_Z(unsigned dx8op)
+{
+    switch (dx8op) {
+        case 0:  // KEEP
+            return BGFX_STENCIL_OP_FAIL_Z_KEEP;
+        case 1:  // ZERO
+            return BGFX_STENCIL_OP_FAIL_Z_ZERO;
+        case 2:  // REPLACE
+            return BGFX_STENCIL_OP_FAIL_Z_REPLACE;
+        case 3:  // INCRSAT
+            return BGFX_STENCIL_OP_FAIL_Z_INCRSAT;
+        case 4:  // DECRSAT
+            return BGFX_STENCIL_OP_FAIL_Z_DECRSAT;
+        case 5:  // INVERT
+            return BGFX_STENCIL_OP_FAIL_Z_INVERT;
+        case 6:  // INCR
+            return BGFX_STENCIL_OP_FAIL_Z_INCR;
+        case 7:  // DECR
+            return BGFX_STENCIL_OP_FAIL_Z_DECR;
+        default:
+            return BGFX_STENCIL_OP_FAIL_Z_KEEP;
+    }
+}
+
+// Helper: Map DX8 stencil operation to bgfx stencil op flags (for depth pass case)
+uint32_t BGFXBackend::Compare_Stencil_Op_Pass(unsigned dx8op)
+{
+    switch (dx8op) {
+        case 0:  // KEEP
+            return BGFX_STENCIL_OP_PASS_Z_KEEP;
+        case 1:  // ZERO
+            return BGFX_STENCIL_OP_PASS_Z_ZERO;
+        case 2:  // REPLACE
+            return BGFX_STENCIL_OP_PASS_Z_REPLACE;
+        case 3:  // INCRSAT
+            return BGFX_STENCIL_OP_PASS_Z_INCRSAT;
+        case 4:  // DECRSAT
+            return BGFX_STENCIL_OP_PASS_Z_DECRSAT;
+        case 5:  // INVERT
+            return BGFX_STENCIL_OP_PASS_Z_INVERT;
+        case 6:  // INCR
+            return BGFX_STENCIL_OP_PASS_Z_INCR;
+        case 7:  // DECR
+            return BGFX_STENCIL_OP_PASS_Z_DECR;
+        default:
+            return BGFX_STENCIL_OP_PASS_Z_KEEP;
+    }
+}
+
+void BGFXBackend::Set_Light_Environment(const void* env)
+{
+    float lightingEnable[4] = { env ? 1.0f : 0.0f, 0.0f, 0.0f, 0.0f };
+    if (bgfx::isValid(m_lightingEnableUniform)) {
+        bgfx::setUniform(m_lightingEnableUniform, lightingEnable);
+    }
+}
+
+void* BGFXBackend::_Get_DX8_Front_Buffer()
+{
+    return nullptr; // Not applicable for bgfx
+}
+
+void BGFXBackend::Update_ViewDimensions()
+{
+    m_viewportX = 0;
+    m_viewportY = 0;
+    m_viewportWidth = m_width;
+    m_viewportHeight = m_height;
+
+    bgfx::setViewRect(0, 0, 0, static_cast<uint16_t>(m_width), static_cast<uint16_t>(m_height));
+    bgfx::setViewMode(0, bgfx::ViewMode::Sequential);
+
+    // Reset scissor to full viewport
+    if (!m_scissorEnabled) {
+        bgfx::setViewScissor(0, 0, 0, static_cast<uint16_t>(m_width), static_cast<uint16_t>(m_height));
+    }
+}
+
+// AutoSelect_Renderer removed - bgfx::RendererType::Count is used directly for auto-detect
+
+// =============================================================================
+// Texture Management
+// =============================================================================
+
+bgfx::TextureHandle BGFXBackend::Create_System_Texture(int width, int height, bgfx::TextureFormat::Enum format, uint64_t flags)
+{
+    bgfx::TextureHandle handle = bgfx::createTexture2D(
+        static_cast<uint16_t>(width),
+        static_cast<uint16_t>(height),
+        false,
+        1,
+        format,
+        flags,
+        nullptr
+    );
+    return handle;
+}
+
+void BGFXBackend::Destroy_Texture(bgfx::TextureHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Set_Texture(int stage, bgfx::TextureHandle handle, uint32_t flags, uint8_t mip)
+{
+    if (stage < 0 || stage >= MAX_TEXTURE_STAGES) {
+        return;
+    }
+
+    m_boundTextures[stage] = handle;
+    m_textureMipLevels[stage] = mip;
+
+    if (flags != UINT32_MAX) {
+        m_textureFlags[stage] = flags;
+    }
+
+    if (!bgfx::isValid(handle) || !bgfx::isValid(m_samplerUniforms[stage])) {
+        return;
+    }
+
+    const uint32_t samplerFlags = (m_textureFlags[stage] == UINT32_MAX) ? BGFX_TEXTURE_NONE : m_textureFlags[stage];
+    bgfx::setTexture(static_cast<uint8_t>(stage), m_samplerUniforms[stage], handle, samplerFlags);
+}
+
+// =============================================================================
+// Vertex Buffer Management
+// =============================================================================
+
+bgfx::VertexBufferHandle BGFXBackend::Create_Vertex_Buffer(void* data, int vertexCount, const bgfx::VertexLayout& layout, uint64_t flags)
+{
+    const bgfx::Memory* mem = bgfx::copy(data, vertexCount * layout.getStride());
+    return bgfx::createVertexBuffer(mem, layout, flags);
+}
+
+void BGFXBackend::Destroy_Vertex_Buffer(bgfx::VertexBufferHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Set_Vertex_Buffer(int stream, bgfx::VertexBufferHandle handle, uint32_t startVertex, uint32_t numVertices)
+{
+    bgfx::setVertexBuffer(stream, handle, startVertex, numVertices);
+}
+
+// =============================================================================
+// Index Buffer Management
+// =============================================================================
+
+bgfx::IndexBufferHandle BGFXBackend::Create_Index_Buffer(void* data, int indexCount, bool index32bit, uint64_t flags)
+{
+    const bgfx::Memory* mem = bgfx::copy(data, indexCount * (index32bit ? 4 : 2));
+    return bgfx::createIndexBuffer(mem, flags);
+}
+
+void BGFXBackend::Destroy_Index_Buffer(bgfx::IndexBufferHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Set_Index_Buffer(bgfx::IndexBufferHandle handle, int startIndex, int numIndices)
+{
+    bgfx::setIndexBuffer(handle, startIndex, numIndices);
+}
+
+// =============================================================================
+// Draw Commands
+// =============================================================================
+
+void BGFXBackend::Draw(int numVertices, int numInstances)
+{
+    bgfx::submit(0, m_currentProgram, 0, numInstances);
+}
+
+void BGFXBackend::Draw_Indexed(int numIndices, int numInstances, int startIndex, int startVertex)
+{
+    bgfx::submit(0, m_currentProgram, 0, numInstances);
+}
+
+// =============================================================================
+// Shader Program Management
+// =============================================================================
+
+bgfx::ShaderHandle BGFXBackend::Load_Shader(const char* shaderPath)
+{
+    // Handle empty path
+    if (!shaderPath || shaderPath[0] == '\0') {
+        return BGFX_INVALID_HANDLE;
+    }
+
+    // Try to load shader from filesystem
+    FILE* file = fopen(shaderPath, "rb");
+    if (!file) {
+        // File not found - will fall back to embedded shader
+        return BGFX_INVALID_HANDLE;
+    }
+
+    // Get file size
+    fseek(file, 0, SEEK_END);
+    long fileSize = ftell(file);
+    fseek(file, 0, SEEK_SET);
+
+    if (fileSize <= 0) {
+        fclose(file);
+        return BGFX_INVALID_HANDLE;
+    }
+
+    // Read shader binary into buffer
+    // Use bgfx::copy to make bgfx own the memory copy
+    uint8_t* buffer = new uint8_t[fileSize];
+    size_t bytesRead = fread(buffer, 1, fileSize, file);
+    fclose(file);
+
+    if (bytesRead != static_cast<size_t>(fileSize)) {
+        delete[] buffer;
+        return BGFX_INVALID_HANDLE;
+    }
+
+    // Copy data into bgfx-managed memory
+    const bgfx::Memory* mem = bgfx::copy(buffer, static_cast<uint32_t>(fileSize));
+    delete[] buffer;  // bgfx::copy made its own copy, we can free ours;
+
+    if (!mem || !mem->data || mem->size == 0) {
+        return BGFX_INVALID_HANDLE;
+    }
+
+    // Create shader from binary data
+    bgfx::ShaderHandle handle = bgfx::createShader(mem);
+
+    if (!bgfx::isValid(handle)) {
+        return BGFX_INVALID_HANDLE;
+    }
+
+    return handle;
+}
+
+bgfx::ProgramHandle BGFXBackend::Create_Program(const char* vsPath, const char* fsPath)
+{
+    bgfx::ShaderHandle vs = Load_Shader(vsPath);
+    bgfx::ShaderHandle fs = Load_Shader(fsPath);
+
+    if (!bgfx::isValid(vs) || !bgfx::isValid(fs)) {
+        return BGFX_INVALID_HANDLE;
+    }
+
+    return Create_Program(vs, fs);
+}
+
+bgfx::ProgramHandle BGFXBackend::Create_Program(bgfx::ShaderHandle vs, bgfx::ShaderHandle fs)
+{
+    if (!bgfx::isValid(vs) || !bgfx::isValid(fs)) {
+        return BGFX_INVALID_HANDLE;
+    }
+
+    return bgfx::createProgram(vs, fs, true);
+}
+
+void BGFXBackend::Destroy_Shader(bgfx::ShaderHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Destroy_Program(bgfx::ProgramHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Set_Program(bgfx::ProgramHandle program)
+{
+    // Note: In bgfx, programs are submitted directly to views, not set separately
+    // This stores the program for later use in submit
+    m_currentProgram = program;
+}
+
+const char* BGFXBackend::Get_Renderer_Name()
+{
+    return bgfx::getRendererName(bgfx::getRendererType());
+}
+
+bgfx::RendererType::Enum BGFXBackend::Get_Renderer_Type()
+{
+    return bgfx::getRendererType();
+}
+
+// =============================================================================
+// Uniform (Constant Buffer) Management
+// =============================================================================
+
+bgfx::UniformHandle BGFXBackend::Create_Uniform(const char* name, bgfx::UniformType::Enum type, uint16_t num)
+{
+    return bgfx::createUniform(name, type, num);
+}
+
+void BGFXBackend::Destroy_Uniform(bgfx::UniformHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Set_Uniform(bgfx::UniformHandle handle, const void* value, uint16_t num)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::setUniform(handle, value, num);
+    }
+}
+
+// =============================================================================
+// Frame Buffer (Render Target) Management
+// =============================================================================
+
+bgfx::FrameBufferHandle BGFXBackend::Create_FrameBuffer(int width, int height, bgfx::TextureFormat::Enum format, uint64_t textureFlags)
+{
+    bgfx::TextureHandle colorHandle = bgfx::createTexture2D(
+        static_cast<uint16_t>(width),
+        static_cast<uint16_t>(height),
+        false,
+        1,
+        format,
+        textureFlags | BGFX_TEXTURE_RT_WRITE_ONLY,
+        nullptr
+    );
+
+    bgfx::FrameBufferHandle fb = bgfx::createFrameBuffer(1, &colorHandle, true);
+    return fb;
+}
+
+bgfx::FrameBufferHandle BGFXBackend::Create_FrameBuffer(int width, int height, bgfx::TextureFormat::Enum colorFormat, bgfx::TextureFormat::Enum depthFormat, uint64_t textureFlags)
+{
+    bgfx::TextureHandle colorHandle = bgfx::createTexture2D(
+        static_cast<uint16_t>(width),
+        static_cast<uint16_t>(height),
+        false,
+        1,
+        colorFormat,
+        textureFlags | BGFX_TEXTURE_RT_WRITE_ONLY,
+        nullptr
+    );
+
+    bgfx::TextureHandle depthHandle = bgfx::createTexture2D(
+        static_cast<uint16_t>(width),
+        static_cast<uint16_t>(height),
+        false,
+        1,
+        depthFormat,
+        BGFX_TEXTURE_RT_WRITE_ONLY,
+        nullptr
+    );
+
+    bgfx::TextureHandle handles[2] = { colorHandle, depthHandle };
+    bgfx::FrameBufferHandle fb = bgfx::createFrameBuffer(2, handles, true);
+    return fb;
+}
+
+bgfx::FrameBufferHandle BGFXBackend::Create_FrameBuffer_Attachment(bgfx::TextureHandle color, bgfx::TextureHandle depth)
+{
+    // Create MRT framebuffer with color and depth attachments
+    bgfx::TextureHandle handles[2] = { color, depth };
+    bgfx::FrameBufferHandle fb = bgfx::createFrameBuffer(2, handles, true);
+    return fb;
+}
+
+void BGFXBackend::Destroy_FrameBuffer(bgfx::FrameBufferHandle handle)
+{
+    if (bgfx::isValid(handle)) {
+        bgfx::destroy(handle);
+    }
+}
+
+void BGFXBackend::Set_FrameBuffer(bgfx::FrameBufferHandle handle, int width, int height)
+{
+    m_activeFrameBuffer = handle;
+    bgfx::setViewFrameBuffer(0, handle);
+
+    if (bgfx::isValid(handle) && width > 0 && height > 0) {
+        bgfx::setViewRect(0, 0, 0, static_cast<uint16_t>(width), static_cast<uint16_t>(height));
+        // Update internal viewport tracking for this framebuffer
+        m_viewportX = 0;
+        m_viewportY = 0;
+        m_viewportWidth = width;
+        m_viewportHeight = height;
+    } else if (!bgfx::isValid(handle)) {
+        // Reset to device resolution
+        Update_ViewDimensions();
+    }
+}
+
+void BGFXBackend::Set_FrameBuffer(bgfx::FrameBufferHandle handle, bgfx::TextureHandle color, bgfx::TextureHandle depth)
+{
+    m_activeFrameBuffer = handle;
+    bgfx::setViewFrameBuffer(0, handle);
+}
+
+void BGFXBackend::Set_Default_FrameBuffer()
+{
+    m_activeFrameBuffer = BGFX_INVALID_HANDLE;
+    bgfx::setViewFrameBuffer(0, BGFX_INVALID_HANDLE);
+    Update_ViewDimensions();
+}
+
+void BGFXBackend::Clear_Resource_Caches()
+{
+    for (auto& pair : m_vbCache) {
+        if (bgfx::isValid(pair.second)) {
+            bgfx::destroy(pair.second);
+        }
+    }
+    m_vbCache.clear();
+
+    for (auto& pair : m_ibCache) {
+        if (bgfx::isValid(pair.second)) {
+            bgfx::destroy(pair.second);
+        }
+    }
+    m_ibCache.clear();
+
+    for (auto& pair : m_textureCache) {
+        if (bgfx::isValid(pair.second) && pair.second.idx != m_whiteTexture.idx) {
+            bgfx::destroy(pair.second);
+        }
+    }
+    m_textureCache.clear();
+
+    m_boundTextures.fill(BGFX_INVALID_HANDLE);
+    m_textureFlags.fill(UINT32_MAX);
+    m_textureMipLevels.fill(0);
+    m_textureUvIndices.fill(0);
+    m_activeTextureStages = 0;
+}
+
+void BGFXBackend::Invalidate_Texture_Cache_Entry(TextureClass* texture)
+{
+    if (!texture) {
+        return;
+    }
+
+    auto it = m_textureCache.find(texture);
+    if (it == m_textureCache.end()) {
+        return;
+    }
+
+    const bgfx::TextureHandle handle = it->second;
+    if (bgfx::isValid(handle) && handle.idx != m_whiteTexture.idx) {
+        bgfx::destroy(handle);
+    }
+
+    m_textureCache.erase(it);
+
+    for (int stage = 0; stage < MAX_TEXTURE_STAGES; ++stage) {
+        if (m_boundTextures[stage].idx == handle.idx) {
+            m_boundTextures[stage] = BGFX_INVALID_HANDLE;
+            m_textureFlags[stage] = UINT32_MAX;
+            m_textureMipLevels[stage] = 0;
+        }
+    }
+}
+
+void BGFXBackend::Invalidate_Vertex_Buffer_Cache_Entry(const VertexBufferClass* vb)
+{
+    if (!vb) {
+        return;
+    }
+
+    auto it = m_vbCache.find(vb);
+    if (it == m_vbCache.end()) {
+        return;
+    }
+
+    if (bgfx::isValid(it->second)) {
+        bgfx::destroy(it->second);
+    }
+    m_vbCache.erase(it);
+
+    if (m_currentVB == vb) {
+        m_currentVB = nullptr;
+    }
+}
+
+void BGFXBackend::Invalidate_Index_Buffer_Cache_Entry(const IndexBufferClass* ib)
+{
+    if (!ib) {
+        return;
+    }
+
+    auto it = m_ibCache.find(ib);
+    if (it == m_ibCache.end()) {
+        return;
+    }
+
+    if (bgfx::isValid(it->second)) {
+        bgfx::destroy(it->second);
+    }
+    m_ibCache.erase(it);
+
+    if (m_currentIB == ib) {
+        m_currentIB = nullptr;
+        m_currentIBOffset = 0;
+    }
+}
+
+// =============================================================================
+// Material Integration
+// =============================================================================
+
+void BGFXBackend::Set_Material_Colors(const Vector3& diffuse, float alpha, const Vector3& specular, float shininess, const Vector3& emissive, const Vector3& ambient)
+{
+    float diffuseVec4[4] = { diffuse.X, diffuse.Y, diffuse.Z, alpha };
+    float specularVec4[4] = { specular.X, specular.Y, specular.Z, shininess };
+    float emissiveVec4[4] = { emissive.X, emissive.Y, emissive.Z, 1.0f };
+    float ambientVec4[4] = { ambient.X, ambient.Y, ambient.Z, 1.0f };
+    float opacityVec4[4] = { alpha, 0.0f, 0.0f, 0.0f };
+
+    if (bgfx::isValid(m_diffuseUniform)) {
+        bgfx::setUniform(m_diffuseUniform, diffuseVec4);
+    }
+    if (bgfx::isValid(m_specularUniform)) {
+        bgfx::setUniform(m_specularUniform, specularVec4);
+    }
+    if (bgfx::isValid(m_emissiveUniform)) {
+        bgfx::setUniform(m_emissiveUniform, emissiveVec4);
+    }
+    if (bgfx::isValid(m_ambientUniform)) {
+        bgfx::setUniform(m_ambientUniform, ambientVec4);
+    }
+    if (bgfx::isValid(m_opacityUniform)) {
+        bgfx::setUniform(m_opacityUniform, opacityVec4);
+    }
+}
+
+void BGFXBackend::Set_Material_Uniforms(bgfx::UniformHandle diffuseHandle, bgfx::UniformHandle specularHandle, bgfx::UniformHandle emissiveHandle, const MaterialColors& colors)
+{
+    float diffuseVec4[4] = { colors.Diffuse.X, colors.Diffuse.Y, colors.Diffuse.Z, colors.Alpha };
+    float specularVec4[4] = { colors.Specular.X, colors.Specular.Y, colors.Specular.Z, colors.Shininess };
+    float emissiveVec4[4] = { colors.Emissive.X, colors.Emissive.Y, colors.Emissive.Z, 1.0f };
+
+    if (bgfx::isValid(diffuseHandle)) {
+        bgfx::setUniform(diffuseHandle, diffuseVec4);
+    }
+    if (bgfx::isValid(specularHandle)) {
+        bgfx::setUniform(specularHandle, specularVec4);
+    }
+    if (bgfx::isValid(emissiveHandle)) {
+        bgfx::setUniform(emissiveHandle, emissiveVec4);
+    }
+}
+
+void BGFXBackend::Set_Texture_Stage(int stage, bgfx::TextureHandle handle, uint32_t flags, uint8_t mip, int uvIndex)
+{
+    if (stage < 0 || stage >= MAX_TEXTURE_STAGES) {
+        return;
+    }
+
+    m_textureUvIndices[stage] = uvIndex;
+
+    // Track active stage count
+    if (stage + 1 > m_activeTextureStages) {
+        m_activeTextureStages = stage + 1;
+    }
+
+    Set_Texture(stage, handle, flags, mip);
+}
+
+
+uint64_t BGFXBackend::Apply_Shader(const ShaderClass& shader, bool lightingEnabled)
+{
+    // Use BGFXMaterialMapper to convert shader to bgfx state
+    uint64_t state = BGFXMaterialMapper::Make_Render_State(shader, lightingEnabled);
+
+    // Apply the state
+    bgfx::setState(state);
+
+    // Update our tracked state
+    m_currentState = state;
+
+    return state;
+}
+
+void BGFXBackend::Begin_Material_Pass()
+{
+    // Reset bound textures to prevent cross-material leakage
+    m_boundTextures.fill(BGFX_INVALID_HANDLE);
+    m_textureFlags.fill(UINT32_MAX);
+    m_textureMipLevels.fill(0);
+    m_textureUvIndices.fill(0);
+    m_activeTextureStages = 0;
+}
+
+void BGFXBackend::End_Material_Pass()
+{
+    // Material pass complete — state is submitted via bgfx::submit()
+    // No explicit cleanup needed since bgfx resets transient state per-submit
+}
+
+// ---------------------------------------------------------------------------
+// Backend dispatch overrides — bridge W3D state to bgfx
+// ---------------------------------------------------------------------------
+
+static void Matrix4ToFloat16Transpose(const Matrix4& src, float dst[16])
+{
+    // W3D Matrix4 is row-major; bgfx GLSL expects column-major.
+    for (int row = 0; row < 4; ++row) {
+        for (int col = 0; col < 4; ++col) {
+            dst[col * 4 + row] = src[row][col];
+        }
+    }
+}
+
+void BGFXBackend::Apply_Shader_State(const ShaderClass& shader)
+{
+    // Build ShaderKey from the W3D shader
+    ShaderKey key = ShaderKey_From_DX8(shader);
+
+    // Update texture stage count from tracked active stages
+    if (m_activeTextureStages > key.texStageCount) {
+        key.texStageCount = static_cast<uint8_t>(m_activeTextureStages);
+    }
+
+    // Get or create the ubershader variant
+    const ShaderVariantCache::ShaderVariant* variant = m_shaderCache.GetOrCreate(key);
+    if (variant && bgfx::isValid(variant->program)) {
+        m_currentProgram = variant->program;
+    } else {
+        // Fallback to default program if ubershader not available
+        m_currentProgram = m_defaultProgram;
+    }
+
+    // ---- Set ubershader uniforms ----
+
+    // Shader mode: encodes gradient, texturing, lighting flags
+    float shaderMode[4] = {
+        static_cast<float>(key.priGradient),   // x: primary gradient mode
+        static_cast<float>(key.secGradient),   // y: secondary gradient on/off
+        static_cast<float>(key.texturing),     // z: texturing on/off
+        static_cast<float>(key.lighting),      // w: lighting on/off
+    };
+    if (bgfx::isValid(m_shaderModeUniform)) {
+        bgfx::setUniform(m_shaderModeUniform, shaderMode);
+    }
+
+    // Shader flags: packed bitfield for fog, alpha test, tex stages, detail funcs
+    float shaderFlags[4] = {
+        static_cast<float>((key.fogMode << 0) |
+                           (key.alphaTest << 4) |
+                           (key.texStageCount << 8)),  // x: packed flags
+        static_cast<float>(key.blendMode),              // y: blend mode enum
+        0.0f, 0.0f  // z, w: reserved
+    };
+    if (bgfx::isValid(m_shaderFlagsUniform)) {
+        bgfx::setUniform(m_shaderFlagsUniform, shaderFlags);
+    }
+
+    // Detail functions: post-detail color and alpha modes
+    float detailFunc[4] = {
+        static_cast<float>(key.detailColor),  // x: detail color func
+        static_cast<float>(key.detailAlpha),  // y: detail alpha func
+        0.0f, 0.0f  // z, w: reserved
+    };
+    if (bgfx::isValid(m_detailFuncUniform)) {
+        bgfx::setUniform(m_detailFuncUniform, detailFunc);
+    }
+
+    // ---- Build bgfx render state from ShaderKey ----
+    uint64_t state = BGFX_STATE_NONE;
+
+    // Depth comparison
+    switch (static_cast<ShaderClass::DepthCompareType>(key.depthCompare)) {
+        case ShaderClass::PASS_NEVER:    state |= BGFX_STATE_DEPTH_TEST_NEVER;    break;
+        case ShaderClass::PASS_LESS:     state |= BGFX_STATE_DEPTH_TEST_LESS;     break;
+        case ShaderClass::PASS_EQUAL:    state |= BGFX_STATE_DEPTH_TEST_EQUAL;    break;
+        case ShaderClass::PASS_LEQUAL:   state |= BGFX_STATE_DEPTH_TEST_LEQUAL;   break;
+        case ShaderClass::PASS_GREATER:  state |= BGFX_STATE_DEPTH_TEST_GREATER;  break;
+        case ShaderClass::PASS_NOTEQUAL: state |= BGFX_STATE_DEPTH_TEST_NOTEQUAL; break;
+        case ShaderClass::PASS_GEQUAL:   state |= BGFX_STATE_DEPTH_TEST_GEQUAL;   break;
+        case ShaderClass::PASS_ALWAYS:   state |= BGFX_STATE_DEPTH_TEST_ALWAYS;   break;
+        default:                         state |= BGFX_STATE_DEPTH_TEST_LEQUAL;   break;
+    }
+
+    // Depth write
+    if (key.depthWrite) {
+        state |= BGFX_STATE_WRITE_Z;
+    }
+
+    // Blend mode
+    switch (key.blendMode) {
+        case 0: // opaque
+            state |= BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ZERO);
+            break;
+        case 1: // additive
+            state |= BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_ONE, BGFX_STATE_BLEND_ONE);
+            break;
+        case 2: // alpha
+            state |= BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_SRC_ALPHA, BGFX_STATE_BLEND_INV_SRC_ALPHA);
+            break;
+        case 3: // multiplicative
+            state |= BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_DST_COLOR, BGFX_STATE_BLEND_ZERO);
+            break;
+        case 4: // screen
+            state |= BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_INV_SRC_COLOR, BGFX_STATE_BLEND_ONE);
+            break;
+        default: // other/custom: default to alpha blend
+            state |= BGFX_STATE_BLEND_FUNC(BGFX_STATE_BLEND_SRC_ALPHA, BGFX_STATE_BLEND_INV_SRC_ALPHA);
+            break;
+    }
+
+    // Cull mode — from cached DX8 render state
+    auto cullIt = m_render_state.find(DX8RenderState::CULLMODE);
+    if (cullIt != m_render_state.end()) {
+        state |= CullMode_To_BGFX(cullIt->second);
+    } else {
+        state |= BGFX_STATE_CULL_CCW; // default
+    }
+
+    // Fill mode — from cached DX8 render state
+    auto fillIt = m_render_state.find(DX8RenderState::FILLMODE);
+    if (fillIt != m_render_state.end()) {
+        state |= FillMode_To_BGFX(fillIt->second);
+    }
+
+    bgfx::setState(state);
+    m_currentState = state;
+
+    // ---- Bind active texture stages ----
+    for (int i = 0; i < m_activeTextureStages; ++i) {
+        if (bgfx::isValid(m_boundTextures[i]) && bgfx::isValid(m_samplerUniforms[i])) {
+            bgfx::setTexture(static_cast<uint8_t>(i), m_samplerUniforms[i], m_boundTextures[i]);
+        }
+    }
+}
+
+static bgfx::TextureFormat::Enum WW3DFormat_To_BGFX(WW3DFormat fmt)
+{
+    switch (fmt) {
+        case WW3D_FORMAT_A8R8G8B8:
+        case WW3D_FORMAT_X8R8G8B8:
+            return bgfx::TextureFormat::BGRA8;
+        case WW3D_FORMAT_R8G8B8:
+            return bgfx::TextureFormat::RGB8;
+        case WW3D_FORMAT_R5G6B5:
+            return bgfx::TextureFormat::R5G6B5;
+        case WW3D_FORMAT_A1R5G5B5:
+        case WW3D_FORMAT_X1R5G5B5:
+            return bgfx::TextureFormat::RGB5A1;
+        case WW3D_FORMAT_A4R4G4B4:
+        case WW3D_FORMAT_X4R4G4B4:
+            return bgfx::TextureFormat::RGBA4;
+        case WW3D_FORMAT_DXT1:
+            return bgfx::TextureFormat::BC1;
+        case WW3D_FORMAT_DXT3:
+            return bgfx::TextureFormat::BC2;
+        case WW3D_FORMAT_DXT5:
+            return bgfx::TextureFormat::BC3;
+        case WW3D_FORMAT_A8:
+            return bgfx::TextureFormat::A8;
+        case WW3D_FORMAT_L8:
+            return bgfx::TextureFormat::R8;
+        default:
+            return bgfx::TextureFormat::BGRA8; // safe fallback
+    }
+}
+
+static int WW3DFormat_BytesPerPixel(WW3DFormat fmt)
+{
+    switch (fmt) {
+        case WW3D_FORMAT_R8G8B8:     return 3;
+        case WW3D_FORMAT_A8R8G8B8:
+        case WW3D_FORMAT_X8R8G8B8:  return 4;
+        case WW3D_FORMAT_R5G6B5:
+        case WW3D_FORMAT_A1R5G5B5:
+        case WW3D_FORMAT_X1R5G5B5:
+        case WW3D_FORMAT_A4R4G4B4:
+        case WW3D_FORMAT_X4R4G4B4:
+        case WW3D_FORMAT_A8L8:      return 2;
+        case WW3D_FORMAT_R3G3B2:
+        case WW3D_FORMAT_A8:
+        case WW3D_FORMAT_A8R3G3B2:
+        case WW3D_FORMAT_P8:
+        case WW3D_FORMAT_L8:
+        case WW3D_FORMAT_A4L4:      return 1;
+        default:                     return 4; // compressed and unknown fallbacks
+    }
+}
+
+void BGFXBackend::Apply_Texture_State(unsigned stage, TextureClass* texture)
+{
+    if (stage >= MAX_TEXTURE_STAGES) {
+        return;
+    }
+
+    if (!texture) {
+        m_boundTextures[stage] = BGFX_INVALID_HANDLE;
+        return;
+    }
+
+    // Track active stage count
+    if (static_cast<int>(stage) + 1 > m_activeTextureStages) {
+        m_activeTextureStages = static_cast<int>(stage) + 1;
+    }
+
+    // Check cache
+    auto it = m_textureCache.find(texture);
+    if (it != m_textureCache.end()) {
+        m_boundTextures[stage] = it->second;
+        return;
+    }
+
+    // NOTE: This path reads back from the D3D9 texture via Peek_DX8_Texture().
+    // For a fully cross-platform backend, textures should be created natively
+    // as BGFXTexture instead of read back from D3D9 on every bind.
+    bgfx::TextureHandle bgfxTex = BGFX_INVALID_HANDLE;
+
+    IDirect3DTexture9* d3dTex = texture->Peek_DX8_Texture();
+    if (d3dTex) {
+        SurfaceClass* surface = texture->Get_Surface_Level(0);
+        if (surface) {
+            int pitch = 0;
+            void* pixels = surface->Lock(&pitch);
+            if (pixels) {
+                SurfaceClass::SurfaceDescription desc;
+                surface->Get_Description(desc);
+
+                int width  = (int)desc.Width;
+                int height = (int)desc.Height;
+                WW3DFormat wwfmt = desc.Format;
+                bgfx::TextureFormat::Enum bgfxFmt = WW3DFormat_To_BGFX(wwfmt);
+
+                // For uncompressed formats, copy row-by-row to handle pitch
+                if (wwfmt >= WW3D_FORMAT_R8G8B8 && wwfmt <= WW3D_FORMAT_A4L4) {
+                    int bpp = WW3DFormat_BytesPerPixel(wwfmt);
+                    int dstPitch = width * bpp;
+                    uint8_t* dst = new uint8_t[dstPitch * height];
+                    const uint8_t* src = static_cast<const uint8_t*>(pixels);
+                    for (int y = 0; y < height; ++y) {
+                        memcpy(dst + y * dstPitch, src + y * pitch, dstPitch);
+                    }
+                    surface->Unlock();
+
+                    const bgfx::Memory* mem = bgfx::copy(dst, dstPitch * height);
+                    delete[] dst;
+
+                    bgfxTex = bgfx::createTexture2D(
+                        (uint16_t)width, (uint16_t)height, false, 1,
+                        bgfxFmt, BGFX_TEXTURE_NONE, mem);
+                } else if (wwfmt == WW3D_FORMAT_DXT1 || wwfmt == WW3D_FORMAT_DXT3 || wwfmt == WW3D_FORMAT_DXT5) {
+                    // Compressed textures: pitch is row pitch in bytes for compressed blocks
+                    int blockSize = (wwfmt == WW3D_FORMAT_DXT1) ? 8 : 16;
+                    int blocksY = (height + 3) / 4;
+                    int dataSize = pitch * blocksY;
+                    surface->Unlock();
+
+                    const bgfx::Memory* mem = bgfx::copy(pixels, dataSize);
+                    bgfxTex = bgfx::createTexture2D(
+                        (uint16_t)width, (uint16_t)height, false, 1,
+                        bgfxFmt, BGFX_TEXTURE_NONE, mem);
+                } else {
+                    // Other formats: raw copy fallback
+                    int size = pitch * height;
+                    surface->Unlock();
+                    WWDEBUG_SAY(("BGFXBackend: unhandled texture format, using raw copy fallback\n"));
+
+                    const bgfx::Memory* mem = bgfx::copy(pixels, size);
+                    bgfxTex = bgfx::createTexture2D(
+                        (uint16_t)width, (uint16_t)height, false, 1,
+                        bgfxFmt, BGFX_TEXTURE_NONE, mem);
+                }
+            } else {
+                WWDEBUG_SAY(("BGFXBackend: failed to lock texture surface\n"));
+            }
+            surface->Release_Ref();
+        }
+    }
+
+    if (!bgfx::isValid(bgfxTex)) {
+        // Fallback: 1x1 white placeholder
+        if (!bgfx::isValid(m_whiteTexture)) {
+            uint32_t white = 0xFFFFFFFF;
+            m_whiteTexture = bgfx::createTexture2D(1, 1, false, 1,
+                bgfx::TextureFormat::BGRA8, BGFX_TEXTURE_NONE, bgfx::copy(&white, sizeof(white)));
+        }
+        bgfxTex = m_whiteTexture;
+    }
+
+    m_textureCache[texture] = bgfxTex;
+    m_boundTextures[stage] = bgfxTex;
+}
+
+void BGFXBackend::Apply_Material_State(const VertexMaterialClass* material)
+{
+    m_currentMaterial = material;
+    if (!material) return;
+
+    Vector3 diffuse, specular, emissive, ambient;
+    material->Get_Diffuse(&diffuse);
+    material->Get_Specular(&specular);
+    material->Get_Emissive(&emissive);
+    material->Get_Ambient(&ambient);
+    float opacity  = material->Get_Opacity();
+    float shininess = material->Get_Shininess();
+
+    float diff[4]  = { diffuse.X,  diffuse.Y,  diffuse.Z,  opacity };
+    float spec[4]  = { specular.X, specular.Y, specular.Z, shininess };
+    float emis[4]  = { emissive.X, emissive.Y, emissive.Z, 0.0f };
+    float amb[4]   = { ambient.X,  ambient.Y,  ambient.Z,  0.0f };
+    float op[4]    = { opacity, 0.0f, 0.0f, 0.0f };
+
+    bgfx::setUniform(m_diffuseUniform,  diff);
+    bgfx::setUniform(m_specularUniform, spec);
+    bgfx::setUniform(m_emissiveUniform, emis);
+    bgfx::setUniform(m_ambientUniform,  amb);
+    bgfx::setUniform(m_opacityUniform,  op);
+}
+
+void BGFXBackend::Apply_Light_Environment_State(LightEnvironmentClass* env)
+{
+    m_currentLightEnv = env;
+    float enable[4] = { env ? 1.0f : 0.0f, 0.0f, 0.0f, 0.0f };
+    bgfx::setUniform(m_lightingEnableUniform, enable);
+
+    if (!env) {
+        // Zero out lights when disabled
+        float zero[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+        bgfx::setUniform(m_ambientLightUniform, zero);
+        float zeroLights[4][4] = {};
+        bgfx::setUniform(m_lightDirUniform, zeroLights, 4);
+        bgfx::setUniform(m_lightDiffuseUniform, zeroLights, 4);
+        return;
+    }
+
+    // Upload ambient light
+    const Vector3& ambient = env->Get_Equivalent_Ambient();
+    float amb[4] = { ambient.X, ambient.Y, ambient.Z, 1.0f };
+    bgfx::setUniform(m_ambientLightUniform, amb);
+
+    // Upload directional lights (up to 4)
+    int lightCount = env->Get_Light_Count();
+    float dirs[4][4];
+    float diffs[4][4];
+    float poss[4][4];
+    for (int i = 0; i < 4; ++i) {
+        if (i < lightCount) {
+            const Vector3& dir = env->Get_Light_Direction(i);
+            const Vector3& diff = env->Get_Light_Diffuse(i);
+            dirs[i][0] = dir.X;  dirs[i][1] = dir.Y;  dirs[i][2] = dir.Z;  dirs[i][3] = 1.0f; // type=1 directional
+            diffs[i][0] = diff.X; diffs[i][1] = diff.Y; diffs[i][2] = diff.Z; diffs[i][3] = 1.0f;
+            poss[i][0] = poss[i][1] = poss[i][2] = poss[i][3] = 0.0f;
+        } else {
+            dirs[i][0] = dirs[i][1] = dirs[i][2] = dirs[i][3] = 0.0f;
+            diffs[i][0] = diffs[i][1] = diffs[i][2] = diffs[i][3] = 0.0f;
+            poss[i][0] = poss[i][1] = poss[i][2] = poss[i][3] = 0.0f;
+        }
+    }
+    bgfx::setUniform(m_lightDirUniform, dirs, 4);
+    bgfx::setUniform(m_lightDiffuseUniform, diffs, 4);
+    bgfx::setUniform(m_lightPosUniform, poss, 4);
+}
+
+// Store individual DX8 lights for sorting-renderer path
+static Vector3 s_dx8LightDirs[4];
+static Vector3 s_dx8LightDiffuses[4];
+static Vector3 s_dx8LightPoss[4];
+static float   s_dx8LightRanges[4];
+static int     s_dx8LightTypes[4];
+static bool    s_dx8LightEnabled[4] = { false, false, false, false };
+
+void BGFXBackend::Set_DX8_Light(int index, const void* light)
+{
+    if (index < 0 || index >= 4) return;
+
+    if (!light) {
+        s_dx8LightEnabled[index] = false;
+    } else {
+        const D3DLIGHT9* d3dLight = static_cast<const D3DLIGHT9*>(light);
+        s_dx8LightEnabled[index] = true;
+        s_dx8LightDirs[index] = Vector3(d3dLight->Direction.x, d3dLight->Direction.y, d3dLight->Direction.z);
+        s_dx8LightDiffuses[index] = Vector3(d3dLight->Diffuse.r, d3dLight->Diffuse.g, d3dLight->Diffuse.b);
+        s_dx8LightPoss[index] = Vector3(d3dLight->Position.x, d3dLight->Position.y, d3dLight->Position.z);
+        s_dx8LightRanges[index] = d3dLight->Range;
+        s_dx8LightTypes[index] = (int)d3dLight->Type; // 1=dir, 2=point, 3=spot
+    }
+
+    // Upload to shader immediately (bgfx uniforms are per-submit)
+    float enable[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
+    bgfx::setUniform(m_lightingEnableUniform, enable);
+
+    float dirs[4][4];
+    float diffs[4][4];
+    float poss[4][4];
+    for (int i = 0; i < 4; ++i) {
+        if (s_dx8LightEnabled[i]) {
+            dirs[i][0] = s_dx8LightDirs[i].X;  dirs[i][1] = s_dx8LightDirs[i].Y;  dirs[i][2] = s_dx8LightDirs[i].Z;  dirs[i][3] = (float)s_dx8LightTypes[i];
+            diffs[i][0] = s_dx8LightDiffuses[i].X; diffs[i][1] = s_dx8LightDiffuses[i].Y; diffs[i][2] = s_dx8LightDiffuses[i].Z; diffs[i][3] = 1.0f;
+            poss[i][0] = s_dx8LightPoss[i].X;  poss[i][1] = s_dx8LightPoss[i].Y;  poss[i][2] = s_dx8LightPoss[i].Z;  poss[i][3] = s_dx8LightRanges[i];
+        } else {
+            dirs[i][0] = dirs[i][1] = dirs[i][2] = dirs[i][3] = 0.0f;
+            diffs[i][0] = diffs[i][1] = diffs[i][2] = diffs[i][3] = 0.0f;
+            poss[i][0] = poss[i][1] = poss[i][2] = poss[i][3] = 0.0f;
+        }
+    }
+    bgfx::setUniform(m_lightDirUniform, dirs, 4);
+    bgfx::setUniform(m_lightDiffuseUniform, diffs, 4);
+    bgfx::setUniform(m_lightPosUniform, poss, 4);
+}
+
+void BGFXBackend::Set_Transform_World(const Matrix4& m)
+{
+    m_worldMatrix = m;
+    m_worldDirty = true;
+}
+
+void BGFXBackend::Set_Transform_View(const Matrix4& m)
+{
+    m_viewMatrix = m;
+    m_viewDirty = true;
+}
+
+void BGFXBackend::Set_Transform_Projection(const Matrix4& m)
+{
+    m_projectionMatrix = m;
+    m_projectionDirty = true;
+}
+
+static int GetTexCoordSize(unsigned fvf, int index)
+{
+    // D3DFVF texcoord sizes are encoded in 2-bit fields starting at bit 16.
+    // 0=1 component, 1=2, 2=3, 3=4.
+    static const int sizeTable[4] = { 1, 2, 3, 4 };
+    int shift = 16 + index * 2;
+    int bits = (fvf >> shift) & 0x3;
+    return sizeTable[bits];
+}
+
+static bool BuildVertexLayoutFromFVF(unsigned fvf, bgfx::VertexLayout& layout)
+{
+    layout.begin();
+
+    unsigned posType = fvf & D3DFVF_POSITION_MASK;
+
+    if (posType == D3DFVF_XYZ) {
+        layout.add(bgfx::Attrib::Position, 3, bgfx::AttribType::Float);
+    } else if (posType == D3DFVF_XYZRHW) {
+        layout.add(bgfx::Attrib::Position, 4, bgfx::AttribType::Float);
+    } else if (posType >= D3DFVF_XYZB1 && posType <= D3DFVF_XYZB5) {
+        int blendCount = (posType - D3DFVF_XYZB1) / 2 + 1;
+        layout.add(bgfx::Attrib::Position, 3, bgfx::AttribType::Float);
+        if (fvf & D3DFVF_LASTBETA_UBYTE4) {
+            // All but the last weight are floats; the last is UBYTE4 bone indices.
+            for (int i = 0; i < blendCount - 1; ++i) {
+                layout.add(bgfx::Attrib::Weight, 1, bgfx::AttribType::Float);
+            }
+            layout.add(bgfx::Attrib::Indices, 4, bgfx::AttribType::Uint8, true);
+        } else {
+            for (int i = 0; i < blendCount; ++i) {
+                layout.add(bgfx::Attrib::Weight, 1, bgfx::AttribType::Float);
+            }
+        }
+    }
+
+    if (fvf & D3DFVF_NORMAL) {
+        layout.add(bgfx::Attrib::Normal, 3, bgfx::AttribType::Float);
+    }
+
+    // Point size not supported in modern bgfx — skipped
+    // if (fvf & D3DFVF_PSIZE) {
+    //     layout.add(bgfx::Attrib::PointSize, 1, bgfx::AttribType::Float);
+    // }
+
+    if (fvf & D3DFVF_DIFFUSE) {
+        layout.add(bgfx::Attrib::Color0, 4, bgfx::AttribType::Uint8, true);
+    }
+
+    if (fvf & D3DFVF_SPECULAR) {
+        layout.add(bgfx::Attrib::Color1, 4, bgfx::AttribType::Uint8, true);
+    }
+
+    // Texture coordinates — respect per-set component counts.
+    int texCount = (fvf & D3DFVF_TEXCOUNT_MASK) >> D3DFVF_TEXCOUNT_SHIFT;
+    for (int i = 0; i < texCount && i < 8; ++i) {
+        int components = GetTexCoordSize(fvf, i);
+        bgfx::Attrib::Enum attr = (bgfx::Attrib::Enum)(bgfx::Attrib::TexCoord0 + i);
+        layout.add(attr, components, bgfx::AttribType::Float);
+    }
+
+    layout.end();
+    return layout.getStride() > 0;
+}
+
+void BGFXBackend::Set_Vertex_Buffer(const VertexBufferClass* vb)
+{
+    if (!vb) {
+        m_currentVB = nullptr;
+        return;
+    }
+    m_currentVB = vb;
+
+    bool isDynamic = (vb->Type() == BUFFER_TYPE_DYNAMIC_DX8 || vb->Type() == BUFFER_TYPE_DYNAMIC_SORTING);
+
+    if (!isDynamic) {
+        auto it = m_vbCache.find(vb);
+        if (it != m_vbCache.end()) {
+            bgfx::setVertexBuffer(0, it->second);
+            return;
+        }
+    }
+
+    // Lock and copy data
+    VertexBufferClass::WriteLockClass lock(const_cast<VertexBufferClass*>(vb));
+    void* data = lock.Get_Vertex_Array();
+    int count = vb->Get_Vertex_Count();
+
+    bgfx::VertexLayout layout;
+    if (!BuildVertexLayoutFromFVF(vb->FVF_Info().Get_FVF(), layout)) {
+        WWDEBUG_SAY(("BGFXBackend: unsupported FVF format for vertex buffer\n"));
+        return;
+    }
+
+    if (isDynamic) {
+        // Transient buffers for per-frame dynamic data
+        bgfx::TransientVertexBuffer tvb;
+        bgfx::allocTransientVertexBuffer(&tvb, count, layout);
+        if (tvb.data) {
+            memcpy(tvb.data, data, count * layout.getStride());
+            bgfx::setVertexBuffer(0, &tvb);
+        } else {
+            WWDEBUG_SAY(("BGFXBackend: failed to allocate transient vertex buffer\n"));
+        }
+    } else {
+        const bgfx::Memory* mem = bgfx::copy(data, count * layout.getStride());
+        bgfx::VertexBufferHandle handle = bgfx::createVertexBuffer(mem, layout);
+        m_vbCache[vb] = handle;
+        bgfx::setVertexBuffer(0, handle);
+    }
+}
+
+void BGFXBackend::Set_Index_Buffer(const IndexBufferClass* ib, unsigned short index_base_offset)
+{
+    if (!ib) {
+        m_currentIB = nullptr;
+        m_currentIBOffset = 0;
+        return;
+    }
+    m_currentIB = ib;
+    m_currentIBOffset = index_base_offset;
+
+    bool isDynamic = (ib->Type() == BUFFER_TYPE_DYNAMIC_DX8 || ib->Type() == BUFFER_TYPE_DYNAMIC_SORTING);
+
+    if (!isDynamic) {
+        auto it = m_ibCache.find(ib);
+        if (it != m_ibCache.end()) {
+            bgfx::setIndexBuffer(it->second);
+            return;
+        }
+    }
+
+    IndexBufferClass::WriteLockClass lock(const_cast<IndexBufferClass*>(ib));
+    unsigned short* data = lock.Get_Index_Array();
+    int count = ib->Get_Index_Count();
+
+    if (isDynamic) {
+        bgfx::TransientIndexBuffer tib;
+        bgfx::allocTransientIndexBuffer(&tib, count);
+        if (tib.data) {
+            memcpy(tib.data, data, count * sizeof(unsigned short));
+            bgfx::setIndexBuffer(&tib);
+        } else {
+            WWDEBUG_SAY(("BGFXBackend: failed to allocate transient index buffer\n"));
+        }
+    } else {
+        const bgfx::Memory* mem = bgfx::copy(data, count * sizeof(unsigned short));
+        bgfx::IndexBufferHandle handle = bgfx::createIndexBuffer(mem);
+        m_ibCache[ib] = handle;
+        bgfx::setIndexBuffer(handle);
+    }
+}
+
+void BGFXBackend::Draw_Indexed_Triangles(unsigned short start_index, unsigned short polygon_count,
+                                         unsigned short min_vertex_index, unsigned short vertex_count)
+{
+    if (!bgfx::isValid(m_currentProgram)) {
+        WWDEBUG_SAY(("BGFXBackend: no program set, skipping draw\n"));
+        return;
+    }
+
+    // Set buffer ranges for this draw call
+    // Try cache first, then fall back to current buffer pointers
+    if (m_currentIB) {
+        auto it = m_ibCache.find(m_currentIB);
+        if (it != m_ibCache.end()) {
+            bgfx::setIndexBuffer(it->second, start_index, polygon_count * 3);
+        }
+        // If not in cache, the buffer should have been set via Set_Index_Buffer already
+    }
+    if (m_currentVB) {
+        auto it = m_vbCache.find(m_currentVB);
+        if (it != m_vbCache.end()) {
+            bgfx::setVertexBuffer(0, it->second, min_vertex_index, vertex_count);
+        }
+        // If not in cache, the buffer should have been set via Set_Vertex_Buffer already
+    }
+
+    bgfx::setState(m_currentState);
+    bgfx::submit(0, m_currentProgram);
+}
+
+void BGFXBackend::Draw_Indexed_Strip(unsigned short start_index, unsigned short index_count,
+                                      unsigned short min_vertex_index, unsigned short vertex_count)
+{
+    if (!bgfx::isValid(m_currentProgram)) {
+        WWDEBUG_SAY(("BGFXBackend: no program set, skipping draw\n"));
+        return;
+    }
+
+    if (m_currentIB) {
+        auto it = m_ibCache.find(m_currentIB);
+        if (it != m_ibCache.end()) {
+            bgfx::setIndexBuffer(it->second, start_index, index_count);
+        }
+    }
+    if (m_currentVB) {
+        auto it = m_vbCache.find(m_currentVB);
+        if (it != m_vbCache.end()) {
+            bgfx::setVertexBuffer(0, it->second, min_vertex_index, vertex_count);
+        }
+    }
+
+    bgfx::setState(m_currentState | BGFX_STATE_PT_TRISTRIP);
+    bgfx::submit(0, m_currentProgram);
+}
+
+void BGFXBackend::Commit_Render_State()
+{
+    // Apply transforms
+    if (m_worldDirty || m_viewDirty || m_projectionDirty) {
+        float modelMtx[16];
+        Matrix4ToFloat16Transpose(m_worldMatrix, modelMtx);
+        bgfx::setUniform(m_modelUniform, modelMtx);
+
+        // Compute viewProj = view * proj (D3D row-vector convention), then transpose for GLSL
+        Matrix4 viewProj = m_viewMatrix * m_projectionMatrix;
+        float vpMtx[16];
+        Matrix4ToFloat16Transpose(viewProj, vpMtx);
+        bgfx::setUniform(m_viewProjUniform, vpMtx);
+
+        // Extract camera position from view matrix
+        // View matrix: t = -R * eye  =>  eye = -R^T * t
+        const Matrix4& V = m_viewMatrix;
+        float tx = V[0][3], ty = V[1][3], tz = V[2][3];
+        float camPos[4];
+        camPos[0] = -(tx * V[0][0] + ty * V[1][0] + tz * V[2][0]);
+        camPos[1] = -(tx * V[0][1] + ty * V[1][1] + tz * V[2][1]);
+        camPos[2] = -(tx * V[0][2] + ty * V[1][2] + tz * V[2][2]);
+        camPos[3] = 1.0f;
+        bgfx::setUniform(m_camPosUniform, camPos);
+
+        m_worldDirty = false;
+        m_viewDirty = false;
+        m_projectionDirty = false;
+    }
+
+    // Ensure default program is set
+    if (bgfx::isValid(m_defaultProgram)) {
+        // Program is bound per-draw via submit()
+    }
+}

--- a/Code/ww3d2/backends/bgfx/bgfxbackend.h
+++ b/Code/ww3d2/backends/bgfx/bgfxbackend.h
@@ -1,0 +1,387 @@
+// bgfxbackend.h - OpenW3D render backend
+
+#ifndef BGFXBACKEND_H
+#define BGFXBACKEND_H
+
+#include "ww3dbackend.h"
+#include "rddesc.h"
+#include "matrix4.h"
+
+#include <bgfx/bgfx.h>
+
+#include <array>
+#include <vector>
+#include <unordered_map>
+
+// Include material mapper for integration
+#include "BGFXMaterialMapper.h"
+
+// Include shader key and variant cache
+#include "ShaderKey.h"
+#include "ShaderVariantCache.h"
+
+// Common DX8 render state values that we track
+namespace DX8RenderState
+{
+    enum {
+        FILLMODE = 8,
+        BLENDENABLE = 19,
+        SRCBLEND = 60,
+        DESTBLEND = 61,
+        BLENDOP = 62,
+        CULLMODE = 22,
+        ZENABLE = 7,
+        ZWRITEENABLE = 14,
+        ALPHABLENDENABLE = 19,
+        ALPHATESTENABLE = 24,
+        STENCILENABLE = 52,
+        LIGHTING = 137,
+        DIFFUSEMATERIALSOURCE = 145,
+        AMBIENTMATERIALSOURCE = 146,
+        EMISSIVEMATERIALSOURCE = 147,
+        SPECULARMATERIALSOURCE = 148,
+        SHADEMODE = 134,
+        COLORVERTEX = 141,
+
+        // Fog states
+        FOGENABLE = 27,
+        FOGCOLOR = 30,
+        FOGSTART = 31,
+        FOGEND = 32,
+        FOGDENSITY = 33,
+        RANGEFOGENABLE = 38,
+
+        // Stencil states
+        STENCILFAIL = 53,
+        STENCILZFAIL = 54,
+        STENCILPASS = 55,
+        STENCILFUNC = 56,
+        STENCILREF = 57,
+        STENCILMASK = 58,
+        STENCILWRITEMASK = 59,
+
+        // Alpha test reference and func (D3DRS_ALPHAREF=24, D3DRS_ALPHAFUNC=25)
+        // Note: ALPHATESTENABLE in this enum is misnamed (value 24 is actually ALPHAREF in D3D)
+        // Kept for compatibility with existing code
+        ALPHAREF = 25,
+
+        // Depth bias states
+        SLOPESCALEDEPTHBIAS = 175,
+        DEPTHBIAS = 195,
+    };
+
+    enum FillMode {
+        SOLID = 3,
+        WIREFRAME = 2,
+        POINT = 1,
+    };
+
+    enum CullMode {
+        NONE = 1,
+        CW = 2,
+        CCW = 3,
+    };
+
+    enum BlendOp {
+        ADD = 0,
+        SUBTRACT = 1,
+        REVSUBTRACT = 2,
+        MIN = 3,
+        MAX = 4,
+    };
+
+    enum BlendFactor {
+        ZERO = 0,
+        ONE = 1,
+        SRCCOLOR = 2,
+        INVERTSRCCOLOR = 3,
+        SRCALPHA = 4,
+        INVERTSRCALPHA = 5,
+        DESTALPHA = 6,
+        INVERTDESTALPHA = 7,
+        DESTCOLOR = 8,
+        INVERTDESTCOLOR = 9,
+        SRCALPHASAT = 10,
+        CONSTANTCOLOR = 11,
+        ONEMINUSCONSTANTCOLOR = 12,
+        CONSTANTALPHA = 13,
+        ONEMINUSCONSTANTALPHA = 14,
+    };
+}
+
+// Forward declarations
+class BGFXTexture;
+class BGFXVertexBuffer;
+class BGFXIndexBuffer;
+
+// BGFX Backend implementation
+class BGFXBackend : public WW3DBackend
+{
+public:
+    BGFXBackend();
+    virtual ~BGFXBackend();
+
+    // WW3DBackend interface
+    virtual bool Init(void * hwnd, bool lite = false) override;
+    virtual void Shutdown() override;
+
+    virtual bool Set_Any_Render_Device() override;
+    virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Next_Render_Device() override;
+    virtual bool Toggle_Windowed() override;
+    virtual bool Is_Windowed() override;
+
+    virtual int Get_Render_Device_Count() override;
+    virtual int Get_Render_Device() override;
+    virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) override;
+    virtual const char * Get_Render_Device_Name(int device_index) override;
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual int Get_Device_Resolution_Width() override;
+    virtual int Get_Device_Resolution_Height() override;
+
+    virtual bool Registry_Save_Render_Device(const char * sub_key) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) override;
+    virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) override;
+
+    virtual void Begin_Scene() override;
+    virtual void End_Scene(bool flip_frame = true) override;
+    virtual void Flip_To_Primary() override;
+
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
+
+    virtual void Set_Swap_Interval(int swap) override;
+    virtual int Get_Swap_Interval() override;
+
+    virtual void Set_Texture_Bitdepth(int depth) override;
+    virtual int Get_Texture_Bitdepth() override;
+
+    virtual void Set_Viewport(const void* viewport) override;
+    void Set_Viewport(int x, int y, int width, int height, float minZ = 0.0f, float maxZ = 1.0f);
+    virtual void Set_DX8_Render_State(int state, unsigned value) override;
+    virtual void Set_Light_Environment(const void* env) override;
+    virtual void* _Get_DX8_Front_Buffer() override;
+
+    // Backend dispatch overrides from WW3DBackend
+    virtual bool Wants_Deferred_State_Apply() const override { return true; }
+    virtual void Apply_Shader_State(const ShaderClass& shader) override;
+    virtual void Apply_Texture_State(unsigned stage, TextureClass* texture) override;
+    virtual void Invalidate_Texture_Cache_Entry(TextureClass* texture) override;
+    virtual void Invalidate_Vertex_Buffer_Cache_Entry(const VertexBufferClass* vb) override;
+    virtual void Invalidate_Index_Buffer_Cache_Entry(const IndexBufferClass* ib) override;
+    virtual void Apply_Material_State(const VertexMaterialClass* material) override;
+    virtual void Apply_Light_Environment_State(LightEnvironmentClass* env) override;
+    virtual void Set_DX8_Light(int index, const void* light) override;
+    virtual void Set_Transform_World(const Matrix4& m) override;
+    virtual void Set_Transform_View(const Matrix4& m) override;
+    virtual void Set_Transform_Projection(const Matrix4& m) override;
+    virtual void Set_Vertex_Buffer(const VertexBufferClass* vb) override;
+    virtual void Set_Index_Buffer(const IndexBufferClass* ib, unsigned short index_base_offset) override;
+    virtual void Draw_Indexed_Triangles(unsigned short start_index, unsigned short polygon_count, unsigned short min_vertex_index, unsigned short vertex_count) override;
+    virtual void Draw_Indexed_Strip(unsigned short start_index, unsigned short index_count, unsigned short min_vertex_index, unsigned short vertex_count) override;
+    virtual void Commit_Render_State() override;
+
+    // Texture management
+    bgfx::TextureHandle Create_System_Texture(int width, int height, bgfx::TextureFormat::Enum format, uint64_t flags = BGFX_TEXTURE_NONE);
+    void Destroy_Texture(bgfx::TextureHandle handle);
+    void Set_Texture(int stage, bgfx::TextureHandle handle, uint32_t flags = UINT32_MAX, uint8_t mip = 0);
+
+    // Vertex buffer management
+    bgfx::VertexBufferHandle Create_Vertex_Buffer(void* data, int vertexCount, const bgfx::VertexLayout& layout, uint64_t flags = BGFX_BUFFER_NONE);
+    void Destroy_Vertex_Buffer(bgfx::VertexBufferHandle handle);
+    void Set_Vertex_Buffer(int stream, bgfx::VertexBufferHandle handle, uint32_t startVertex = 0, uint32_t numVertices = UINT32_MAX);
+
+    // Index buffer management
+    bgfx::IndexBufferHandle Create_Index_Buffer(void* data, int indexCount, bool index32bit = false, uint64_t flags = BGFX_BUFFER_NONE);
+    void Destroy_Index_Buffer(bgfx::IndexBufferHandle handle);
+    void Set_Index_Buffer(bgfx::IndexBufferHandle handle, int startIndex = 0, int numIndices = INT32_MAX);
+
+    // Draw commands
+    void Draw(int numVertices, int numInstances = 1);
+    void Draw_Indexed(int numIndices, int numInstances = 1, int startIndex = 0, int startVertex = 0);
+
+    // Shader program management
+    bgfx::ShaderHandle Load_Shader(const char* shaderPath);
+    bgfx::ProgramHandle Create_Program(const char* vsPath, const char* fsPath);
+    bgfx::ProgramHandle Create_Program(bgfx::ShaderHandle vs, bgfx::ShaderHandle fs);
+    void Destroy_Shader(bgfx::ShaderHandle handle);
+    void Destroy_Program(bgfx::ProgramHandle handle);
+    void Set_Program(bgfx::ProgramHandle program);
+
+    // Uniform (constant buffer) management
+    bgfx::UniformHandle Create_Uniform(const char* name, bgfx::UniformType::Enum type, uint16_t num = 1);
+    void Destroy_Uniform(bgfx::UniformHandle handle);
+    void Set_Uniform(bgfx::UniformHandle handle, const void* value, uint16_t num = 1);
+
+    // Scissor rect management
+    void Enable_Scissor(bool enable);
+    void Set_Scissor(int x, int y, int width, int height);
+    bool Is_Scissor_Enabled() const;
+
+    // Frame buffer (render target) management
+    bgfx::FrameBufferHandle Create_FrameBuffer(int width, int height, bgfx::TextureFormat::Enum format, uint64_t textureFlags = BGFX_TEXTURE_RT_WRITE_ONLY);
+    bgfx::FrameBufferHandle Create_FrameBuffer(int width, int height, bgfx::TextureFormat::Enum colorFormat, bgfx::TextureFormat::Enum depthFormat, uint64_t textureFlags = BGFX_TEXTURE_RT_WRITE_ONLY);
+    bgfx::FrameBufferHandle Create_FrameBuffer_Attachment(bgfx::TextureHandle color, bgfx::TextureHandle depth);
+    void Destroy_FrameBuffer(bgfx::FrameBufferHandle handle);
+    void Set_FrameBuffer(bgfx::FrameBufferHandle handle, int width = -1, int height = -1);
+    void Set_FrameBuffer(bgfx::FrameBufferHandle handle, bgfx::TextureHandle color, bgfx::TextureHandle depth);
+    void Set_Default_FrameBuffer();
+
+    // Resource cache management
+    void Clear_Resource_Caches();
+
+    // Material integration - map ww3d2 material properties to bgfx
+    void Set_Material_Colors(const Vector3& diffuse, float alpha, const Vector3& specular, float shininess, const Vector3& emissive, const Vector3& ambient);
+    void Set_Material_Uniforms(bgfx::UniformHandle diffuseHandle, bgfx::UniformHandle specularHandle, bgfx::UniformHandle emissiveHandle, const MaterialColors& colors);
+    void Set_Texture_Stage(int stage, bgfx::TextureHandle handle, uint32_t flags = UINT32_MAX, uint8_t mip = 0, int uvIndex = 0);
+    uint64_t Apply_Shader(const ShaderClass& shader, bool lightingEnabled);
+    void Begin_Material_Pass();
+    void End_Material_Pass();
+
+    // Renderer info
+    const char* Get_Renderer_Name();
+    bgfx::RendererType::Enum Get_Renderer_Type();
+
+private:
+    static constexpr int MAX_TEXTURE_STAGES = 4;
+
+    void Update_ViewDimensions();
+    void Apply_Render_State(int state, unsigned value);
+
+    // Helper: Map DX8 stencil comparison function to bgfx stencil func
+    static uint32_t Compare_Stencil_Func(unsigned dx8func);
+    // Helper: Map DX8 stencil operation to bgfx stencil op (stencil fail)
+    static uint32_t Compare_Stencil_Op(unsigned dx8op);
+    // Helper: Map DX8 stencil operation to bgfx stencil op (depth fail)
+    static uint32_t Compare_Stencil_Op_Z(unsigned dx8op);
+    // Helper: Map DX8 stencil operation to bgfx stencil op (depth pass)
+    static uint32_t Compare_Stencil_Op_Pass(unsigned dx8op);
+
+    // Convert from W3D color format (0-1 float) to 0xAABBGGRR in little-endian memory
+    static uint32_t Color_To_ABGR(const Vector3& color)
+    {
+        uint8_t r = static_cast<uint8_t>(color.X * 255.0f);
+        uint8_t g = static_cast<uint8_t>(color.Y * 255.0f);
+        uint8_t b = static_cast<uint8_t>(color.Z * 255.0f);
+        return 0xFF000000 | (r << 16) | (g << 8) | b;
+    }
+
+    // Window/Surface
+    void* m_hwnd;
+    void* m_nativeDisplay;
+    int m_width;
+    int m_height;
+    int m_bitDepth;
+    bool m_windowed;
+
+    // Device enumeration
+    std::vector<std::string> m_deviceNames;
+    int m_currentDevice;
+
+    // Swap/VSync
+    int m_swapInterval;
+    int m_textureBitDepth;
+
+    // DX8 render state cache - maps state enum to value
+    std::unordered_map<int, unsigned> m_render_state;
+
+    // Internal bgfx state
+    bgfx::TextureHandle m_systemTexture;
+    bgfx::FrameBufferHandle m_frameBuffer;
+    bgfx::ProgramHandle m_currentProgram;
+    bgfx::TextureHandle m_whiteTexture;
+    bool m_initialized;
+
+    // Current bgfx state for tracking changes
+    uint64_t m_currentState;
+    uint32_t m_currentColor;
+
+    // Viewport state
+    int m_viewportX;
+    int m_viewportY;
+    int m_viewportWidth;
+    int m_viewportHeight;
+    float m_viewportMinZ;
+    float m_viewportMaxZ;
+
+    // Scissor state
+    bool m_scissorEnabled;
+    int m_scissorX;
+    int m_scissorY;
+    int m_scissorWidth;
+    int m_scissorHeight;
+
+    // Active framebuffer (0 = default/backbuffer)
+    bgfx::FrameBufferHandle m_activeFrameBuffer;
+
+    // Sampler + texture stage state
+    std::array<bgfx::UniformHandle, MAX_TEXTURE_STAGES> m_samplerUniforms;
+    std::array<bgfx::TextureHandle, MAX_TEXTURE_STAGES> m_boundTextures;
+    std::array<uint32_t, MAX_TEXTURE_STAGES> m_textureFlags;
+    std::array<uint8_t, MAX_TEXTURE_STAGES> m_textureMipLevels;
+    std::array<int, MAX_TEXTURE_STAGES> m_textureUvIndices;
+    int m_activeTextureStages = 0;
+
+    // Material/light uniforms
+    bgfx::UniformHandle m_diffuseUniform;
+    bgfx::UniformHandle m_specularUniform;
+    bgfx::UniformHandle m_emissiveUniform;
+    bgfx::UniformHandle m_ambientUniform;
+    bgfx::UniformHandle m_opacityUniform;
+    bgfx::UniformHandle m_lightingEnableUniform;
+    bgfx::UniformHandle m_alphaTestUniform;
+
+    // Light environment uniforms
+    bgfx::UniformHandle m_ambientLightUniform;
+    bgfx::UniformHandle m_lightDirUniform;
+    bgfx::UniformHandle m_lightDiffuseUniform;
+    bgfx::UniformHandle m_lightPosUniform;
+
+    // Transform uniforms
+    bgfx::UniformHandle m_modelUniform;
+    bgfx::UniformHandle m_viewProjUniform;
+    bgfx::UniformHandle m_camPosUniform;
+
+    // Fog uniforms
+    bgfx::UniformHandle m_fogColorUniform;
+    bgfx::UniformHandle m_fogParamsUniform;
+
+    // Ubershader uniforms
+    bgfx::UniformHandle m_shaderModeUniform;
+    bgfx::UniformHandle m_shaderFlagsUniform;
+    bgfx::UniformHandle m_detailFuncUniform;
+
+    // Cached render state from DX8Wrapper dispatch
+    Matrix4 m_worldMatrix;
+    Matrix4 m_viewMatrix;
+    Matrix4 m_projectionMatrix;
+    bool m_worldDirty;
+    bool m_viewDirty;
+    bool m_projectionDirty;
+
+    // Cached W3D objects for bridging
+    const VertexBufferClass* m_currentVB;
+    const IndexBufferClass* m_currentIB;
+    unsigned short m_currentIBOffset;
+    const VertexMaterialClass* m_currentMaterial;
+    LightEnvironmentClass* m_currentLightEnv;
+
+    // Default shader program for mesh rendering
+    bgfx::ProgramHandle m_defaultProgram;
+
+    // Resource caches (W3D object -> bgfx handle).
+    // NOTE: These caches do not evict entries when W3D objects are destroyed.
+    // If a destroyed object is reallocated at the same address, a stale handle
+    // may be reused. A proper fix requires invalidation on object destruction.
+    std::unordered_map<const void*, bgfx::VertexBufferHandle> m_vbCache;
+    std::unordered_map<const void*, bgfx::IndexBufferHandle> m_ibCache;
+    std::unordered_map<const void*, bgfx::TextureHandle> m_textureCache;
+
+    // Shader variant cache
+    ShaderVariantCache m_shaderCache;
+};
+
+#endif // BGFXBACKEND_H

--- a/Code/ww3d2/backends/bgfx/shaders/source/fs_mesh.sc
+++ b/Code/ww3d2/backends/bgfx/shaders/source/fs_mesh.sc
@@ -1,0 +1,111 @@
+$input v_texcoord0, v_color0, v_normal, v_worldPos
+$output gl_FragColor
+
+#include <bgfx_shader.sh>
+
+uniform vec4 u_diffuseColor;
+uniform vec4 u_specularColor;
+uniform vec4 u_emissiveColor;
+uniform vec4 u_ambientColor;
+uniform vec4 u_shininess;
+uniform vec4 u_lightingEnable;
+uniform vec4 u_opacity;
+uniform vec4 u_alphaTest;
+
+// Light environment — up to 4 lights (directional/point/spot)
+uniform vec4 u_ambientLight;
+uniform vec4 u_lightDir[4];   // xyz=direction, w=type (1=dir, 2=point, 3=spot)
+uniform vec4 u_lightDiffuse[4]; // xyz=color, w=enable
+uniform vec4 u_lightPos[4];   // xyz=position, w=range
+uniform vec4 u_camPos;
+
+// Fog
+uniform vec4 u_fogColor;
+uniform vec4 u_fogParams; // x=start, y=end, z=density, w=enable
+
+SAMPLER2D(s_diffuse, 0);
+
+vec3 CalculateLighting(vec3 worldPos, vec3 normal, vec3 diffuseColor, vec3 specularColor, float shininess)
+{
+    vec3 result = vec3_splat(0.0);
+
+    if (u_lightingEnable.x < 0.5)
+    {
+        return diffuseColor;
+    }
+
+    // Ambient term
+    vec3 ambient = u_ambientLight.xyz * diffuseColor;
+    result += ambient;
+
+    vec3 viewDir = normalize(u_camPos.xyz - worldPos);
+
+    for (int i = 0; i < 4; i++)
+    {
+        // Light enabled if diffuse alpha > 0
+        if (u_lightDiffuse[i].w < 0.5) continue;
+
+        vec3 lightColor = u_lightDiffuse[i].xyz;
+        vec3 lightDir;
+        float attenuation = 1.0;
+        int lightType = int(u_lightDir[i].w + 0.5);
+
+        if (lightType == 2) // Point
+        {
+            vec3 toLight = u_lightPos[i].xyz - worldPos;
+            float dist = length(toLight);
+            lightDir = normalize(toLight);
+            float range = u_lightPos[i].w;
+            if (dist > range) continue;
+            attenuation = 1.0 - (dist / range);
+            attenuation = max(attenuation, 0.0);
+            attenuation = pow(attenuation, 2.0);
+        }
+        else // Directional (type 1) or default
+        {
+            lightDir = -normalize(u_lightDir[i].xyz);
+        }
+
+        // Diffuse
+        float NdotL = max(dot(normal, lightDir), 0.0);
+        vec3 diff = diffuseColor * lightColor * NdotL;
+
+        // Specular (Blinn-Phong)
+        vec3 halfDir = normalize(lightDir + viewDir);
+        float NdotH = max(dot(normal, halfDir), 0.0);
+        float specFactor = pow(NdotH, shininess);
+        vec3 spec = specularColor * lightColor * specFactor;
+
+        result += (diff + spec) * attenuation;
+    }
+
+    return result;
+}
+
+void main()
+{
+    vec4 texColor = texture2D(s_diffuse, v_texcoord0);
+    vec4 diffuse = texColor * u_diffuseColor;
+
+    // Alpha test
+    if (u_alphaTest.x > 0.5 && diffuse.a < u_alphaTest.y)
+    {
+        discard;
+    }
+
+    vec3 litColor = CalculateLighting(v_worldPos, normalize(v_normal), diffuse.xyz, u_specularColor.xyz, u_shininess.x);
+
+    vec3 finalColor = litColor + u_emissiveColor.xyz;
+    float alpha = diffuse.a * u_opacity.x;
+
+    // Fog
+    if (u_fogParams.w > 0.5)
+    {
+        float dist = length(u_camPos.xyz - v_worldPos);
+        float fogFactor = (u_fogParams.y - dist) / (u_fogParams.y - u_fogParams.x);
+        fogFactor = clamp(fogFactor, 0.0, 1.0);
+        finalColor = mix(u_fogColor.rgb, finalColor, fogFactor);
+    }
+
+    gl_FragColor = vec4(finalColor, alpha);
+}

--- a/Code/ww3d2/backends/bgfx/shaders/source/fs_uber.sc
+++ b/Code/ww3d2/backends/bgfx/shaders/source/fs_uber.sc
@@ -1,0 +1,486 @@
+$input v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+$input v_color0, v_color1, v_normal, v_worldPos
+$output gl_FragColor
+
+#include <bgfx_shader.sh>
+
+// ============================================================================
+// Shader Mode Enums
+// ============================================================================
+
+// Blend modes (u_shaderMode.x)
+#define BLEND_REPLACE   0
+#define BLEND_ADD       1
+#define BLEND_MULTIPLY  2
+#define BLEND_ALPHA     3
+
+// Fog modes (u_shaderMode.y)
+#define FOG_NONE        0
+#define FOG_LINEAR      1
+#define FOG_EXP         2
+#define FOG_EXP2        3
+
+// Primary gradient modes (u_shaderMode.z)
+#define PRIGRAD_NONE    0
+#define PRIGRAD_MOD     1
+#define PRIGRAD_ADD     2
+
+// Secondary gradient modes (u_shaderMode.w)
+#define SECGRAD_NONE    0
+#define SECGRAD_ADD     1
+
+// ============================================================================
+// Shader Mode Uniforms
+// ============================================================================
+
+// x=blendMode, y=fogMode, z=priGradient, w=secGradient
+uniform vec4 u_shaderMode;
+
+// x=alphaTest, y=texturing, z=lighting, w=alphaTestRef
+uniform vec4 u_shaderFlags;
+
+// x=detailColor mode, y=detailAlpha mode
+uniform vec4 u_detailFunc;
+
+// ============================================================================
+// Material Uniforms
+// ============================================================================
+
+uniform vec4 u_diffuseColor;
+uniform vec4 u_specularColor;
+uniform vec4 u_emissiveColor;
+uniform vec4 u_ambientColor;
+uniform vec4 u_shininess;
+uniform vec4 u_opacity;
+
+// ============================================================================
+// Light Environment
+// ============================================================================
+
+uniform vec4 u_ambientLight;
+uniform vec4 u_lightDir[4];    // xyz=direction, w=type (1=dir, 2=point, 3=spot)
+uniform vec4 u_lightDiffuse[4]; // xyz=color, w=enable
+uniform vec4 u_lightPos[4];    // xyz=position, w=range
+uniform vec4 u_camPos;
+
+// ============================================================================
+// Fog
+// ============================================================================
+
+uniform vec4 u_fogColor;
+uniform vec4 u_fogParams; // x=start, y=end, z=density, w=enable (redundant with fogMode)
+
+// ============================================================================
+// Texture Samplers
+// ============================================================================
+
+SAMPLER2D(s_tex0, 0);
+SAMPLER2D(s_tex1, 1);
+SAMPLER2D(s_tex2, 2);
+SAMPLER2D(s_tex3, 3);
+
+// ============================================================================
+// DX8 Texture Stage Combiner Operations
+// ============================================================================
+
+#define COMBOP_SELECTARG1   0
+#define COMBOP_SELECTARG2   1
+#define COMBOP_MODULATE     2
+#define COMBOP_ADD          3
+#define COMBOP_ADDSIGNED    4
+#define COMBOP_SUBTRACT     5
+#define COMBOP_BLEND        6
+#define COMBOP_DOTPRODUCT3  7
+
+#define TEXARG_TEXTURE      0
+#define TEXARG_CURRENT      1
+#define TEXARG_CONSTANT     2
+#define TEXARG_DIFFUSE      3
+#define TEXARG_SPECULAR     4
+#define TEXARG_TFACTOR      5
+
+vec4 GetTextureArg(int argType, vec4 texel, vec4 current, vec4 constant, vec4 vertexColor, vec4 vertexColor1, vec4 tFactor)
+{
+    if (argType == TEXARG_TEXTURE)  return texel;
+    if (argType == TEXARG_CURRENT)  return current;
+    if (argType == TEXARG_CONSTANT) return constant;
+    if (argType == TEXARG_DIFFUSE)  return vertexColor;
+    if (argType == TEXARG_SPECULAR) return vertexColor1;
+    if (argType == TEXARG_TFACTOR)  return tFactor;
+    return vec4_splat(1.0);
+}
+
+// Single combiner operation (combines two args)
+vec4 CombinerOp(int op, vec4 arg1, vec4 arg2, vec4 alphaArg1, vec4 alphaArg2)
+{
+    vec4 result;
+
+    if (op == COMBOP_SELECTARG1)
+    {
+        result = arg1;
+    }
+    else if (op == COMBOP_SELECTARG2)
+    {
+        result = arg2;
+    }
+    else if (op == COMBOP_MODULATE)
+    {
+        result = arg1 * arg2;
+    }
+    else if (op == COMBOP_ADD)
+    {
+        result = arg1 + arg2;
+    }
+    else if (op == COMBOP_ADDSIGNED)
+    {
+        // (arg1 - 0.5) + (arg2 - 0.5) + 0.5 = arg1 + arg2 - 0.5
+        result = arg1 + arg2 - vec4_splat(0.5);
+    }
+    else if (op == COMBOP_SUBTRACT)
+    {
+        result = arg1 - arg2;
+    }
+    else if (op == COMBOP_BLEND)
+    {
+        // arg1 * (1 - arg2.a) + arg2 * arg2.a
+        result = arg1 * (1.0 - arg2.aaaa) + arg2 * arg2.aaaa;
+    }
+    else if (op == COMBOP_DOTPRODUCT3)
+    {
+        float d = dot(arg1.xyz, arg2.xyz);
+        result = vec4(vec3_splat(d), 1.0);
+    }
+    else
+    {
+        result = arg1;
+    }
+
+    return result;
+}
+
+// ============================================================================
+// Detail Map Operations
+// ============================================================================
+
+#define DETAIL_NONE       0
+#define DETAIL_SCALE      1
+#define DETAIL_SCALE2X    2
+#define DETAIL_SCALE2XADD 3
+#define DETAIL_ADD        4
+#define DETAIL_BLEND      5
+#define DETAIL_BLENDALPHA 6
+
+vec3 DetailColorOp(int op, vec3 baseColor, vec3 detailColor, float detailAlpha)
+{
+    if (op == DETAIL_NONE)
+    {
+        return baseColor;
+    }
+    else if (op == DETAIL_SCALE)
+    {
+        // baseColor * detailColor (scaled darkening)
+        return baseColor * detailColor;
+    }
+    else if (op == DETAIL_SCALE2X)
+    {
+        // 2 * baseColor * detailColor - baseColor (scaled to center)
+        return baseColor * detailColor * vec3_splat(2.0) - baseColor;
+    }
+    else if (op == DETAIL_SCALE2XADD)
+    {
+        // 2 * baseColor * detailColor - baseColor + detailColor
+        return baseColor * detailColor * vec3_splat(2.0) - baseColor + detailColor;
+    }
+    else if (op == DETAIL_ADD)
+    {
+        return baseColor + detailColor;
+    }
+    else if (op == DETAIL_BLEND)
+    {
+        return mix(baseColor, detailColor, detailAlpha);
+    }
+    else if (op == DETAIL_BLENDALPHA)
+    {
+        // Blend based on detail alpha, but also modulate by base alpha
+        return mix(baseColor, detailColor, detailAlpha * baseColor.r);
+    }
+
+    return baseColor;
+}
+
+float DetailAlphaOp(int op, float baseAlpha, float detailAlpha)
+{
+    if (op == DETAIL_NONE)
+    {
+        return baseAlpha;
+    }
+    else if (op == DETAIL_SCALE)
+    {
+        return baseAlpha * detailAlpha;
+    }
+    else if (op == DETAIL_SCALE2X)
+    {
+        return baseAlpha * detailAlpha * 2.0 - baseAlpha;
+    }
+    else if (op == DETAIL_SCALE2XADD)
+    {
+        return baseAlpha * detailAlpha * 2.0 - baseAlpha + detailAlpha;
+    }
+    else if (op == DETAIL_ADD)
+    {
+        return baseAlpha + detailAlpha;
+    }
+    else if (op == DETAIL_BLEND)
+    {
+        return mix(baseAlpha, detailAlpha, 0.5);
+    }
+    else if (op == DETAIL_BLENDALPHA)
+    {
+        return mix(baseAlpha, detailAlpha, baseAlpha);
+    }
+
+    return baseAlpha;
+}
+
+// ============================================================================
+// Lighting Calculation
+// ============================================================================
+
+vec3 CalculateLighting(vec3 worldPos, vec3 normal, vec3 diffuseColor, vec3 specularColor, float shininess)
+{
+    vec3 result = vec3_splat(0.0);
+
+    if (u_shaderFlags.z < 0.5)
+    {
+        // Lighting disabled, return diffuse color
+        return diffuseColor;
+    }
+
+    // Ambient term
+    vec3 ambient = u_ambientLight.xyz * diffuseColor;
+    result += ambient;
+
+    vec3 viewDir = normalize(u_camPos.xyz - worldPos);
+
+    for (int i = 0; i < 4; i++)
+    {
+        // Light enabled if diffuse alpha (w) > 0
+        if (u_lightDiffuse[i].w < 0.5) continue;
+
+        vec3 lightColor = u_lightDiffuse[i].xyz;
+        vec3 lightDir;
+        float attenuation = 1.0;
+        int lightType = int(u_lightDir[i].w + 0.5);
+
+        if (lightType == 2) // Point light
+        {
+            vec3 toLight = u_lightPos[i].xyz - worldPos;
+            float dist = length(toLight);
+            lightDir = normalize(toLight);
+            float range = u_lightPos[i].w;
+            if (dist > range) continue;
+            attenuation = 1.0 - (dist / range);
+            attenuation = max(attenuation, 0.0);
+            attenuation = pow(attenuation, 2.0);
+        }
+        else if (lightType == 3) // Spot light
+        {
+            vec3 toLight = u_lightPos[i].xyz - worldPos;
+            float dist = length(toLight);
+            lightDir = normalize(toLight);
+            float range = u_lightPos[i].w;
+            if (dist > range) continue;
+            attenuation = 1.0 - (dist / range);
+            attenuation = max(attenuation, 0.0);
+            attenuation = pow(attenuation, 2.0);
+        }
+        else // Directional (type 1) or default
+        {
+            lightDir = -normalize(u_lightDir[i].xyz);
+        }
+
+        // Diffuse
+        float NdotL = max(dot(normal, lightDir), 0.0);
+        vec3 diff = diffuseColor * lightColor * NdotL;
+
+        // Specular (Blinn-Phong)
+        vec3 halfDir = normalize(lightDir + viewDir);
+        float NdotH = max(dot(normal, halfDir), 0.0);
+        float specFactor = pow(NdotH, shininess);
+        vec3 spec = specularColor * lightColor * specFactor;
+
+        result += (diff + spec) * attenuation;
+    }
+
+    return result;
+}
+
+// ============================================================================
+// Fog Calculation
+// ============================================================================
+
+float CalculateFogFactor(float dist)
+{
+    if (u_shaderMode.y < 1.5) // FOG_NONE
+    {
+        return 1.0;
+    }
+    else if (u_shaderMode.y < 2.5) // FOG_LINEAR
+    {
+        float fogFactor = (u_fogParams.y - dist) / (u_fogParams.y - u_fogParams.x);
+        return clamp(fogFactor, 0.0, 1.0);
+    }
+    else if (u_shaderMode.y < 3.5) // FOG_EXP
+    {
+        float fogDensity = u_fogParams.z;
+        return exp(-dist * fogDensity);
+    }
+    else // FOG_EXP2
+    {
+        float fogDensity = u_fogParams.z;
+        float d = dist * fogDensity;
+        return exp(-(d * d));
+    }
+
+    return 1.0;
+}
+
+// ============================================================================
+// Main Fragment Shader
+// ============================================================================
+
+void main()
+{
+    // =========================================================================
+    // Stage 1: Texture Sampling & Detail Maps
+    // =========================================================================
+
+    vec4 texColor0 = vec4_splat(1.0);
+    vec4 texColor1 = vec4_splat(1.0);
+    vec4 texColor2 = vec4_splat(1.0);
+    vec4 texColor3 = vec4_splat(1.0);
+
+    // Sample textures based on texturing flag
+    if (u_shaderFlags.y > 0.5)
+    {
+        texColor0 = texture2D(s_tex0, v_texcoord0);
+    }
+
+    // Sample secondary texture (detail map, lightmap, etc.)
+    if (u_shaderFlags.y > 0.5)
+    {
+        texColor1 = texture2D(s_tex1, v_texcoord1);
+    }
+
+    // Sample third texture (only if texturing enabled)
+    if (u_shaderFlags.y > 0.5)
+    {
+        texColor2 = texture2D(s_tex2, v_texcoord2);
+        texColor3 = texture2D(s_tex3, v_texcoord3);
+    }
+
+    // =========================================================================
+    // Stage 2: Apply Detail Maps (color and alpha)
+    // =========================================================================
+
+    vec3 baseColor = texColor0.rgb;
+    float baseAlpha = texColor0.a;
+
+    int detailColorMode = int(u_detailFunc.x + 0.5);
+    int detailAlphaMode = int(u_detailFunc.y + 0.5);
+
+    baseColor = DetailColorOp(detailColorMode, baseColor, texColor1.rgb, texColor1.a);
+    baseAlpha = DetailAlphaOp(detailAlphaMode, baseAlpha, texColor1.a);
+
+    // =========================================================================
+    // Stage 3: DX8 Texture Combiner (texture * vertex color)
+    // =========================================================================
+
+    // Simple modulate: texColor0 * v_color0
+    vec4 combinedColor = texColor0 * v_color0;
+
+    // Use vertex color alpha
+    combinedColor.a = texColor0.a * v_color0.a;
+
+    // =========================================================================
+    // Stage 4: Apply Material Colors
+    // =========================================================================
+
+    vec4 diffuse = combinedColor * u_diffuseColor;
+
+    // Override alpha with computed value
+    diffuse.a = combinedColor.a * u_opacity.x;
+
+    // =========================================================================
+    // Stage 5: Alpha Test
+    // =========================================================================
+
+    if (u_shaderFlags.x > 0.5) // Alpha test enabled
+    {
+        if (diffuse.a < u_shaderFlags.w)
+        {
+            discard;
+        }
+    }
+
+    // =========================================================================
+    // Stage 6: Lighting
+    // =========================================================================
+
+    vec3 normal = normalize(v_normal);
+    vec3 litColor = CalculateLighting(v_worldPos, normal, diffuse.rgb, u_specularColor.rgb, u_shininess.x);
+
+    // =========================================================================
+    // Stage 7: Primary Gradient
+    // =========================================================================
+
+    int priGradMode = int(u_shaderMode.z + 0.5);
+
+    if (priGradMode == PRIGRAD_NONE)
+    {
+        // Keep litColor as is
+    }
+    else if (priGradMode == PRIGRAD_MOD)
+    {
+        // Modulate: litColor * diffuseColor
+        litColor *= u_diffuseColor.rgb;
+    }
+    else if (priGradMode == PRIGRAD_ADD)
+    {
+        // Add: litColor + diffuseColor
+        litColor += u_diffuseColor.rgb;
+    }
+
+    // =========================================================================
+    // Stage 8: Emissive
+    // =========================================================================
+
+    litColor += u_emissiveColor.rgb;
+
+    // =========================================================================
+    // Stage 9: Secondary Gradient (Specular Add)
+    // =========================================================================
+
+    int secGradMode = int(u_shaderMode.w + 0.5);
+
+    if (secGradMode == SECGRAD_ADD)
+    {
+        litColor += u_specularColor.rgb;
+    }
+
+    // =========================================================================
+    // Stage 10: Fog
+    // =========================================================================
+
+    vec3 finalColor = litColor;
+    float fogFactor = CalculateFogFactor(length(u_camPos.xyz - v_worldPos));
+    finalColor = mix(u_fogColor.rgb, finalColor, fogFactor);
+
+    // =========================================================================
+    // Stage 11: Output
+    // =========================================================================
+
+    float alpha = diffuse.a;
+
+    gl_FragColor = vec4(finalColor, alpha);
+}

--- a/Code/ww3d2/backends/bgfx/shaders/source/vs_mesh.sc
+++ b/Code/ww3d2/backends/bgfx/shaders/source/vs_mesh.sc
@@ -1,0 +1,20 @@
+$input a_position, a_normal, a_texcoord0, a_color0
+$output v_texcoord0, v_color0, v_normal, v_worldPos
+
+#include <bgfx_shader.sh>
+
+uniform vec4 u_lightingEnable;
+
+void main()
+{
+    vec3 worldPos = mul(u_model[0], vec4(a_position, 1.0)).xyz;
+    v_worldPos = worldPos;
+
+    vec3 worldNormal = normalize(mul(u_model[0], vec4(a_normal, 0.0)).xyz);
+    v_normal = worldNormal;
+
+    v_texcoord0 = a_texcoord0;
+    v_color0 = a_color0;
+
+    gl_Position = mul(u_viewProj, vec4(worldPos, 1.0));
+}

--- a/Code/ww3d2/backends/bgfx/shaders/source/vs_uber.sc
+++ b/Code/ww3d2/backends/bgfx/shaders/source/vs_uber.sc
@@ -1,0 +1,47 @@
+$input a_position, a_normal, a_texcoord0, a_color0
+$input a_texcoord1, a_texcoord2, a_texcoord3, a_color1
+$output v_texcoord0, v_texcoord1, v_texcoord2, v_texcoord3
+$output v_color0, v_color1, v_normal, v_worldPos
+
+#include <bgfx_shader.sh>
+
+// Custom uniforms (avoid names defined in bgfx_shader.sh)
+uniform vec4 u_uberModel[4];
+uniform vec4 u_uberViewProj[4];
+uniform vec4 u_uberCamPos;
+uniform vec4 u_uberLightingEnable;
+
+void main()
+{
+    vec4 pos = vec4(a_position, 1.0);
+    vec4 worldPos = vec4(
+        dot(u_uberModel[0], pos),
+        dot(u_uberModel[1], pos),
+        dot(u_uberModel[2], pos),
+        dot(u_uberModel[3], pos)
+    );
+    v_worldPos = worldPos.xyz;
+
+    vec4 normal = vec4(a_normal, 0.0);
+    v_normal = vec3(
+        dot(u_uberModel[0], normal),
+        dot(u_uberModel[1], normal),
+        dot(u_uberModel[2], normal)
+    );
+
+    v_texcoord0 = a_texcoord0;
+    v_texcoord1 = a_texcoord1;
+    v_texcoord2 = a_texcoord2;
+    v_texcoord3 = a_texcoord3;
+
+    v_color0 = a_color0;
+    v_color1 = a_color1;
+
+    vec4 viewProjPos = vec4(
+        dot(u_uberViewProj[0], worldPos),
+        dot(u_uberViewProj[1], worldPos),
+        dot(u_uberViewProj[2], worldPos),
+        dot(u_uberViewProj[3], worldPos)
+    );
+    gl_Position = viewProjPos;
+}

--- a/Code/ww3d2/backends/bgfx/shaders/varying.def.sc
+++ b/Code/ww3d2/backends/bgfx/shaders/varying.def.sc
@@ -1,0 +1,17 @@
+vec3 a_position    : POSITION;
+vec3 a_normal      : NORMAL;
+vec2 a_texcoord0   : TEXCOORD0;
+vec2 a_texcoord1   : TEXCOORD1;
+vec2 a_texcoord2   : TEXCOORD2;
+vec2 a_texcoord3   : TEXCOORD3;
+vec4 a_color0      : COLOR0;
+vec4 a_color1      : COLOR1;
+
+vec2 v_texcoord0   : TEXCOORD0;
+vec2 v_texcoord1   : TEXCOORD1;
+vec2 v_texcoord2   : TEXCOORD2;
+vec2 v_texcoord3   : TEXCOORD3;
+vec4 v_color0      : COLOR0;
+vec4 v_color1      : COLOR1;
+vec3 v_normal      : NORMAL;
+vec3 v_worldPos    : TEXCOORD4;

--- a/Code/ww3d2/dx8backend.cpp
+++ b/Code/ww3d2/dx8backend.cpp
@@ -1,0 +1,205 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * DX8Backend implementation.                                                                  *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#include "dx8backend.h"
+#include "dx8wrapper.h"
+
+DX8Backend::DX8Backend()
+{
+}
+
+DX8Backend::~DX8Backend()
+{
+}
+
+bool DX8Backend::Init(void * hwnd, bool lite)
+{
+    return DX8Wrapper::Init(hwnd, lite);
+}
+
+void DX8Backend::Shutdown()
+{
+    DX8Wrapper::Shutdown();
+}
+
+bool DX8Backend::Set_Any_Render_Device()
+{
+    return DX8Wrapper::Set_Any_Render_Device();
+}
+
+bool DX8Backend::Set_Render_Device(const char * dev_name, int width, int height, int bits, int windowed, bool resize_window)
+{
+    return DX8Wrapper::Set_Render_Device(dev_name, width, height, bits, windowed, resize_window);
+}
+
+bool DX8Backend::Set_Render_Device(int dev, int resx, int resy, int bits, int windowed, bool resize_window)
+{
+    return DX8Wrapper::Set_Render_Device(dev, resx, resy, bits, windowed, resize_window);
+}
+
+bool DX8Backend::Set_Next_Render_Device()
+{
+    return DX8Wrapper::Set_Next_Render_Device();
+}
+
+bool DX8Backend::Toggle_Windowed()
+{
+    return DX8Wrapper::Toggle_Windowed();
+}
+
+bool DX8Backend::Is_Windowed()
+{
+    return DX8Wrapper::Is_Windowed();
+}
+
+int DX8Backend::Get_Render_Device_Count()
+{
+    return DX8Wrapper::Get_Render_Device_Count();
+}
+
+int DX8Backend::Get_Render_Device()
+{
+    return DX8Wrapper::Get_Render_Device();
+}
+
+const RenderDeviceDescClass & DX8Backend::Get_Render_Device_Desc(int deviceidx)
+{
+    return DX8Wrapper::Get_Render_Device_Desc(deviceidx);
+}
+
+const char * DX8Backend::Get_Render_Device_Name(int device_index)
+{
+    return DX8Wrapper::Get_Render_Device_Name(device_index);
+}
+
+bool DX8Backend::Set_Device_Resolution(int width, int height, int bits, int windowed, bool resize_window)
+{
+    return DX8Wrapper::Set_Device_Resolution(width, height, bits, windowed, resize_window);
+}
+
+void DX8Backend::Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    DX8Wrapper::Get_Device_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+void DX8Backend::Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+    DX8Wrapper::Get_Render_Target_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+int DX8Backend::Get_Device_Resolution_Width()
+{
+    return DX8Wrapper::Get_Device_Resolution_Width();
+}
+
+int DX8Backend::Get_Device_Resolution_Height()
+{
+    return DX8Wrapper::Get_Device_Resolution_Height();
+}
+
+bool DX8Backend::Registry_Save_Render_Device(const char * sub_key)
+{
+    return DX8Wrapper::Registry_Save_Render_Device(sub_key);
+}
+
+bool DX8Backend::Registry_Load_Render_Device(const char * sub_key, bool resize_window)
+{
+    return DX8Wrapper::Registry_Load_Render_Device(sub_key, resize_window);
+}
+
+bool DX8Backend::Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth)
+{
+    return DX8Wrapper::Registry_Save_Render_Device(sub_key, device, width, height, depth, windowed, texture_depth);
+}
+
+bool DX8Backend::Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth)
+{
+    return DX8Wrapper::Registry_Load_Render_Device(sub_key, device, device_len, width, height, depth, windowed, texture_depth);
+}
+
+void DX8Backend::Begin_Scene()
+{
+    DX8Wrapper::Begin_Scene();
+}
+
+void DX8Backend::End_Scene(bool flip_frame)
+{
+    DX8Wrapper::End_Scene(flip_frame);
+}
+
+void DX8Backend::Flip_To_Primary()
+{
+    DX8Wrapper::Flip_To_Primary();
+}
+
+void DX8Backend::Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z, unsigned int stencil)
+{
+    DX8Wrapper::Clear(clear_color, clear_z_stencil, color, z, stencil);
+}
+
+void DX8Backend::Set_Swap_Interval(int swap)
+{
+    DX8Wrapper::Set_Swap_Interval(swap);
+}
+
+int DX8Backend::Get_Swap_Interval()
+{
+    return DX8Wrapper::Get_Swap_Interval();
+}
+
+void DX8Backend::Set_Texture_Bitdepth(int depth)
+{
+    DX8Wrapper::Set_Texture_Bitdepth(depth);
+}
+
+int DX8Backend::Get_Texture_Bitdepth()
+{
+    return DX8Wrapper::Get_Texture_Bitdepth();
+}
+
+void DX8Backend::Set_Viewport(const void* viewport)
+{
+    DX8Wrapper::Set_Viewport(viewport);
+}
+
+void DX8Backend::Set_DX8_Render_State(int state, unsigned value)
+{
+    DX8Wrapper::Set_DX8_Render_State(state, value);
+}
+
+void DX8Backend::Set_Light_Environment(const void* env)
+{
+    DX8Wrapper::Set_Light_Environment(env);
+}
+
+void* DX8Backend::_Get_DX8_Front_Buffer()
+{
+    return DX8Wrapper::_Get_DX8_Front_Buffer();
+}

--- a/Code/ww3d2/dx8backend.h
+++ b/Code/ww3d2/dx8backend.h
@@ -1,0 +1,91 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * DX8Backend - concrete WW3DBackend implementation wrapping DX8Wrapper static methods.         *
+ * DX8Wrapper stays standalone and does NOT inherit from WW3DBackend.                          *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef DX8BACKEND_H
+#define DX8BACKEND_H
+
+#include "ww3dbackend.h"
+
+// DX8Wrapper static methods are called directly from here.
+// No include of dx8wrapper.h at header level to keep D3D9 out of the ww3d2 include chain.
+class DX8Wrapper;
+
+class DX8Backend : public WW3DBackend
+{
+public:
+    DX8Backend();
+    virtual ~DX8Backend();
+
+    // WW3DBackend interface - delegate to DX8Wrapper static methods
+    virtual bool Init(void * hwnd, bool lite = false) override;
+    virtual void Shutdown() override;
+
+    virtual bool Set_Any_Render_Device() override;
+    virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual bool Set_Next_Render_Device() override;
+    virtual bool Toggle_Windowed() override;
+    virtual bool Is_Windowed() override;
+
+    virtual int Get_Render_Device_Count() override;
+    virtual int Get_Render_Device() override;
+    virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) override;
+    virtual const char * Get_Render_Device_Name(int device_index) override;
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+    virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+    virtual int Get_Device_Resolution_Width() override;
+    virtual int Get_Device_Resolution_Height() override;
+
+    virtual bool Registry_Save_Render_Device(const char * sub_key) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) override;
+    virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) override;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) override;
+
+    virtual void Begin_Scene() override;
+    virtual void End_Scene(bool flip_frame = true) override;
+    virtual void Flip_To_Primary() override;
+
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
+
+    virtual void Set_Swap_Interval(int swap) override;
+    virtual int Get_Swap_Interval() override;
+
+    virtual void Set_Texture_Bitdepth(int depth) override;
+    virtual int Get_Texture_Bitdepth() override;
+
+    virtual void Set_Viewport(const void* viewport) override;
+    virtual void Set_DX8_Render_State(int state, unsigned value) override;
+    virtual void Set_Light_Environment(const void* env) override;
+    virtual void* _Get_DX8_Front_Buffer() override;
+};
+
+#endif // DX8BACKEND_H

--- a/Code/ww3d2/dx8indexbuffer.cpp
+++ b/Code/ww3d2/dx8indexbuffer.cpp
@@ -44,6 +44,8 @@
 #include "sphere.h"
 #include "thread.h"
 #include "wwmemlog.h"
+#include "ww3d.h"
+#include "ww3dbackend.h"
 
 #define DEFAULT_IB_SIZE 5000
 
@@ -90,6 +92,10 @@ IndexBufferClass::IndexBufferClass(unsigned type_, unsigned short index_count_)
 
 IndexBufferClass::~IndexBufferClass()
 {
+	if (WW3D::Get_Backend()) {
+		WW3D::Get_Backend()->Invalidate_Index_Buffer_Cache_Entry(this);
+	}
+
 	_IndexBufferCount--;
 	_IndexBufferTotalIndices-=index_count;
 	_IndexBufferTotalSize-=index_count*sizeof(unsigned short);

--- a/Code/ww3d2/dx8texman.cpp
+++ b/Code/ww3d2/dx8texman.cpp
@@ -50,6 +50,8 @@
 // destructor
 
 #include "dx8texman.h"
+#include "ww3d.h"
+#include "ww3dbackend.h"
 
 DX8TextureTrackerList DX8TextureManagerClass::Managed_Textures;
 
@@ -158,12 +160,15 @@ void DX8TextureManagerClass::Release_Textures()
 	{
 		DX8TextureTrackerClass *track=it.Peek_Obj();
 		WWASSERT(track->Texture->D3DTexture);
+		if (WW3D::Get_Backend()) {
+			WW3D::Get_Backend()->Invalidate_Texture_Cache_Entry(track->Texture);
+		}
 		track->Texture->D3DTexture->Release();
 		track->Texture->D3DTexture=NULL;
+		track->Texture->Initialized=false;
 		it.Next();
 	}
 }
-
 
 /***********************************************************************************************
  * DX8TextureManagerClass::Recreate_Textures -- Reallocates lost textures                      *

--- a/Code/ww3d2/dx8vertexbuffer.cpp
+++ b/Code/ww3d2/dx8vertexbuffer.cpp
@@ -45,6 +45,8 @@
 #include "thread.h"
 #include "wwmemlog.h"
 #include <d3dx9core.h>
+#include "ww3d.h"
+#include "ww3dbackend.h"
 
 #define DEFAULT_VB_SIZE 5000
 
@@ -100,6 +102,10 @@ VertexBufferClass::VertexBufferClass(unsigned type_, unsigned FVF, unsigned shor
 
 VertexBufferClass::~VertexBufferClass()
 {
+	if (WW3D::Get_Backend()) {
+		WW3D::Get_Backend()->Invalidate_Vertex_Buffer_Cache_Entry(this);
+	}
+
 	_VertexBufferCount--;
 	_VertexBufferTotalVertices-=VertexCount;
 	_VertexBufferTotalSize-=VertexCount*fvf_info->Get_FVF_Size();

--- a/Code/ww3d2/dx8wrapper.cpp
+++ b/Code/ww3d2/dx8wrapper.cpp
@@ -47,6 +47,7 @@
 #include "dx8indexbuffer.h"
 #include "dx8renderer.h"
 #include "ww3d.h"
+#include "ww3dbackend.h"
 #include "camera.h"
 #include "wwstring.h"
 #include "matrix4.h"
@@ -795,24 +796,24 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 
 		WWDEBUG_SAY(("Using buffer format: %d\r\n",_PresentParameters.BackBufferFormat));
 
-		/*
-		** Find an appropriate Z buffer
-		*/
-		if (!Find_Z_Mode(_PresentParameters.BackBufferFormat,_PresentParameters.BackBufferFormat,&_PresentParameters.AutoDepthStencilFormat))
-		{
-			// If opening 32 bit mode failed, try 16 bit, even if the desktop happens to be 32 bit
-			if (BitDepth==32) {
-				WWDEBUG_SAY(("Failed to find a 32 bit mode, trying 16 bit\r\n"));
-				BitDepth=16;
-				_PresentParameters.BackBufferFormat=D3DFMT_R5G6B5;
-				if (!Find_Z_Mode(_PresentParameters.BackBufferFormat,_PresentParameters.BackBufferFormat,&_PresentParameters.AutoDepthStencilFormat)) {
-					_PresentParameters.AutoDepthStencilFormat=D3DFMT_UNKNOWN;
-				}
-			}
-			else {
+	/*
+	** Find an appropriate Z buffer
+	*/
+	if (!Find_Z_Mode(_PresentParameters.BackBufferFormat,_PresentParameters.BackBufferFormat,&_PresentParameters.AutoDepthStencilFormat))
+	{
+		// If opening 32 bit mode failed, try 16 bit, even if the desktop happens to be 32 bit
+		if (BitDepth==32) {
+			WWDEBUG_SAY(("Failed to find a 32 bit mode, trying 16 bit\r\n"));
+			BitDepth=16;
+			_PresentParameters.BackBufferFormat=D3DFMT_R5G6B5;
+			if (!Find_Z_Mode(_PresentParameters.BackBufferFormat,_PresentParameters.BackBufferFormat,&_PresentParameters.AutoDepthStencilFormat)) {
 				_PresentParameters.AutoDepthStencilFormat=D3DFMT_UNKNOWN;
 			}
 		}
+		else {
+			_PresentParameters.AutoDepthStencilFormat=D3DFMT_UNKNOWN;
+		}
+	}
 
 	} else {
 
@@ -1019,21 +1020,26 @@ const char * DX8Wrapper::Get_Render_Device_Name(int device_index)
 	return _RenderDeviceShortNameTable[device_index];
 }
 
-bool DX8Wrapper::Set_Device_Resolution(int width,int height,int /*bits*/,int /*windowed*/, bool /*resize_window*/)
+bool DX8Wrapper::Set_Device_Resolution(int width,int height,int bits,int windowed, bool resize_window)
 {
-	if (D3DDevice != NULL) {
-
-		if (width != -1) {
-			_PresentParameters.BackBufferWidth = ResolutionWidth = width;
-		}
-		if (height != -1) {
-			_PresentParameters.BackBufferHeight = ResolutionHeight = height;
-		}
-// FIXME TODO: support changing windowed status and changing the bit depth
-		return Reset_Device();
-	} else {
-		return false;
+	// If device hasn't been created yet, do full device setup
+	if (D3DDevice == NULL) {
+		// Use provided resolution (or defaults), force windowed for safety
+		int w = (width != -1) ? width : ResolutionWidth;
+		int h = (height != -1) ? height : ResolutionHeight;
+		int b = (bits != -1) ? bits : BitDepth;
+		int win = (windowed != -1) ? windowed : 1; // default to windowed
+		return Set_Render_Device(-1, w, h, b, win, resize_window);
 	}
+
+	if (width != -1) {
+		_PresentParameters.BackBufferWidth = ResolutionWidth = width;
+	}
+	if (height != -1) {
+		_PresentParameters.BackBufferHeight = ResolutionHeight = height;
+	}
+// FIXME TODO: support changing windowed status and changing the bit depth
+	return Reset_Device();
 }
 
 void DX8Wrapper::Get_Device_Resolution(int & set_w,int & set_h,int & set_bits,bool & set_windowed)
@@ -1720,17 +1726,6 @@ void DX8Wrapper::Draw_Sorting_IB_VB(
 		}
 	}
 
-	DX8CALL(SetStreamSource(
-		0,
-		static_cast<DX8VertexBufferClass*>(dyn_vb_access.VertexBuffer)->Get_DX8_Vertex_Buffer(),
-		0,
-		dyn_vb_access.FVF_Info().Get_FVF_Size()));
-	// Release the programmable shader
-	// DX8CALL(SetVertexShader(NULL));
-	// Set the fixed-function vertex format
-	DX8CALL(SetFVF(dyn_vb_access.FVF_Info().Get_FVF()));
-	DX8_RECORD_VERTEX_BUFFER_CHANGE();
-
 	unsigned index_count=0;
 	switch (primitive_type) {
 	case D3DPT_TRIANGLELIST: index_count=polygon_count*3; break;
@@ -1755,6 +1750,30 @@ void DX8Wrapper::Draw_Sorting_IB_VB(
 			*dest++=index;
 		}
 	}
+
+	// Backend dispatch for non-DX8 rendering
+	if (WW3D::Get_Backend() && WW3D::Get_Backend()->Wants_Deferred_State_Apply()) {
+		// Set dynamic buffers on backend and draw
+		WW3D::Get_Backend()->Set_Vertex_Buffer(dyn_vb_access.VertexBuffer);
+		WW3D::Get_Backend()->Set_Index_Buffer(dyn_ib_access.IndexBuffer, 0);
+		if (primitive_type == D3DPT_TRIANGLELIST) {
+			WW3D::Get_Backend()->Draw_Indexed_Triangles(dyn_ib_access.IndexBufferOffset, polygon_count, 0, vertex_count);
+		} else if (primitive_type == D3DPT_TRIANGLESTRIP) {
+			WW3D::Get_Backend()->Draw_Indexed_Strip(dyn_ib_access.IndexBufferOffset, polygon_count + 2, 0, vertex_count);
+		} else {
+			WWDEBUG_SAY(("Draw_Sorting_IB_VB: unsupported primitive type %d for BGFX backend\n", primitive_type));
+		}
+		return;
+	}
+
+	// Original DX8 path
+	DX8CALL(SetStreamSource(
+		0,
+		static_cast<DX8VertexBufferClass*>(dyn_vb_access.VertexBuffer)->Get_DX8_Vertex_Buffer(),
+		0,
+		dyn_vb_access.FVF_Info().Get_FVF_Size()));
+	DX8CALL(SetFVF(dyn_vb_access.FVF_Info().Get_FVF()));
+	DX8_RECORD_VERTEX_BUFFER_CHANGE();
 
 	DX8CALL(SetIndices(
 		static_cast<DX8IndexBufferClass*>(dyn_ib_access.IndexBuffer)->Get_DX8_Index_Buffer()));
@@ -1789,6 +1808,32 @@ void DX8Wrapper::Draw(
 	SNAPSHOT_SAY(("DX8 - draw\n"));
 
 	Apply_Render_State_Changes();
+
+	// Backend dispatch for non-DX8 rendering
+	if (WW3D::Get_Backend() && WW3D::Get_Backend()->Wants_Deferred_State_Apply()) {
+		unsigned short actual_start = start_index + render_state.iba_offset;
+		unsigned short actual_count = vertex_count;
+		if (actual_count < 3) {
+			switch (render_state.vertex_buffer_type) {
+			case BUFFER_TYPE_DX8:
+			case BUFFER_TYPE_SORTING:
+				actual_count = render_state.vertex_buffer->Get_Vertex_Count() - render_state.index_base_offset - render_state.vba_offset - min_vertex_index;
+				break;
+			case BUFFER_TYPE_DYNAMIC_DX8:
+			case BUFFER_TYPE_DYNAMIC_SORTING:
+				actual_count = render_state.vba_count;
+				break;
+			}
+		}
+		if (primitive_type == D3DPT_TRIANGLELIST) {
+			WW3D::Get_Backend()->Draw_Indexed_Triangles(actual_start, polygon_count, min_vertex_index, actual_count);
+		} else if (primitive_type == D3DPT_TRIANGLESTRIP) {
+			WW3D::Get_Backend()->Draw_Indexed_Strip(actual_start, polygon_count + 2, min_vertex_index, actual_count);
+		} else {
+			WWDEBUG_SAY(("DX8Wrapper::Draw: unsupported primitive type %d for BGFX backend\n", primitive_type));
+		}
+		return;
+	}
 
 	// Debug feature to disable triangle drawing...
 	if (!_Is_Triangle_Draw_Enabled()) return;
@@ -1968,6 +2013,57 @@ void DX8Wrapper::Draw_Strip(
 void DX8Wrapper::Apply_Render_State_Changes()
 {
 	if (!render_state_changed) return;
+
+	// Backend dispatch path for non-DX8 backends (e.g. BGFX)
+	if (WW3D::Get_Backend() && WW3D::Get_Backend()->Wants_Deferred_State_Apply()) {
+		if (render_state_changed&SHADER_CHANGED) {
+			WW3D::Get_Backend()->Apply_Shader_State(render_state.shader);
+		}
+
+		unsigned mask=TEXTURE0_CHANGED;
+		for (unsigned i=0;i<MAX_TEXTURE_STAGES;++i,mask<<=1) {
+			if (render_state_changed&mask) {
+				WW3D::Get_Backend()->Apply_Texture_State(i, render_state.Textures[i]);
+			}
+		}
+
+		if (render_state_changed&MATERIAL_CHANGED) {
+			WW3D::Get_Backend()->Apply_Material_State(render_state.material);
+		}
+
+		if (render_state_changed&LIGHTS_CHANGED) {
+			unsigned mask=LIGHT0_CHANGED;
+			for (unsigned index=0;index<4;++index,mask<<=1) {
+				if (render_state_changed&mask) {
+					if (render_state.LightEnable[index]) {
+						WW3D::Get_Backend()->Set_DX8_Light(index, &render_state.Lights[index]);
+					}
+					else {
+						WW3D::Get_Backend()->Set_DX8_Light(index, nullptr);
+					}
+				}
+			}
+		}
+
+		if (render_state_changed&WORLD_CHANGED) {
+			WW3D::Get_Backend()->Set_Transform_World(render_state.world);
+		}
+		if (render_state_changed&VIEW_CHANGED) {
+			WW3D::Get_Backend()->Set_Transform_View(render_state.view);
+		}
+		if (render_state_changed&VERTEX_BUFFER_CHANGED) {
+			WW3D::Get_Backend()->Set_Vertex_Buffer(render_state.vertex_buffer);
+		}
+		if (render_state_changed&INDEX_BUFFER_CHANGED) {
+			WW3D::Get_Backend()->Set_Index_Buffer(render_state.index_buffer, render_state.index_base_offset);
+		}
+
+		WW3D::Get_Backend()->Commit_Render_State();
+		render_state_changed&=((unsigned)WORLD_IDENTITY|(unsigned)VIEW_IDENTITY);
+		return;
+	}
+
+	// Original DX8 path
 	if (render_state_changed&SHADER_CHANGED) {
 		SNAPSHOT_SAY(("DX8 - apply shader\n"));
 		render_state.shader.Apply();

--- a/Code/ww3d2/dx8wrapper.h
+++ b/Code/ww3d2/dx8wrapper.h
@@ -158,6 +158,8 @@ struct RenderStateStruct
 	RenderStateStruct& operator= (const RenderStateStruct& src);
 };
 
+class DX8Backend;
+
 /**
 ** DX8Wrapper
 **
@@ -567,6 +569,7 @@ protected:
 
 	friend void DX8_Assert();
 	friend class WW3D;
+	friend class DX8Backend;
 	friend class DX8IndexBufferClass;
 	friend class DX8VertexBufferClass;
 };

--- a/Code/ww3d2/nullbackend.cpp
+++ b/Code/ww3d2/nullbackend.cpp
@@ -1,0 +1,220 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "nullbackend.h"
+#include "rddesc.h"
+
+namespace
+{
+	const int DEFAULT_WIDTH = 640;
+	const int DEFAULT_HEIGHT = 480;
+	const int DEFAULT_BIT_DEPTH = 16;
+}
+
+NullBackend::NullBackend() :
+	Width(DEFAULT_WIDTH),
+	Height(DEFAULT_HEIGHT),
+	BitDepth(DEFAULT_BIT_DEPTH),
+	Windowed(true),
+	SwapInterval(0),
+	TextureBitDepth(DEFAULT_BIT_DEPTH)
+{
+}
+
+NullBackend::~NullBackend()
+{
+}
+
+bool NullBackend::Init(void * /*hwnd*/, bool /*lite*/)
+{
+	return true;
+}
+
+void NullBackend::Shutdown()
+{
+}
+
+bool NullBackend::Set_Any_Render_Device()
+{
+	return true;
+}
+
+bool NullBackend::Set_Render_Device(const char * /*dev_name*/, int width, int height, int bits, int windowed, bool /*resize_window*/)
+{
+	return Set_Device_Resolution(width, height, bits, windowed, false);
+}
+
+bool NullBackend::Set_Render_Device(int /*dev*/, int resx, int resy, int bits, int windowed, bool /*resize_window*/)
+{
+	return Set_Device_Resolution(resx, resy, bits, windowed, false);
+}
+
+bool NullBackend::Set_Next_Render_Device()
+{
+	return true;
+}
+
+bool NullBackend::Toggle_Windowed()
+{
+	Windowed = !Windowed;
+	return true;
+}
+
+bool NullBackend::Is_Windowed()
+{
+	return Windowed;
+}
+
+int NullBackend::Get_Render_Device_Count()
+{
+	return 1;
+}
+
+int NullBackend::Get_Render_Device()
+{
+	return 0;
+}
+
+const RenderDeviceDescClass & NullBackend::Get_Render_Device_Desc(int /*deviceidx*/)
+{
+	static RenderDeviceDescClass desc;
+	return desc;
+}
+
+const char * NullBackend::Get_Render_Device_Name(int /*device_index*/)
+{
+	return "Null Renderer";
+}
+
+bool NullBackend::Set_Device_Resolution(int width, int height, int bits, int windowed, bool /*resize_window*/)
+{
+	if (width > 0) {
+		Width = width;
+	}
+	if (height > 0) {
+		Height = height;
+	}
+	if (bits > 0) {
+		BitDepth = bits;
+	}
+	if (windowed != -1) {
+		Windowed = (windowed != 0);
+	}
+	return true;
+}
+
+void NullBackend::Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+	set_w = Width;
+	set_h = Height;
+	set_bits = BitDepth;
+	set_windowed = Windowed;
+}
+
+void NullBackend::Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed)
+{
+	Get_Device_Resolution(set_w, set_h, set_bits, set_windowed);
+}
+
+int NullBackend::Get_Device_Resolution_Width()
+{
+	return Width;
+}
+
+int NullBackend::Get_Device_Resolution_Height()
+{
+	return Height;
+}
+
+bool NullBackend::Registry_Save_Render_Device(const char * /*sub_key*/)
+{
+	return true;
+}
+
+bool NullBackend::Registry_Load_Render_Device(const char * /*sub_key*/, bool /*resize_window*/)
+{
+	return true;
+}
+
+bool NullBackend::Registry_Save_Render_Device(const char */*sub_key*/, int /*device*/, int /*width*/, int /*height*/, int /*depth*/, bool /*windowed*/, int /*texture_depth*/)
+{
+	return true;
+}
+
+bool NullBackend::Registry_Load_Render_Device(const char * /*sub_key*/, char */*device*/, int /*device_len*/, int &width, int &height, int &depth, int &windowed, int &texture_depth)
+{
+	width = Width;
+	height = Height;
+	depth = BitDepth;
+	windowed = Windowed ? 1 : 0;
+	texture_depth = TextureBitDepth;
+	return true;
+}
+
+void NullBackend::Begin_Scene()
+{
+}
+
+void NullBackend::End_Scene(bool /*flip_frame*/)
+{
+}
+
+void NullBackend::Flip_To_Primary()
+{
+}
+
+void NullBackend::Clear(bool /*clear_color*/, bool /*clear_z_stencil*/, const Vector3 &/*color*/, float /*z*/, unsigned int /*stencil*/)
+{
+}
+
+void NullBackend::Set_Swap_Interval(int swap)
+{
+	SwapInterval = swap;
+}
+
+int NullBackend::Get_Swap_Interval()
+{
+	return SwapInterval;
+}
+
+void NullBackend::Set_Texture_Bitdepth(int depth)
+{
+	TextureBitDepth = depth;
+}
+
+int NullBackend::Get_Texture_Bitdepth()
+{
+	return TextureBitDepth;
+}
+
+void NullBackend::Set_Viewport(const void* /*viewport*/)
+{
+}
+
+void NullBackend::Set_DX8_Render_State(int /*state*/, unsigned /*value*/)
+{
+}
+
+void NullBackend::Set_Light_Environment(const void* /*env*/)
+{
+}
+
+void* NullBackend::_Get_DX8_Front_Buffer()
+{
+	return nullptr;
+}

--- a/Code/ww3d2/nullbackend.h
+++ b/Code/ww3d2/nullbackend.h
@@ -1,0 +1,81 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NULLBACKEND_H
+#define NULLBACKEND_H
+
+#include "ww3dbackend.h"
+
+class NullBackend : public WW3DBackend
+{
+public:
+	NullBackend();
+	virtual ~NullBackend();
+
+	virtual bool Init(void * hwnd, bool lite = false) override;
+	virtual void Shutdown() override;
+
+	virtual bool Set_Any_Render_Device() override;
+	virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+	virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+	virtual bool Set_Next_Render_Device() override;
+	virtual bool Toggle_Windowed() override;
+	virtual bool Is_Windowed() override;
+
+	virtual int Get_Render_Device_Count() override;
+	virtual int Get_Render_Device() override;
+	virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) override;
+	virtual const char * Get_Render_Device_Name(int device_index) override;
+	virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) override;
+	virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+	virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) override;
+	virtual int Get_Device_Resolution_Width() override;
+	virtual int Get_Device_Resolution_Height() override;
+
+	virtual bool Registry_Save_Render_Device(const char * sub_key) override;
+	virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) override;
+	virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) override;
+	virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) override;
+
+	virtual void Begin_Scene() override;
+	virtual void End_Scene(bool flip_frame = true) override;
+	virtual void Flip_To_Primary() override;
+
+	virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) override;
+
+	virtual void Set_Viewport(const void* viewport) override;
+	virtual void Set_DX8_Render_State(int state, unsigned value) override;
+	virtual void Set_Light_Environment(const void* env) override;
+	virtual void* _Get_DX8_Front_Buffer() override;
+
+	virtual void Set_Swap_Interval(int swap) override;
+	virtual int Get_Swap_Interval() override;
+
+	virtual void Set_Texture_Bitdepth(int depth) override;
+	virtual int Get_Texture_Bitdepth() override;
+
+private:
+	int Width;
+	int Height;
+	int BitDepth;
+	bool Windowed;
+	int SwapInterval;
+	int TextureBitDepth;
+};
+
+#endif // NULLBACKEND_H

--- a/Code/ww3d2/texture.cpp
+++ b/Code/ww3d2/texture.cpp
@@ -53,6 +53,8 @@
 #include "dx8texman.h"
 #include "meshmatdesc.h"
 #include "texturethumbnail.h"
+#include "ww3d.h"
+#include "ww3dbackend.h"
 
 const unsigned DEFAULT_INACTIVATION_TIME=20000;
 
@@ -422,6 +424,9 @@ TextureClass::~TextureClass(void)
 	ThumbnailLoadTask=NULL;
 
 	if (D3DTexture) {
+		if (WW3D::Get_Backend()) {
+			WW3D::Get_Backend()->Invalidate_Texture_Cache_Entry(this);
+		}
 		D3DTexture->Release();
 		D3DTexture = NULL;
 	}
@@ -511,6 +516,9 @@ void TextureClass::Invalidate()
 	}
 
 	if (D3DTexture) {
+		if (WW3D::Get_Backend()) {
+			WW3D::Get_Backend()->Invalidate_Texture_Cache_Entry(this);
+		}
 		D3DTexture->Release();
 		D3DTexture = NULL;
 	}
@@ -524,7 +532,12 @@ void TextureClass::Invalidate()
 
 void TextureClass::Load_Locked_Surface()
 {
-	if (D3DTexture) D3DTexture->Release();
+	if (D3DTexture) {
+		if (WW3D::Get_Backend()) {
+			WW3D::Get_Backend()->Invalidate_Texture_Cache_Entry(this);
+		}
+		D3DTexture->Release();
+	}
 	D3DTexture=0;
 	TextureLoader::Request_Thumbnail(this);
 	Initialized=false;

--- a/Code/ww3d2/ww3d.cpp
+++ b/Code/ww3d2/ww3d.cpp
@@ -78,6 +78,9 @@
 
 
 #include "ww3d.h"
+#include "ww3dbackend.h"
+#include "dx8backend.h"
+#include "nullbackend.h"
 #include "rinfo.h"
 #include "assetmgr.h"
 #include "boxrobj.h"
@@ -220,6 +223,7 @@ int														WW3D::LastFrameMemoryFrees;
 int														WW3D::TextureFilter;
 
 bool														WW3D::Lite = false;
+WW3DBackend *												WW3D::Backend = NULL;
 
 /**********************************************************************************
 **
@@ -264,11 +268,23 @@ WW3DErrorType WW3D::Init(void *hwnd, char * /*defaultpal*/, bool lite)
 	Lite = lite;
 
 	/*
+	** Backend selection
+	*/
+	if (!Backend) {
+		// Default to DX8 backend on Windows, null backend elsewhere
+		#if defined(_WIN32) || defined(WIN32)
+			Backend = new DX8Backend();
+		#else
+			Backend = new NullBackend();
+		#endif
+	}
+
+	/*
 	** Initialize d3d, this also enumerates the available devices and resolutions.
 	*/
 	Init_D3D_To_WW3_Conversion();
-	WWDEBUG_SAY(("Init DX8Wrapper\n"));
-	if (!DX8Wrapper::Init(_Hwnd, lite)) {
+	WWDEBUG_SAY(("Init Backend\n"));
+	if (!Backend->Init(_Hwnd, lite)) {
 		return(WW3D_ERROR_DIRECTX8_INITIALIZATION_FAILED);
 	}
 	WWDEBUG_SAY(("Allocate Debug Resources\n"));
@@ -320,6 +336,14 @@ WW3DErrorType WW3D::Init(void *hwnd, char * /*defaultpal*/, bool lite)
  * HISTORY:                                                                                    *
  *   3/24/98    GTH : Created.                                                                 *
  *=============================================================================================*/
+/***********************************************************************************************
+ * WW3D::Set_Backend -- set the active render backend                                          *
+ *=============================================================================================*/
+void WW3D::Set_Backend(WW3DBackend* backend)
+{
+	Backend = backend;
+}
+
 WW3DErrorType WW3D::Shutdown(void)
 {
 	assert(Lite || IsInitted == true);
@@ -353,7 +377,11 @@ WW3DErrorType WW3D::Shutdown(void)
 
 	DX8TextureManagerClass::Shutdown();
 	if (!Lite) {
-		DX8Wrapper::Shutdown();
+		if (Backend) {
+			Backend->Shutdown();
+			delete Backend;
+			Backend = NULL;
+		}
 	}
 
 	/*
@@ -385,7 +413,7 @@ WW3DErrorType WW3D::Shutdown(void)
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Render_Device( const char * dev_name, int width, int height, int bits, int windowed, bool resize_window )
 {
-	bool success = DX8Wrapper::Set_Render_Device(dev_name,width,height,bits,windowed,resize_window);
+	bool success = Backend->Set_Render_Device(dev_name,width,height,bits,windowed,resize_window);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -408,7 +436,7 @@ WW3DErrorType WW3D::Set_Render_Device( const char * dev_name, int width, int hei
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Any_Render_Device( void )
 {
-	bool success = DX8Wrapper::Set_Any_Render_Device();
+	bool success = Backend->Set_Any_Render_Device();
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -431,7 +459,7 @@ WW3DErrorType WW3D::Set_Any_Render_Device( void )
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Render_Device(int dev, int width, int height, int bits, int windowed, bool resize_window)
 {
-	bool success = DX8Wrapper::Set_Render_Device(dev,width,height,bits,windowed,resize_window);
+	bool success = Backend->Set_Render_Device(dev,width,height,bits,windowed,resize_window);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -454,7 +482,7 @@ WW3DErrorType WW3D::Set_Render_Device(int dev, int width, int height, int bits, 
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Next_Render_Device(void)
 {
-	bool success = DX8Wrapper::Set_Next_Render_Device();
+	bool success = Backend->Set_Next_Render_Device();
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -493,7 +521,7 @@ void *WW3D::Get_Window( void )
  *=============================================================================================*/
 bool WW3D::Is_Windowed( void )
 {
-	return DX8Wrapper::Is_Windowed();
+	return Backend->Is_Windowed();
 }
 
 /***********************************************************************************************
@@ -513,7 +541,7 @@ bool WW3D::Is_Windowed( void )
  *=============================================================================================*/
 WW3DErrorType WW3D::Toggle_Windowed (void)
 {
-	bool success = DX8Wrapper::Toggle_Windowed();
+	bool success = Backend->Toggle_Windowed();
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -537,7 +565,7 @@ WW3DErrorType WW3D::Toggle_Windowed (void)
  *=============================================================================================*/
 int WW3D::Get_Render_Device(void)
 {
-	return DX8Wrapper::Get_Render_Device();
+	return Backend->Get_Render_Device();
 }
 
 
@@ -556,7 +584,7 @@ int WW3D::Get_Render_Device(void)
  *=============================================================================================*/
 const RenderDeviceDescClass & WW3D::Get_Render_Device_Desc(int deviceidx)
 {
-	return DX8Wrapper::Get_Render_Device_Desc(deviceidx);
+	return Backend->Get_Render_Device_Desc(deviceidx);
 }
 
 
@@ -576,7 +604,7 @@ const RenderDeviceDescClass & WW3D::Get_Render_Device_Desc(int deviceidx)
  *=============================================================================================*/
 const int WW3D::Get_Render_Device_Count(void)
 {
-	return DX8Wrapper::Get_Render_Device_Count();
+	return Backend->Get_Render_Device_Count();
 }
 
 
@@ -595,7 +623,7 @@ const int WW3D::Get_Render_Device_Count(void)
  *=============================================================================================*/
 const char * WW3D::Get_Render_Device_Name(int device_index)
 {
-	return DX8Wrapper::Get_Render_Device_Name(device_index);
+	return Backend->Get_Render_Device_Name(device_index);
 }
 
 
@@ -613,7 +641,7 @@ const char * WW3D::Get_Render_Device_Name(int device_index)
  *=============================================================================================*/
 WW3DErrorType WW3D::Set_Device_Resolution(int width,int height,int bits,int windowed, bool resize_window)
 {
-	bool success = DX8Wrapper::Set_Device_Resolution(width,height,bits,windowed,resize_window);
+	bool success = Backend->Set_Device_Resolution(width,height,bits,windowed,resize_window);
 
 	if (success) {
 		return WW3D_ERROR_OK;
@@ -638,7 +666,7 @@ WW3DErrorType WW3D::Set_Device_Resolution(int width,int height,int bits,int wind
  *=============================================================================================*/
 void WW3D::Get_Render_Target_Resolution(int & set_w,int & set_h,int & set_bits,bool & set_windowed)
 {
-	DX8Wrapper::Get_Render_Target_Resolution(set_w,set_h,set_bits,set_windowed);
+	Backend->Get_Render_Target_Resolution(set_w,set_h,set_bits,set_windowed);
 }
 
 
@@ -657,7 +685,7 @@ void WW3D::Get_Render_Target_Resolution(int & set_w,int & set_h,int & set_bits,b
  *=============================================================================================*/
 void WW3D::Get_Device_Resolution(int & set_w,int & set_h,int & set_bits,bool & set_windowed)
 {
-	DX8Wrapper::Get_Device_Resolution(set_w,set_h,set_bits,set_windowed);
+	Backend->Get_Device_Resolution(set_w,set_h,set_bits,set_windowed);
 }
 
 
@@ -676,7 +704,7 @@ void WW3D::Get_Device_Resolution(int & set_w,int & set_h,int & set_bits,bool & s
  *=============================================================================================*/
 WW3DErrorType WW3D::Registry_Save_Render_Device( const char * sub_key )
 {
-	bool success = DX8Wrapper::Registry_Save_Render_Device(sub_key);
+	bool success = Backend->Registry_Save_Render_Device(sub_key);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -698,7 +726,7 @@ WW3DErrorType WW3D::Registry_Save_Render_Device( const char * sub_key )
  *=============================================================================================*/
 WW3DErrorType WW3D::Registry_Save_Render_Device( const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth )
 {
-	bool success = DX8Wrapper::Registry_Save_Render_Device(sub_key,device,width,height,depth,windowed,texture_depth);
+	bool success = Backend->Registry_Save_Render_Device(sub_key,device,width,height,depth,windowed,texture_depth);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -721,7 +749,7 @@ WW3DErrorType WW3D::Registry_Save_Render_Device( const char *sub_key, int device
  *=============================================================================================*/
 WW3DErrorType WW3D::Registry_Load_Render_Device( const char * sub_key, bool resize_window )
 {
-	bool success = DX8Wrapper::Registry_Load_Render_Device(sub_key,resize_window);
+	bool success = Backend->Registry_Load_Render_Device(sub_key,resize_window);
 	if (success) {
 		return WW3D_ERROR_OK;
 	} else {
@@ -731,7 +759,7 @@ WW3DErrorType WW3D::Registry_Load_Render_Device( const char * sub_key, bool resi
 
 bool WW3D::Registry_Load_Render_Device( const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth)
 {
-	return DX8Wrapper::Registry_Load_Render_Device(sub_key,device,device_len,width,height,depth,windowed,texture_depth);
+	return Backend->Registry_Load_Render_Device(sub_key,device,device_len,width,height,depth,windowed,texture_depth);
 }
 
 void WW3D::_Invalidate_Mesh_Cache()
@@ -819,12 +847,12 @@ WW3DErrorType WW3D::Begin_Render(bool clear,bool clearz,const Vector3 & color, v
 		vp.Height = height;
 		vp.MinZ = 0.0f;;
 		vp.MaxZ = 1.0f;
-		DX8Wrapper::Set_Viewport(&vp);
-		DX8Wrapper::Clear(clear, clearz, color);
+		Backend->Set_Viewport(&vp);
+		Backend->Clear(clear, clearz, color);
 	}
 
 	// Notify D3D that we are beginning to render the frame
-	DX8Wrapper::Begin_Scene();
+	Backend->Begin_Scene();
 
 	return WW3D_ERROR_OK;
 }
@@ -921,26 +949,26 @@ WW3DErrorType WW3D::Render(SceneClass * scene,CameraClass * cam,bool clear,bool 
 
 	// Clear the viewport
 	if (clear || clearz) {
-		DX8Wrapper::Clear(clear, clearz, color);
+		Backend->Clear(clear, clearz, color);
 	}
 
 	// set the rendering mode
 	switch(scene->Get_Polygon_Mode()) {
 		case SceneClass::POINT:
-			DX8Wrapper::Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_POINT);
+			Backend->Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_POINT);
 			break;
 		case SceneClass::LINE:
-			DX8Wrapper::Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_WIREFRAME);
+			Backend->Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_WIREFRAME);
 			break;
 		case SceneClass::FILL:
-			DX8Wrapper::Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_SOLID);
+			Backend->Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_SOLID);
 			break;
 	}
 
 	// Set the global ambient light value here.  If the scene is using the LightEnvironment system
 	// this setting will get overriden.
 	Vector3 ambient = scene->Get_Ambient_Light();
-	DX8Wrapper::Set_DX8_Render_State(D3DRS_AMBIENT, DX8Wrapper::Convert_Color(ambient,0.0f));
+	Backend->Set_DX8_Render_State(D3DRS_AMBIENT, DX8Wrapper::Convert_Color(ambient,0.0f));
 
 	// render the scene
 
@@ -988,11 +1016,11 @@ WW3DErrorType WW3D::Render(
 	rinfo.Camera.Apply();
 
 	// set the rendering mode
-	DX8Wrapper::Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_SOLID);
+	Backend->Set_DX8_Render_State(D3DRS_FILLMODE,D3DFILL_SOLID);
 
 	// Install the lighting environment if one is supplied
 	if (rinfo.light_environment != NULL) {
-		DX8Wrapper::Set_Light_Environment(rinfo.light_environment);
+		Backend->Set_Light_Environment(rinfo.light_environment);
 	}
 
 	// Render the object
@@ -1065,7 +1093,7 @@ WW3DErrorType WW3D::End_Render(bool flip_frame)
 
 	{
 		WWPROFILE("DX8Wrapper::End_Scene");
-		DX8Wrapper::End_Scene(flip_frame);
+		Backend->End_Scene(flip_frame);
 	}
 
 	FrameCount++;
@@ -1094,7 +1122,7 @@ WW3DErrorType WW3D::End_Render(bool flip_frame)
  *=============================================================================================*/
 void WW3D::Flip_To_Primary(void)
 {
-	DX8Wrapper::Flip_To_Primary();
+	Backend->Flip_To_Primary();
 }
 
 
@@ -1154,7 +1182,7 @@ void WW3D::Sync(unsigned int sync_time)
  *=============================================================================================*/
 void WW3D::Set_Ext_Swap_Interval(int swap)
 {
-	DX8Wrapper::Set_Swap_Interval(swap);
+	Backend->Set_Swap_Interval(swap);
 }
 
 
@@ -1172,7 +1200,7 @@ void WW3D::Set_Ext_Swap_Interval(int swap)
  *=============================================================================================*/
 int WW3D::Get_Ext_Swap_Interval(void)
 {
-	return DX8Wrapper::Get_Swap_Interval();
+	return Backend->Get_Swap_Interval();
 }
 
 
@@ -1229,12 +1257,12 @@ int WW3D::Get_Collision_Box_Display_Mask(void)
 void WW3D::Normalize_Coordinates(int x, int y, float &fx, float &fy)
 {
 	// clip the coordinates back into the resolution of the screen
-	x = Bound(x, 0, DX8Wrapper::Get_Device_Resolution_Width());
-	y = Bound(y, 0, DX8Wrapper::Get_Device_Resolution_Height());
+	x = Bound(x, 0, Backend->Get_Device_Resolution_Width());
+	y = Bound(y, 0, Backend->Get_Device_Resolution_Height());
 
 	// now that the coordinates are clipped convert them to their normalized values.
-	fx = (float)x / DX8Wrapper::Get_Device_Resolution_Width();
-	fy = (float)y / DX8Wrapper::Get_Device_Resolution_Height();
+	fx = (float)x / Backend->Get_Device_Resolution_Width();
+	fy = (float)y / Backend->Get_Device_Resolution_Height();
 }
 
 
@@ -1278,7 +1306,7 @@ void WW3D::Make_Screen_Shot( const char * filename_base )
 	// Lock front buffer and copy
 
 	IDirect3DSurface9 *fb;
-	fb=DX8Wrapper::_Get_DX8_Front_Buffer();
+	fb=Backend->_Get_DX8_Front_Buffer();
 	D3DSURFACE_DESC desc;
 	fb->GetDesc(&desc);
 
@@ -1560,7 +1588,7 @@ void WW3D::Update_Movie_Capture( void )
 		// Lock front buffer and copy
 
 	IDirect3DSurface9 *fb;
-	fb=DX8Wrapper::_Get_DX8_Front_Buffer();
+	fb=Backend->_Get_DX8_Front_Buffer();
 	D3DSURFACE_DESC desc;
 	fb->GetDesc(&desc);
 
@@ -1843,12 +1871,12 @@ void WW3D::Update_Pixel_Center(void)
 
 void WW3D::Set_Texture_Bitdepth(int bitdepth)
 {
-	DX8Wrapper::Set_Texture_Bitdepth(bitdepth);
+	Backend->Set_Texture_Bitdepth(bitdepth);
 }
 
 int WW3D::Get_Texture_Bitdepth()
 {
-	return DX8Wrapper::Get_Texture_Bitdepth();
+	return Backend->Get_Texture_Bitdepth();
 }
 
 void WW3D::Add_To_Static_Sort_List(RenderObjClass *robj, unsigned int sort_level)

--- a/Code/ww3d2/ww3d.cpp
+++ b/Code/ww3d2/ww3d.cpp
@@ -79,8 +79,14 @@
 
 #include "ww3d.h"
 #include "ww3dbackend.h"
+
+#if defined(WW3D_DX9_BACKEND)
 #include "dx8backend.h"
+#elif defined(WW3D_BGFX_BACKEND)
+#include "backends/bgfx/bgfxbackend.h"
+#else
 #include "nullbackend.h"
+#endif
 #include "rinfo.h"
 #include "assetmgr.h"
 #include "boxrobj.h"
@@ -271,12 +277,15 @@ WW3DErrorType WW3D::Init(void *hwnd, char * /*defaultpal*/, bool lite)
 	** Backend selection
 	*/
 	if (!Backend) {
-		// Default to DX8 backend on Windows, null backend elsewhere
-		#if defined(_WIN32) || defined(WIN32)
-			Backend = new DX8Backend();
-		#else
-			Backend = new NullBackend();
-		#endif
+		// Create default backend based on compile-time selection
+		// Can be overridden by calling Set_Backend() before Init()
+#if defined(WW3D_DX9_BACKEND)
+		Backend = new DX8Backend();
+#elif defined(WW3D_BGFX_BACKEND)
+		Backend = new BGFXBackend();
+#else
+		Backend = new NullBackend();
+#endif
 	}
 
 	/*
@@ -341,6 +350,12 @@ WW3DErrorType WW3D::Init(void *hwnd, char * /*defaultpal*/, bool lite)
  *=============================================================================================*/
 void WW3D::Set_Backend(WW3DBackend* backend)
 {
+	if (Backend && Backend != backend) {
+		if (IsInitted) {
+			Backend->Shutdown();
+		}
+		delete Backend;
+	}
 	Backend = backend;
 }
 
@@ -1303,10 +1318,14 @@ void WW3D::Make_Screen_Shot( const char * filename_base )
 
 	WWDEBUG_SAY(( "Creating Screen Shot %s\n", filename ));
 
-	// Lock front buffer and copy
+		// Lock front buffer and copy
 
 	IDirect3DSurface9 *fb;
-	fb=Backend->_Get_DX8_Front_Buffer();
+	fb = static_cast<IDirect3DSurface9*>(Backend->_Get_DX8_Front_Buffer());
+	if (!fb) {
+		WWDEBUG_SAY(("Make_Screen_Shot: backend does not support front buffer capture\n"));
+		return;
+	}
 	D3DSURFACE_DESC desc;
 	fb->GetDesc(&desc);
 
@@ -1585,10 +1604,14 @@ void WW3D::Update_Movie_Capture( void )
 	WWPROFILE("WW3D::Update_Movie_Capture");
 	WWDEBUG_SAY(( "Updating\n"));
 
-		// Lock front buffer and copy
+	// Lock front buffer and copy
 
 	IDirect3DSurface9 *fb;
-	fb=Backend->_Get_DX8_Front_Buffer();
+	fb = static_cast<IDirect3DSurface9*>(Backend->_Get_DX8_Front_Buffer());
+	if (!fb) {
+		WWDEBUG_SAY(("Update_Movie_Capture: backend does not support front buffer capture\n"));
+		return;
+	}
 	D3DSURFACE_DESC desc;
 	fb->GetDesc(&desc);
 

--- a/Code/ww3d2/ww3d.h
+++ b/Code/ww3d2/ww3d.h
@@ -62,6 +62,7 @@ class		RenderDeviceDescClass;
 class		StringClass;
 class		LightEnvironmentClass;
 class		MaterialPassClass;
+class		WW3DBackend;
 
 #define MESH_RENDER_SNAPSHOT_ENABLED
 #define SNAPSHOT_SAY(x) if (WW3D::Is_Snapshot_Activated()) { WWDEBUG_SAY(x); }
@@ -102,6 +103,7 @@ public:
 
 	static WW3DErrorType		Init(void * hwnd, char *defaultpal = NULL, bool lite = false);
 	static WW3DErrorType		Shutdown(void);
+        static void                    Set_Backend(WW3DBackend* backend);
 	static bool					Is_Initted(void)								{ return IsInitted; }
 
 	static const int			Get_Render_Device_Count(void);
@@ -350,6 +352,7 @@ private:
 	static bool							IsTexturingEnabled;
 
 	static bool							Lite;
+	static WW3DBackend *				Backend;
 
 	// This is the default native screen size which will be set for each
 	// RenderObject on construction. The native screen size is the screen size

--- a/Code/ww3d2/ww3d.h
+++ b/Code/ww3d2/ww3d.h
@@ -104,7 +104,8 @@ public:
 	static WW3DErrorType		Init(void * hwnd, char *defaultpal = NULL, bool lite = false);
 	static WW3DErrorType		Shutdown(void);
         static void                    Set_Backend(WW3DBackend* backend);
-	static bool					Is_Initted(void)								{ return IsInitted; }
+        static WW3DBackend*            Get_Backend() { return Backend; }
+	static bool							Is_Initted(void){ return IsInitted; }
 
 	static const int			Get_Render_Device_Count(void);
 	static const char *		Get_Render_Device_Name(int device_index);

--- a/Code/ww3d2/ww3dbackend.h
+++ b/Code/ww3d2/ww3dbackend.h
@@ -1,0 +1,98 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2025 Electronic Arts Inc.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/***********************************************************************************************
+ ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
+ ***********************************************************************************************
+ *                                                                                             *
+ *                 Project Name : ww3d                                                         *
+ *                                                                                             *
+ *                    $Revision:: 1                                                           $*
+ *                                                                                             *
+ *---------------------------------------------------------------------------------------------*
+ * WW3DBackend interface - minimal device-level abstraction for render backends.              *
+ *                                                                                             *
+ * Concrete backends (DX8, BGFX, null) implement this interface. DX8Wrapper stays          *
+ * standalone and is NOT part of this interface chain.                                        *
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+
+#ifndef WW3DBACKEND_H
+#define WW3DBACKEND_H
+
+#include "vector3.h"
+
+class SceneClass;
+class RenderDeviceDescClass;
+
+class WW3DBackend
+{
+public:
+    virtual ~WW3DBackend() {}
+
+    // Initialization
+    virtual bool Init(void * hwnd, bool lite = false) = 0;
+    virtual void Shutdown() = 0;
+
+    // Device enumeration
+    virtual bool Set_Any_Render_Device() = 0;
+    virtual bool Set_Render_Device(const char * dev_name, int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+    virtual bool Set_Render_Device(int dev = -1, int resx = -1, int resy = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+    virtual bool Set_Next_Render_Device() = 0;
+    virtual bool Toggle_Windowed() = 0;
+    virtual bool Is_Windowed() = 0;
+
+    virtual int Get_Render_Device_Count() = 0;
+    virtual int Get_Render_Device() = 0;
+    virtual const RenderDeviceDescClass & Get_Render_Device_Desc(int deviceidx) = 0;
+    virtual const char * Get_Render_Device_Name(int device_index) = 0;
+    virtual bool Set_Device_Resolution(int width = -1, int height = -1, int bits = -1, int windowed = -1, bool resize_window = false) = 0;
+    virtual void Get_Device_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) = 0;
+    virtual void Get_Render_Target_Resolution(int & set_w, int & set_h, int & set_bits, bool & set_windowed) = 0;
+    virtual int Get_Device_Resolution_Width() = 0;
+    virtual int Get_Device_Resolution_Height() = 0;
+
+    // Registry
+    virtual bool Registry_Save_Render_Device(const char * sub_key) = 0;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, bool resize_window) = 0;
+    virtual bool Registry_Save_Render_Device(const char *sub_key, int device, int width, int height, int depth, bool windowed, int texture_depth) = 0;
+    virtual bool Registry_Load_Render_Device(const char * sub_key, char *device, int device_len, int &width, int &height, int &depth, int &windowed, int &texture_depth) = 0;
+
+    // Scene
+    virtual void Begin_Scene() = 0;
+    virtual void End_Scene(bool flip_frame = true) = 0;
+    virtual void Flip_To_Primary() = 0;
+
+    // Clear
+    virtual void Clear(bool clear_color, bool clear_z_stencil, const Vector3 &color, float z = 1.0f, unsigned int stencil = 0) = 0;
+
+    // VSync
+    virtual void Set_Swap_Interval(int swap) = 0;
+    virtual int Get_Swap_Interval() = 0;
+
+    // Texture depth
+    virtual void Set_Texture_Bitdepth(int depth) = 0;
+    virtual int Get_Texture_Bitdepth() = 0;
+
+    // Render state
+    virtual void Set_Viewport(const void* viewport) = 0;
+    virtual void Set_DX8_Render_State(int state, unsigned value) = 0;
+    virtual void Set_Light_Environment(const void* env) = 0;
+    virtual void* _Get_DX8_Front_Buffer() = 0;
+};
+
+#endif // WW3DBACKEND_H

--- a/Code/ww3d2/ww3dbackend.h
+++ b/Code/ww3d2/ww3dbackend.h
@@ -1,35 +1,4 @@
-/*
-**	Command & Conquer Renegade(tm)
-**	Copyright 2025 Electronic Arts Inc.
-**
-**	This program is free software: you can redistribute it and/or modify
-**	it under the terms of the GNU General Public License as published by
-**	the Free Software Foundation, either version 3 of the License, or
-**	(at your option) any later version.
-**
-**	This program is distributed in the hope that it will be useful,
-**	but WITHOUT ANY WARRANTY; without even the implied warranty of
-**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-**	GNU General Public License for more details.
-**
-**	You should have received a copy of the GNU General Public License
-**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-/***********************************************************************************************
- ***              C O N F I D E N T I A L  ---  W E S T W O O D  S T U D I O S               ***
- ***********************************************************************************************
- *                                                                                             *
- *                 Project Name : ww3d                                                         *
- *                                                                                             *
- *                    $Revision:: 1                                                           $*
- *                                                                                             *
- *---------------------------------------------------------------------------------------------*
- * WW3DBackend interface - minimal device-level abstraction for render backends.              *
- *                                                                                             *
- * Concrete backends (DX8, BGFX, null) implement this interface. DX8Wrapper stays          *
- * standalone and is NOT part of this interface chain.                                        *
- * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
+// ww3dbackend.h - OpenW3D render backend
 
 #ifndef WW3DBACKEND_H
 #define WW3DBACKEND_H
@@ -38,6 +7,18 @@
 
 class SceneClass;
 class RenderDeviceDescClass;
+
+// Forward declarations for render state methods
+class ShaderClass;
+class TextureClass;
+class VertexMaterialClass;
+class LightEnvironmentClass;
+class VertexBufferClass;
+class IndexBufferClass;
+class DynamicVBAccessClass;
+class DynamicIBAccessClass;
+class Matrix3D;
+class Matrix4;
 
 class WW3DBackend
 {
@@ -93,6 +74,40 @@ public:
     virtual void Set_DX8_Render_State(int state, unsigned value) = 0;
     virtual void Set_Light_Environment(const void* env) = 0;
     virtual void* _Get_DX8_Front_Buffer() = 0;
+
+    // =========================================================================
+    // Extended render state — backends that support modern APIs implement these
+    // DX8Backend can leave these as no-ops since it uses the existing DX8 path
+    // =========================================================================
+
+    // Transform state
+    virtual void Set_Transform_World(const Matrix4& m) { (void)m; }
+    virtual void Set_Transform_View(const Matrix4& m) { (void)m; }
+    virtual void Set_Transform_Projection(const Matrix4& m) { (void)m; }
+
+    // Shader / material / texture state (deferred application)
+    virtual void Apply_Shader_State(const ShaderClass& shader) { (void)shader; }
+    virtual void Apply_Texture_State(unsigned stage, TextureClass* texture) { (void)stage; (void)texture; }
+    virtual void Invalidate_Texture_Cache_Entry(TextureClass* texture) { (void)texture; }
+    virtual void Invalidate_Vertex_Buffer_Cache_Entry(const VertexBufferClass* vb) { (void)vb; }
+    virtual void Invalidate_Index_Buffer_Cache_Entry(const IndexBufferClass* ib) { (void)ib; }
+    virtual void Apply_Material_State(const VertexMaterialClass* material) { (void)material; }
+    virtual void Apply_Light_Environment_State(LightEnvironmentClass* env) { (void)env; }
+    virtual void Set_DX8_Light(int index, const void* light) { (void)index; (void)light; }
+
+    // Buffer binding
+    virtual void Set_Vertex_Buffer(const VertexBufferClass* vb) { (void)vb; }
+    virtual void Set_Index_Buffer(const IndexBufferClass* ib, unsigned short index_base_offset) { (void)ib; (void)index_base_offset; }
+
+    // Draw submission
+    virtual void Draw_Indexed_Triangles(unsigned short start_index, unsigned short polygon_count, unsigned short min_vertex_index, unsigned short vertex_count) { (void)start_index; (void)polygon_count; (void)min_vertex_index; (void)vertex_count; }
+    virtual void Draw_Indexed_Strip(unsigned short start_index, unsigned short index_count, unsigned short min_vertex_index, unsigned short vertex_count) { (void)start_index; (void)index_count; (void)min_vertex_index; (void)vertex_count; }
+
+    // Finalize state application (called after all individual state pieces are set)
+    virtual void Commit_Render_State() {}
+
+    // Returns true if this backend wants DX8Wrapper to delegate Apply_Render_State_Changes
+    virtual bool Wants_Deferred_State_Apply() const { return false; }
 };
 
 #endif // WW3DBACKEND_H

--- a/cmake/bgfx.cmake
+++ b/cmake/bgfx.cmake
@@ -1,0 +1,195 @@
+#
+# BGFX CMake integration for OpenW3D
+#
+# BGFX uses genie (from bx) for building. This cmake provides integration
+# by setting up include paths and linking when bgfx is built.
+#
+# IMPORTANT - Build Requirements:
+#   - genie build tool: https://github.com/bkaradzic/genie
+#   - C++20 compiler (GCC 11+, Clang 11+, MSVC 17.5+)
+#
+# To enable and build bgfx:
+#   # First build bgfx itself:
+#   cd external/bgfx
+#   make linux-gcc-release64
+#
+#   # Then build OpenW3D with bgfx backend:
+#   cd ../..
+#   mkdir build && cd build
+#   cmake .. -DENABLE_BGFX_BACKEND=ON
+#   make
+
+# Guard against double inclusion
+if(TARGET bgfximpl)
+    return()
+endif()
+#
+
+set(BGFX_DIR "${CMAKE_SOURCE_DIR}/external/bgfx")
+set(BX_DIR "${CMAKE_SOURCE_DIR}/external/bx")
+set(BIMG_DIR "${CMAKE_SOURCE_DIR}/external/bimg")
+
+if(NOT ENABLE_BGFX_BACKEND)
+    return()
+endif()
+
+# Verify bx submodule is present
+if(NOT EXISTS "${BX_DIR}/include/bx/bx.h")
+    message(FATAL_ERROR "bx submodule not initialized. Run:\n  git submodule update --init --recursive")
+endif()
+
+# Verify bgfx submodule is present
+if(NOT EXISTS "${BGFX_DIR}/include/bgfx/bgfx.h")
+    message(FATAL_ERROR "bgfx submodule not initialized. Run:\n  git submodule update --init --recursive")
+endif()
+
+# Create interface library for bgfx headers and dependencies
+add_library(bgfx INTERFACE)
+
+target_include_directories(bgfx INTERFACE
+    "${BGFX_DIR}/include"
+    "${BGFX_DIR}/include/c99"
+    "${BX_DIR}/include"
+)
+
+# BGFX requires C++17 minimum; consumers opt into higher standards as needed
+target_compile_features(bgfx INTERFACE cxx_std_17)
+
+# Platform defines
+if(WIN32)
+    target_compile_definitions(bgfx INTERFACE BGFX_PLATFORM_WINDOWS=1)
+elseif(UNIX AND NOT APPLE)
+    target_compile_definitions(bgfx INTERFACE BGFX_PLATFORM_LINUX=1)
+elseif(APPLE)
+    target_compile_definitions(bgfx INTERFACE BGFX_PLATFORM_OSX=1)
+endif()
+
+# bx/bimg/bgfx config defines (required by bx headers)
+target_compile_definitions(bgfx INTERFACE
+    BX_CONFIG_DEBUG=0
+    BX_CONFIG_CACHELINE_SIZE=64
+)
+
+# Find system dependencies for bgfx
+if(WIN32)
+    target_link_libraries(bgfx INTERFACE winmm user32 gdi32 dxguid)
+elseif(UNIX AND NOT APPLE)
+    find_package(OpenGL)
+    find_package(X11 REQUIRED)
+    target_link_libraries(bgfx INTERFACE X11::X11 X11::Xrandr X11::Xcursor dl pthread)
+    if(OpenGL_FOUND)
+        target_link_libraries(bgfx INTERFACE OpenGL::GL)
+    endif()
+elseif(APPLE)
+    find_library(COCOA_LIBRARY Cocoa REQUIRED)
+    find_library(FOUNDATION_LIBRARY Foundation REQUIRED)
+    target_link_libraries(bgfx INTERFACE ${COCOA_LIBRARY} ${FOUNDATION_LIBRARY})
+endif()
+
+# Look for bgfx library in common build output locations
+set(BGFX_LIB_FOUND FALSE)
+
+if(WIN32)
+    # Windows: look for .lib files from VS2022 builds
+    foreach(CONFIG Release Debug RelWithDebInfo MinSizeRel)
+        foreach(ARCH win64 win32 x64 x86)
+            set(CANDIDATE "${BGFX_DIR}/.build/${ARCH}_vs2022/bin/bgfx${CONFIG}.lib")
+            if(EXISTS "${CANDIDATE}")
+                set(BGFX_LIB "${CANDIDATE}")
+                set(BGFX_LIB_FOUND TRUE)
+                break()
+            endif()
+        endforeach()
+        if(BGFX_LIB_FOUND)
+            break()
+        endif()
+    endforeach()
+
+    # Fallback: search recursively
+    if(NOT BGFX_LIB_FOUND)
+        file(GLOB_RECURSE BGFX_LIB_CANDIDATES "${BGFX_DIR}/.build/**/*.lib")
+        if(BGFX_LIB_CANDIDATES)
+            list(GET BGFX_LIB_CANDIDATES 0 BGFX_LIB)
+            set(BGFX_LIB_FOUND TRUE)
+        endif()
+    endif()
+
+    # Also look for bx and bimg libs
+    foreach(LIBNAME bx bimg)
+        foreach(CONFIG Release Debug RelWithDebInfo MinSizeRel)
+            foreach(ARCH win64 win32 x64 x86)
+                set(CANDIDATE "${BGFX_DIR}/.build/${ARCH}_vs2022/bin/${LIBNAME}${CONFIG}.lib")
+                if(EXISTS "${CANDIDATE}")
+                    add_library(${LIBNAME}impl STATIC IMPORTED GLOBAL)
+                    set_target_properties(${LIBNAME}impl PROPERTIES IMPORTED_LOCATION "${CANDIDATE}")
+                    target_link_libraries(bgfx INTERFACE ${LIBNAME}impl)
+                    break()
+                endif()
+            endforeach()
+        endforeach()
+    endforeach()
+else()
+    # Linux/macOS: look for .a files
+    foreach(CONFIG release release64 debug debug64)
+        set(CANDIDATE "${BGFX_DIR}/.build/linux64_gcc/bin/libbgfx${CONFIG}.a")
+        if(EXISTS "${CANDIDATE}")
+            set(BGFX_LIB "${CANDIDATE}")
+            set(BGFX_LIB_FOUND TRUE)
+            break()
+        endif()
+    endforeach()
+
+    if(NOT BGFX_LIB_FOUND)
+        file(GLOB_RECURSE BGFX_LIB_CANDIDATES "${BGFX_DIR}/.build/**/libbgfx*.a")
+        if(BGFX_LIB_CANDIDATES)
+            list(GET BGFX_LIB_CANDIDATES 0 BGFX_LIB)
+            set(BGFX_LIB_FOUND TRUE)
+        endif()
+    endif()
+endif()
+
+if(BGFX_LIB_FOUND)
+    message(STATUS "Found bgfx library: ${BGFX_LIB}")
+
+    add_library(bgfximpl STATIC IMPORTED GLOBAL)
+    set_target_properties(bgfximpl PROPERTIES IMPORTED_LOCATION "${BGFX_LIB}")
+    target_link_libraries(bgfx INTERFACE bgfximpl)
+else()
+    if(WIN32)
+        set(BGFX_BUILD_HELP "  1. cd ${BGFX_DIR}\n  2. ..\\..\\bx\\tools\\bin\\windows\\genie.exe vs2022\n  3. Open .build\\projects\\vs2022\\bgfx.sln in Visual Studio and build\n  4. Rebuild this project with -DENABLE_BGFX_BACKEND=ON")
+        set(BGFX_STUB_EXT "lib")
+    else()
+        set(BGFX_BUILD_HELP "  1. cd ${BGFX_DIR}\n  2. make linux-gcc-release64\n  3. Rebuild this project with -DENABLE_BGFX_BACKEND=ON")
+        set(BGFX_STUB_EXT "a")
+    endif()
+
+    message(WARNING "BGFX library not found. The bgfx backend will compile but won't link.\n"
+        "\n"
+        "To build bgfx:\n"
+        "${BGFX_BUILD_HELP}\n"
+        "\n"
+        "Without the library, only the null backend can be used.")
+
+    add_library(bgfximpl STATIC IMPORTED GLOBAL)
+    # Create a minimal valid static library stub so the linker accepts it
+    set(BGFX_STUB_LIB "${CMAKE_BINARY_DIR}/libbgfx_stub.${BGFX_STUB_EXT}")
+    set_target_properties(bgfximpl PROPERTIES IMPORTED_LOCATION "${BGFX_STUB_LIB}")
+    if(NOT EXISTS "${BGFX_STUB_LIB}")
+        if(WIN32)
+            file(WRITE "${BGFX_STUB_LIB}" "\n")
+        else()
+            # Create a valid ar archive with an empty symbol table
+            find_program(AR_EXECUTABLE NAMES ar REQUIRED)
+            file(WRITE "${CMAKE_BINARY_DIR}/.bgfx_stub_empty.c" "")
+            execute_process(COMMAND ${AR_EXECUTABLE} rcs "${BGFX_STUB_LIB}" "${CMAKE_BINARY_DIR}/.bgfx_stub_empty.c"
+                RESULT_VARIABLE AR_RESULT)
+            if(NOT AR_RESULT EQUAL 0)
+                message(FATAL_ERROR "Failed to create stub static library for bgfx")
+            endif()
+        endif()
+    endif()
+endif()
+
+message(STATUS "BGFX backend enabled")
+message(STATUS "  BGFX_DIR: ${BGFX_DIR}")
+message(STATUS "  BX_DIR: ${BX_DIR}")


### PR DESCRIPTION
## Summary

Implements a complete BGFX renderer backend for OpenW3D, replacing the Direct3D 9 rendering path with a portable, cross-platform BGFX implementation.

## Changes

### 1. Build System (518 lines)
- Add bgfx/bimg/bx git submodules
- Add cmake/bgfx.cmake with BGFX dependency resolution
- Wire BGFX backend into root and ww3d2 CMakeLists.txt
- Add WW3D_BGFX_BACKEND compile-time option

### 2. BGFX Backend Implementation (4,441 lines)
- **BGFXBackend**: Full Direct3D 9 feature mapping to bgfx API
- **Buffer management**: Vertex buffers, index buffers with transient cache
- **Texture system**: DXT compression, format conversion, cache management
- **Material mapper**: Ubershader with variant cache for state combinations
- **Shader pipeline**: Mesh shaders (lighting, fog, alpha) + ubershader
- **State bridging**: Blend modes, alpha test, fog, render states
- **Light environment**: Point lights, sorting renderer dispatch
- **Camera uniform**: Position extraction from view matrix

### 3. Integration (251 insertions, 83 deletions)
- Backend dispatch seams in DX8Wrapper for BGFX state bridging
- Compile-time backend selection (DX9/BGFX/Null) in ww3d.cpp
- Get_Backend() accessor, proper backend cleanup
- Texture cache invalidation for BGFX managed textures
- DX8Wrapper updates for backend-agnostic state management

## Review Notes

This PR depends on #120 (Backend Abstraction) and should be reviewed after that PR is merged.

The BGFX backend is a drop-in replacement for the DX8 backend - same WW3DBackend interface, same rendering API. All existing game code continues to work without modification.

## Commits

1. `feat(bgfx): add BGFX build system and CMake integration`
2. `feat(bgfx): implement BGFX renderer backend`
3. `feat(bgfx): integrate BGFX backend into ww3d2 rendering pipeline`