### PR TITLE
build(cmake): add MinGW cross-compilation toolchain

### DIFF
--- a/cmake/toolchains/mingw-w64-i686.cmake
+++ b/cmake/toolchains/mingw-w64-i686.cmake
@@ -28,9 +28,9 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
-# MinGW-specific flags
-set(CMAKE_C_FLAGS_INIT "-static-libgcc")
-set(CMAKE_CXX_FLAGS_INIT "-static-libgcc -static-libstdc++")
+# MinGW-specific linker flags
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-static-libgcc -static-libstdc++")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-static-libgcc")
 set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
 # Windows version target (Windows 7+)

--- a/cmake/toolchains/mingw-w64-i686.cmake
+++ b/cmake/toolchains/mingw-w64-i686.cmake
@@ -1,0 +1,37 @@
+# MinGW-w64 i686 Cross-Compilation Toolchain for Linux
+# Usage: cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/mingw-w64-i686.cmake ..
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR X86)
+
+# MinGW-w64 compiler prefix
+set(MINGW_PREFIX i686-w64-mingw32)
+
+# Compilers
+set(CMAKE_C_COMPILER ${MINGW_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${MINGW_PREFIX}-g++)
+set(CMAKE_RC_COMPILER ${MINGW_PREFIX}-windres)
+set(CMAKE_AR ${MINGW_PREFIX}-ar)
+set(CMAKE_RANLIB ${MINGW_PREFIX}-ranlib)
+set(CMAKE_LINKER ${MINGW_PREFIX}-ld)
+set(CMAKE_NM ${MINGW_PREFIX}-nm)
+set(CMAKE_OBJCOPY ${MINGW_PREFIX}-objcopy)
+set(CMAKE_OBJDUMP ${MINGW_PREFIX}-objdump)
+set(CMAKE_STRIP ${MINGW_PREFIX}-strip)
+
+# Target environment
+set(CMAKE_FIND_ROOT_PATH /usr/${MINGW_PREFIX})
+
+# Search paths
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# MinGW-specific flags
+set(CMAKE_C_FLAGS_INIT "-static-libgcc")
+set(CMAKE_CXX_FLAGS_INIT "-static-libgcc -static-libstdc++")
+set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
+
+# Windows version target (Windows 7+)
+add_compile_definitions(_WIN32_WINNT=0x0601 WINVER=0x0601)

--- a/cmake/toolchains/mingw-w64-x86_64.cmake
+++ b/cmake/toolchains/mingw-w64-x86_64.cmake
@@ -1,0 +1,37 @@
+# MinGW-w64 x86_64 Cross-Compilation Toolchain for Linux
+# Usage: cmake -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/mingw-w64-x86_64.cmake ..
+
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR AMD64)
+
+# MinGW-w64 compiler prefix
+set(MINGW_PREFIX x86_64-w64-mingw32)
+
+# Compilers
+set(CMAKE_C_COMPILER ${MINGW_PREFIX}-gcc)
+set(CMAKE_CXX_COMPILER ${MINGW_PREFIX}-g++)
+set(CMAKE_RC_COMPILER ${MINGW_PREFIX}-windres)
+set(CMAKE_AR ${MINGW_PREFIX}-ar)
+set(CMAKE_RANLIB ${MINGW_PREFIX}-ranlib)
+set(CMAKE_LINKER ${MINGW_PREFIX}-ld)
+set(CMAKE_NM ${MINGW_PREFIX}-nm)
+set(CMAKE_OBJCOPY ${MINGW_PREFIX}-objcopy)
+set(CMAKE_OBJDUMP ${MINGW_PREFIX}-objdump)
+set(CMAKE_STRIP ${MINGW_PREFIX}-strip)
+
+# Target environment
+set(CMAKE_FIND_ROOT_PATH /usr/${MINGW_PREFIX})
+
+# Search paths
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# MinGW-specific flags
+set(CMAKE_C_FLAGS_INIT "-static-libgcc")
+set(CMAKE_CXX_FLAGS_INIT "-static-libgcc -static-libstdc++")
+set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
+
+# Windows version target (Windows 7+)
+add_compile_definitions(_WIN32_WINNT=0x0601 WINVER=0x0601)

--- a/cmake/toolchains/mingw-w64-x86_64.cmake
+++ b/cmake/toolchains/mingw-w64-x86_64.cmake
@@ -28,9 +28,9 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
-# MinGW-specific flags
-set(CMAKE_C_FLAGS_INIT "-static-libgcc")
-set(CMAKE_CXX_FLAGS_INIT "-static-libgcc -static-libstdc++")
+# MinGW-specific linker flags
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-static-libgcc -static-libstdc++")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-static-libgcc")
 set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
 # Windows version target (Windows 7+)


### PR DESCRIPTION
## Summary

Add CMake toolchain files for cross-compiling Windows binaries from Linux using MinGW-w64.

## Motivation

Enables Linux CI to build Windows artifacts without requiring a Windows runner. This reduces CI costs and allows cross-platform validation from a single build environment.

## Toolchains

- `cmake/toolchains/mingw-w64-x86_64.cmake`: 64-bit Windows target
- `cmake/toolchains/mingw-w64-i686.cmake`: 32-bit Windows target

## Features

- Configures MinGW compiler toolchain (gcc, g++, windres, ar, etc.)
- Sets up proper library/include search paths via `CMAKE_FIND_ROOT_PATH`
- Adds static linking flags for libgcc/libstdc++
- Targets Windows 7+ (`_WIN32_WINNT=0x0601`)

## Usage



## Testing

- [x] Successfully cross-compiles OpenW3D from Linux to Windows x86_64
- [x] Produces working PE32+ executable
- [x] No impact on native builds (toolchain files are opt-in)

## Notes

These are additive files only — zero changes to existing CMake configuration. Safe to merge without risk.