### PR TITLE
Fix DX9 depth bias for decals and weather

### DIFF
--- a/Code/Combat/WeatherMgr.cpp
+++ b/Code/Combat/WeatherMgr.cpp
@@ -81,6 +81,8 @@ WeatherSystemClass							*WeatherMgrClass::_Precipitation [PRECIPITATION_COUNT];
 bool												 WeatherMgrClass::_FogEnabled;
 bool												 WeatherMgrClass::_Dirty;
 
+static const float WEATHER_SURFACE_OFFSET_DISTANCE = 0.01f;
+
 
 /***********************************************************************************************
  * WindClass::WindClass --																							  *
@@ -1049,12 +1051,6 @@ void WeatherSystemClass::Render (RenderInfoClass &rinfo)
 
 		DX8Wrapper::Set_Index_Buffer (IndexBuffer, 0);
 
-		#if WEATHER_PARTICLE_SORT
-		#else
-		float depthbias = -0.02f;
-		DX8Wrapper::Set_DX8_Render_State(D3DRS_DEPTHBIAS,*reinterpret_cast<unsigned*>(&depthbias));
-		#endif
-
  		camerafocus = rinfo.Camera.Get_Transform().Get_Z_Vector();
 		particleptr = ParticleHead;
 		processedparticlecount = 0;
@@ -1113,6 +1109,7 @@ void WeatherSystemClass::Render (RenderInfoClass &rinfo)
 								// Particle has an orientation so back-face cull it.
 								if (Vector3::Dot_Product (camerafocus, particleptr->SurfaceNormal) > 0.0f) {
 
+									position += particleptr->SurfaceNormal * WEATHER_SURFACE_OFFSET_DISTANCE;
 									x = Vector3::Cross_Product (camerafocus, particleptr->SurfaceNormal);
 									x /= x.Quick_Length();
 									y = Vector3::Cross_Product (x, particleptr->SurfaceNormal);
@@ -1216,10 +1213,6 @@ void WeatherSystemClass::Render (RenderInfoClass &rinfo)
 
 		WWASSERT (particleptr == NULL);
 
-		#if WEATHER_PARTICLE_SORT
-		#else
-		DX8Wrapper::Set_DX8_Render_State (D3DRS_DEPTHBIAS, 0);
-		#endif
 	}
 }
 

--- a/Code/Combat/WeatherMgr.cpp
+++ b/Code/Combat/WeatherMgr.cpp
@@ -81,7 +81,7 @@ WeatherSystemClass							*WeatherMgrClass::_Precipitation [PRECIPITATION_COUNT];
 bool												 WeatherMgrClass::_FogEnabled;
 bool												 WeatherMgrClass::_Dirty;
 
-static const float WEATHER_SURFACE_OFFSET_DISTANCE = 0.01f;
+static constexpr float WEATHER_SURFACE_OFFSET_DISTANCE = 0.01f;
 
 
 /***********************************************************************************************

--- a/Code/ww3d2/decalmsh.cpp
+++ b/Code/ww3d2/decalmsh.cpp
@@ -62,9 +62,10 @@
 #include "simplevec.h"
 #include "texture.h"
 #include "dx8wrapper.h"
-#include "dx8caps.h"
 
 #define DISABLE_CLIPPING	0
+
+static const float DECAL_ZBIAS_DISTANCE = 0.01f;
 
 /**
 ** DecalPolyClass - This class is used to clip polygons as they are
@@ -418,19 +419,13 @@ bool RigidDecalMeshClass::Create_Decal
 	[[maybe_unused]] const DynamicVectorClass<Vector3> * world_vertex_locs
 )
 {
-	// Since we can't rely on the hardware polygon offset function, I'm physically offsetting
-	// the decal polygons along the normal of the decal generator.  If we could instead rely
-	// on hardware "polygon offset" we could remove this code and we could make decals non-sorting
+	// Keep the decal lift in geometry so the bias stays stable with camera distance.
 	Vector3 zbias_offset(0.0f,0.0f,0.0f);
-
-	if (!DX8Wrapper::Get_Current_Caps()->Support_ZBias()) {
-		const float ZBIAS_DISTANCE = 0.01f;
-		generator->Get_Transform().Get_Z_Vector(&zbias_offset);
-		Matrix3D invtm;
-		Parent->Get_Transform().Get_Orthogonal_Inverse(invtm);
-		Matrix3D::Rotate_Vector(invtm,zbias_offset,&zbias_offset);
-		zbias_offset *= ZBIAS_DISTANCE;
-	}
+	generator->Get_Transform().Get_Z_Vector(&zbias_offset);
+	Matrix3D invtm;
+	Parent->Get_Transform().Get_Orthogonal_Inverse(invtm);
+	Matrix3D::Rotate_Vector(invtm,zbias_offset,&zbias_offset);
+	zbias_offset *= DECAL_ZBIAS_DISTANCE;
 
 	// NOTE: world_vertex_locs/norms should not be set for this class
 	WWASSERT(world_vertex_locs == 0);
@@ -807,13 +802,17 @@ void SkinDecalMeshClass::Render(void)
 
 		for (int i=0; i<ParentVertexIndices.Count(); i++) {
 			int src_i = ParentVertexIndices[i];
-			vertex->x = _TempVertexBuffer[src_i].X;
-			vertex->y = _TempVertexBuffer[src_i].Y;
-			vertex->z = _TempVertexBuffer[src_i].Z;
+			Vector3 normal = _TempNormalBuffer[src_i];
+			normal.Normalize();
+			Vector3 position = _TempVertexBuffer[src_i] + normal * DECAL_ZBIAS_DISTANCE;
 
-			vertex->nx = _TempNormalBuffer[src_i].X;
-			vertex->ny = _TempNormalBuffer[src_i].Y;
-			vertex->nz = _TempNormalBuffer[src_i].Z;
+			vertex->x = position.X;
+			vertex->y = position.Y;
+			vertex->z = position.Z;
+
+			vertex->nx = normal.X;
+			vertex->ny = normal.Y;
+			vertex->nz = normal.Z;
 
 			vertex->diffuse = 0xFFFFFFFF;
 

--- a/Code/ww3d2/decalmsh.cpp
+++ b/Code/ww3d2/decalmsh.cpp
@@ -65,7 +65,7 @@
 
 #define DISABLE_CLIPPING	0
 
-static const float DECAL_ZBIAS_DISTANCE = 0.01f;
+static constexpr float DECAL_ZBIAS_DISTANCE = 0.01f;
 
 /**
 ** DecalPolyClass - This class is used to clip polygons as they are

--- a/Code/ww3d2/dx8renderer.cpp
+++ b/Code/ww3d2/dx8renderer.cpp
@@ -2041,8 +2041,9 @@ static inline DWORD Float2Unsigned(float f) {
 }
 void DX8MeshRendererClass::Render_Decal_Meshes()
 {
+	static constexpr float DEPTH_BIAS_UNIT = 1.0f / 16777216.0f;
 	const float slope_scale = 0.0f;
-	const float const_bias = -0.001f;
+	const float const_bias = -DEPTH_BIAS_UNIT;
 
 	DX8Wrapper::Set_DX8_Render_State(D3DRS_SLOPESCALEDEPTHBIAS, Float2Unsigned(slope_scale));
 	DX8Wrapper::Set_DX8_Render_State(D3DRS_DEPTHBIAS, Float2Unsigned(const_bias));
@@ -2103,7 +2104,6 @@ void DX8MeshRendererClass::Invalidate()
 
 	texture_category_container_lists_rigid.Delete_All();
 }
-
 
 
 

--- a/Code/ww3d2/dx8wrapper.cpp
+++ b/Code/ww3d2/dx8wrapper.cpp
@@ -65,6 +65,7 @@
 #include "textureloader.h"
 #include "missingtexture.h"
 #include "thread.h"
+#include <bit>
 #include <stdio.h>
 #include <d3dx9core.h>
 #include "dxerr_compat.h"
@@ -356,7 +357,8 @@ void DX8Wrapper::Do_Onetime_Device_Dependent_Inits(void)
 	Set_Default_Global_Render_States();
 }
 
-inline DWORD F2DW(float f) { return *((unsigned*)&f); }
+inline DWORD F2DW(float f) { return std::bit_cast<DWORD>(f); }
+static constexpr float DX8_ZBIAS_DEPTH_UNIT = 1.0f / 16777216.0f;
 void DX8Wrapper::Set_Default_Global_Render_States(void)
 {
 	DX8_THREAD_ASSERT();
@@ -3009,10 +3011,11 @@ void DX8Wrapper::Get_DX8_Render_State_Value_Name(StringClass& name, D3DRENDERSTA
 	case D3DRS_POINTSCALE_C:
 	case D3DRS_POINTSIZE_MAX:
 	case D3DRS_TWEENFACTOR:
+	case D3DRS_DEPTHBIAS:
+	case D3DRS_SLOPESCALEDEPTHBIAS:
 		name.Format("%f",*(float*)&value);
 		break;
 
-	case D3DRS_DEPTHBIAS:
 	case D3DRS_STENCILREF:
 		name.Format("%d",value);
 		break;
@@ -3409,9 +3412,9 @@ void DX8Wrapper::Set_DX8_ZBias(int zbias)
 		DX8CALL(SetTransform(D3DTS_PROJECTION,(D3DMATRIX*)&tmp));
 	}
 	else {
-		//float ZBias_float = zbias / 8.0f;
-		Set_DX8_Render_State (D3DRS_DEPTHBIAS, ZBias);
-		Set_DX8_Render_State (D3DRS_SLOPESCALEDEPTHBIAS, ZBias);
+		const float depth_bias = (ZBias == 0) ? 0.0f : -static_cast<float>(ZBias) * DX8_ZBIAS_DEPTH_UNIT;
+		Set_DX8_Render_State (D3DRS_DEPTHBIAS, F2DW(depth_bias));
+		Set_DX8_Render_State (D3DRS_SLOPESCALEDEPTHBIAS, F2DW(0.0f));
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes DX9 depth-bias handling that caused decals to render in front of scene geometry at certain ranges and caused weather/surface effects to appear indoors.

- Converts legacy DX8 z-bias values to small DX9 `D3DRS_DEPTHBIAS` float values using a 24-bit depth unit scale.
- Reduces decal render-state bias from a large constant to a minimal depth-unit bias.
- Keeps decal separation stable by applying a small geometry offset along decal normals.
- Removes the large global weather depth bias and instead offsets surface-aligned weather particles slightly along the surface normal.

