### PR TITLE
refactor(ww3d2): add CPU staging buffers and NULL guards for non-DX9 backends

### DIFF
--- a/Code/ww3d2/dx8caps.cpp
+++ b/Code/ww3d2/dx8caps.cpp
@@ -455,6 +455,42 @@ DX8Caps::DeviceTypeIntel DX8Caps::Get_Intel_Device(unsigned device_id)
 	}
 }
 
+DX8Caps::DX8Caps()
+	:
+	Direct3D(NULL),
+	MaxDisplayWidth(0),
+	MaxDisplayHeight(0)
+{
+	memset(&Caps, 0, sizeof(Caps));
+	SupportTnL = true;
+	SupportDXTC = true;
+	supportGamma = true;
+	SupportNPatches = false;
+	SupportBumpEnvmap = true;
+	SupportBumpEnvmapLuminance = true;
+	memset(SupportTextureFormat, 0, sizeof(SupportTextureFormat));
+	memset(SupportRenderToTextureFormat, 0, sizeof(SupportRenderToTextureFormat));
+	SupportZBias = true;
+	SupportAnisotropicFiltering = true;
+	CanDoMultiPass = true;
+	IsFogAllowed = true;
+	MaxTexturesPerPass = 4;
+	VertexShaderVersion = 0x300;
+	PixelShaderVersion = 0x300;
+	DeviceId = 0;
+	DriverBuildVersion = 0;
+	DriverVersionStatus = DRIVER_STATUS_GOOD;
+	VendorId = VENDOR_NVIDIA;
+	DriverDLL = "stub.dll";
+	CapsLog = "";
+	CompactLog = "";
+}
+
+DX8Caps* DX8Caps::Create_Stub_Caps()
+{
+	return new DX8Caps();
+}
+
 DX8Caps::DX8Caps(
 	IDirect3D9* direct3d,
 	IDirect3DDevice9* D3DDevice,

--- a/Code/ww3d2/dx8caps.h
+++ b/Code/ww3d2/dx8caps.h
@@ -204,8 +204,12 @@ public:
 	};
 
 
+	DX8Caps();
+
 	DX8Caps(IDirect3D9* direct3d, const D3DCAPS9& caps,WW3DFormat display_format, const D3DADAPTER_IDENTIFIER9& adapter_id);
 	DX8Caps(IDirect3D9* direct3d, IDirect3DDevice9* D3DDevice,WW3DFormat display_format, const D3DADAPTER_IDENTIFIER9& adapter_id);
+
+	static DX8Caps* Create_Stub_Caps();
 
 	void Compute_Caps(WW3DFormat display_format, const D3DADAPTER_IDENTIFIER9& adapter_id);
 	bool Support_TnL() const { return SupportTnL; };

--- a/Code/ww3d2/dx8indexbuffer.cpp
+++ b/Code/ww3d2/dx8indexbuffer.cpp
@@ -47,7 +47,6 @@
 #include "thread.h"
 #include "wwmemlog.h"
 #include "ww3d.h"
-#include "ww3dbackend.h"
 
 #define DEFAULT_IB_SIZE 5000
 
@@ -94,10 +93,6 @@ IndexBufferClass::IndexBufferClass(unsigned type_, unsigned short index_count_)
 
 IndexBufferClass::~IndexBufferClass()
 {
-	if (WW3D::Get_Backend()) {
-		WW3D::Get_Backend()->Invalidate_Index_Buffer_Cache_Entry(this);
-	}
-
 	_IndexBufferCount--;
 	_IndexBufferTotalIndices-=index_count;
 	_IndexBufferTotalSize-=index_count*sizeof(unsigned short);
@@ -367,8 +362,9 @@ DX8IndexBufferClass::DX8IndexBufferClass(unsigned short index_count_,UsageType u
 // ----------------------------------------------------------------------------
 
 DX8IndexBufferClass::~DX8IndexBufferClass()
-{	if (cpu_buffer) {
-		free(cpu_buffer);
+{
+	if (cpu_buffer) {
+		delete[] static_cast<uint8_t*>(cpu_buffer);
 		cpu_buffer = NULL;
 	}
 	if (index_buffer) {

--- a/Code/ww3d2/dx8indexbuffer.cpp
+++ b/Code/ww3d2/dx8indexbuffer.cpp
@@ -40,10 +40,14 @@
 
 #include "dx8indexbuffer.h"
 #include "dx8wrapper.h"
+
+
 #include "dx8caps.h"
 #include "sphere.h"
 #include "thread.h"
 #include "wwmemlog.h"
+#include "ww3d.h"
+#include "ww3dbackend.h"
 
 #define DEFAULT_IB_SIZE 5000
 
@@ -90,6 +94,10 @@ IndexBufferClass::IndexBufferClass(unsigned type_, unsigned short index_count_)
 
 IndexBufferClass::~IndexBufferClass()
 {
+	if (WW3D::Get_Backend()) {
+		WW3D::Get_Backend()->Invalidate_Index_Buffer_Cache_Entry(this);
+	}
+
 	_IndexBufferCount--;
 	_IndexBufferTotalIndices-=index_count;
 	_IndexBufferTotalSize-=index_count*sizeof(unsigned short);
@@ -190,11 +198,15 @@ IndexBufferClass::WriteLockClass::WriteLockClass(IndexBufferClass* index_buffer_
 	switch (index_buffer->Type()) {
 	case BUFFER_TYPE_DX8:
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(index_buffer)->Get_DX8_Index_Buffer()->Lock(
-			0,
-			index_buffer->Get_Index_Count()*sizeof(WORD),
-			(void**)&indices,
-			0));
+		if (static_cast<DX8IndexBufferClass*>(index_buffer)->Get_DX8_Index_Buffer()) {
+			DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(index_buffer)->Get_DX8_Index_Buffer()->Lock(
+				0,
+				index_buffer->Get_Index_Count()*sizeof(WORD),
+				(void**)&indices,
+				0));
+		} else {
+			indices = static_cast<unsigned short*>(static_cast<DX8IndexBufferClass*>(index_buffer)->Get_CPU_Buffer());
+		}
 		break;
 	case BUFFER_TYPE_SORTING:
 		indices=static_cast<SortingIndexBufferClass*>(index_buffer)->index_buffer;
@@ -216,7 +228,9 @@ IndexBufferClass::WriteLockClass::~WriteLockClass()
 	switch (index_buffer->Type()) {
 	case BUFFER_TYPE_DX8:
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(index_buffer)->index_buffer->Unlock());
+		if (static_cast<DX8IndexBufferClass*>(index_buffer)->index_buffer) {
+			DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(index_buffer)->index_buffer->Unlock());
+		}
 		break;
 	case BUFFER_TYPE_SORTING:
 		break;
@@ -241,11 +255,15 @@ IndexBufferClass::AppendLockClass::AppendLockClass(IndexBufferClass* index_buffe
 	switch (index_buffer->Type()) {
 	case BUFFER_TYPE_DX8:
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(index_buffer)->index_buffer->Lock(
-			start_index*sizeof(unsigned short),
-			index_range*sizeof(unsigned short),
-			(void**)&indices,
-			0));	// Optional pointer to receive the buffer size
+		if (static_cast<DX8IndexBufferClass*>(index_buffer)->index_buffer) {
+			DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(index_buffer)->index_buffer->Lock(
+				start_index*sizeof(unsigned short),
+				index_range*sizeof(unsigned short),
+				(void**)&indices,
+				0));	// Optional pointer to receive the buffer size
+		} else {
+			indices = static_cast<unsigned short*>(static_cast<DX8IndexBufferClass*>(index_buffer)->Get_CPU_Buffer()) + start_index;
+		}
 		break;
 	case BUFFER_TYPE_SORTING:
 		indices=static_cast<SortingIndexBufferClass*>(index_buffer)->index_buffer+start_index;
@@ -264,7 +282,9 @@ IndexBufferClass::AppendLockClass::~AppendLockClass()
 	switch (index_buffer->Type()) {
 	case BUFFER_TYPE_DX8:
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(index_buffer)->index_buffer->Unlock());
+		if (static_cast<DX8IndexBufferClass*>(index_buffer)->index_buffer) {
+			DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(index_buffer)->index_buffer->Unlock());
+		}
 		break;
 	case BUFFER_TYPE_SORTING:
 		break;
@@ -283,10 +303,19 @@ IndexBufferClass::AppendLockClass::~AppendLockClass()
 
 DX8IndexBufferClass::DX8IndexBufferClass(unsigned short index_count_,UsageType usage)
 	:
-	IndexBufferClass(BUFFER_TYPE_DX8,index_count_)
+	IndexBufferClass(BUFFER_TYPE_DX8,index_count_),
+	index_buffer(NULL),
+	cpu_buffer(NULL)
 {
 	DX8_THREAD_ASSERT();
 	WWASSERT(index_count);
+
+	if (!DX8Wrapper::_Get_D3D_Device8()) {
+		cpu_buffer = new uint8_t[sizeof(WORD) * index_count];
+		memset(cpu_buffer, 0, sizeof(WORD) * index_count);
+		return;
+	}
+
 	unsigned usage_flags=
 		D3DUSAGE_WRITEONLY|
 		((usage&USAGE_DYNAMIC) ? D3DUSAGE_DYNAMIC : 0)|
@@ -338,8 +367,13 @@ DX8IndexBufferClass::DX8IndexBufferClass(unsigned short index_count_,UsageType u
 // ----------------------------------------------------------------------------
 
 DX8IndexBufferClass::~DX8IndexBufferClass()
-{
-	index_buffer->Release();
+{	if (cpu_buffer) {
+		free(cpu_buffer);
+		cpu_buffer = NULL;
+	}
+	if (index_buffer) {
+		index_buffer->Release();
+	}
 }
 
 // ----------------------------------------------------------------------------
@@ -431,12 +465,16 @@ DynamicIBAccessClass::WriteLockClass::WriteLockClass(DynamicIBAccessClass* ib_ac
 		WWASSERT(DynamicIBAccess);
 //		WWASSERT(!dynamic_dx8_index_buffer->Engine_Refs());
 		DX8_Assert();
-		DX8_ErrorCode(
-			static_cast<DX8IndexBufferClass*>(DynamicIBAccess->IndexBuffer)->Get_DX8_Index_Buffer()->Lock(
-			DynamicIBAccess->IndexBufferOffset*sizeof(WORD),
-			DynamicIBAccess->Get_Index_Count()*sizeof(WORD),
-			(void**)&Indices,
-			!DynamicIBAccess->IndexBufferOffset ? D3DLOCK_DISCARD : D3DLOCK_NOOVERWRITE));
+		if (static_cast<DX8IndexBufferClass*>(DynamicIBAccess->IndexBuffer)->Get_DX8_Index_Buffer()) {
+			DX8_ErrorCode(
+				static_cast<DX8IndexBufferClass*>(DynamicIBAccess->IndexBuffer)->Get_DX8_Index_Buffer()->Lock(
+				DynamicIBAccess->IndexBufferOffset*sizeof(WORD),
+				DynamicIBAccess->Get_Index_Count()*sizeof(WORD),
+				(void**)&Indices,
+				!DynamicIBAccess->IndexBufferOffset ? D3DLOCK_DISCARD : D3DLOCK_NOOVERWRITE));
+		} else {
+			Indices = static_cast<unsigned short*>(static_cast<DX8IndexBufferClass*>(DynamicIBAccess->IndexBuffer)->Get_CPU_Buffer()) + DynamicIBAccess->IndexBufferOffset;
+		}
 		break;
 	case BUFFER_TYPE_DYNAMIC_SORTING:
 		Indices=static_cast<SortingIndexBufferClass*>(DynamicIBAccess->IndexBuffer)->index_buffer;
@@ -454,7 +492,9 @@ DynamicIBAccessClass::WriteLockClass::~WriteLockClass()
 	switch (DynamicIBAccess->Get_Type()) {
 	case BUFFER_TYPE_DYNAMIC_DX8:
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(DynamicIBAccess->IndexBuffer)->Get_DX8_Index_Buffer()->Unlock());
+		if (static_cast<DX8IndexBufferClass*>(DynamicIBAccess->IndexBuffer)->Get_DX8_Index_Buffer()) {
+			DX8_ErrorCode(static_cast<DX8IndexBufferClass*>(DynamicIBAccess->IndexBuffer)->Get_DX8_Index_Buffer()->Unlock());
+		}
 		break;
 	case BUFFER_TYPE_DYNAMIC_SORTING:
 		break;

--- a/Code/ww3d2/dx8indexbuffer.h
+++ b/Code/ww3d2/dx8indexbuffer.h
@@ -47,6 +47,7 @@
 #include "wwdebug.h"
 #include "refcount.h"
 #include "sphere.h"
+#include <cstdint>
 
 class DX8Wrapper;
 class SortingRendererClass;
@@ -173,9 +174,11 @@ public:
 	void Copy(unsigned short* indices,unsigned start_index,unsigned index_count);
 
 	inline IDirect3DIndexBuffer9* Get_DX8_Index_Buffer()	{ return index_buffer; }
+	void* Get_CPU_Buffer() { return cpu_buffer; }
 
 private:
 	IDirect3DIndexBuffer9*	index_buffer;		// actual dx8 index buffer
+	void*					cpu_buffer;
 };
 
 

--- a/Code/ww3d2/dx8renderer.cpp
+++ b/Code/ww3d2/dx8renderer.cpp
@@ -2011,7 +2011,9 @@ void DX8MeshRendererClass::Flush(void)
 		Render_FVF_Category_Container_List(*texture_category_container_lists_rigid[i]);
 	}
 
-	Render_FVF_Category_Container_List(*texture_category_container_list_skin);
+	if (texture_category_container_list_skin) {
+		Render_FVF_Category_Container_List(*texture_category_container_list_skin);
+	}
 
 	Render_Decal_Meshes();
 

--- a/Code/ww3d2/dx8vertexbuffer.cpp
+++ b/Code/ww3d2/dx8vertexbuffer.cpp
@@ -46,7 +46,6 @@
 #include "wwmemlog.h"
 #include <d3dx9core.h>
 #include "ww3d.h"
-#include "ww3dbackend.h"
 
 #define DEFAULT_VB_SIZE 5000
 
@@ -102,10 +101,6 @@ VertexBufferClass::VertexBufferClass(unsigned type_, unsigned FVF, unsigned shor
 
 VertexBufferClass::~VertexBufferClass()
 {
-	if (WW3D::Get_Backend()) {
-		WW3D::Get_Backend()->Invalidate_Vertex_Buffer_Cache_Entry(this);
-	}
-
 	_VertexBufferCount--;
 	_VertexBufferTotalVertices-=VertexCount;
 	_VertexBufferTotalSize-=VertexCount*fvf_info->Get_FVF_Size();
@@ -429,7 +424,7 @@ DX8VertexBufferClass::~DX8VertexBufferClass()
 		VertexBuffer->Release();
 	}
 	if (cpu_buffer) {
-		free(cpu_buffer);
+		delete[] static_cast<uint8_t*>(cpu_buffer);
 		cpu_buffer = NULL;
 	}
 }
@@ -459,6 +454,12 @@ void DX8VertexBufferClass::Create_Vertex_Buffer(UsageType usage)
 	WWDEBUG_SAY(("Current vertex buffer count: %d\n",_DX8VertexBufferCount));
 #endif
 
+	if (!DX8Wrapper::_Get_D3D_Device8()) {
+		cpu_buffer = new uint8_t[FVF_Info().Get_FVF_Size() * VertexCount];
+		memset(cpu_buffer, 0, FVF_Info().Get_FVF_Size() * VertexCount);
+		return;
+	}
+
 	unsigned usage_flags=
 		D3DUSAGE_WRITEONLY|
 		((usage&USAGE_DYNAMIC) ? D3DUSAGE_DYNAMIC : 0)|
@@ -466,12 +467,6 @@ void DX8VertexBufferClass::Create_Vertex_Buffer(UsageType usage)
 		((usage&USAGE_SOFTWAREPROCESSING) ? D3DUSAGE_SOFTWAREPROCESSING : 0);
 	if (!DX8Wrapper::Get_Current_Caps()->Support_TnL()) {
 		usage_flags|=D3DUSAGE_SOFTWAREPROCESSING;
-	}
-
-	if (!DX8Wrapper::_Get_D3D_Device8()) {
-		cpu_buffer = new uint8_t[FVF_Info().Get_FVF_Size() * VertexCount];
-		memset(cpu_buffer, 0, FVF_Info().Get_FVF_Size() * VertexCount);
-		return;
 	}
 
 	HRESULT ret=DX8Wrapper::_Get_D3D_Device8()->CreateVertexBuffer(

--- a/Code/ww3d2/dx8vertexbuffer.cpp
+++ b/Code/ww3d2/dx8vertexbuffer.cpp
@@ -45,6 +45,8 @@
 #include "thread.h"
 #include "wwmemlog.h"
 #include <d3dx9core.h>
+#include "ww3d.h"
+#include "ww3dbackend.h"
 
 #define DEFAULT_VB_SIZE 5000
 
@@ -100,6 +102,10 @@ VertexBufferClass::VertexBufferClass(unsigned type_, unsigned FVF, unsigned shor
 
 VertexBufferClass::~VertexBufferClass()
 {
+	if (WW3D::Get_Backend()) {
+		WW3D::Get_Backend()->Invalidate_Vertex_Buffer_Cache_Entry(this);
+	}
+
 	_VertexBufferCount--;
 	_VertexBufferTotalVertices-=VertexCount;
 	_VertexBufferTotalSize-=VertexCount*fvf_info->Get_FVF_Size();
@@ -172,11 +178,15 @@ VertexBufferClass::WriteLockClass::WriteLockClass(VertexBufferClass* VertexBuffe
 		}
 #endif
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()->Lock(
-			0,
-			0,
-			(void**)&Vertices,
-			0));	// Default (no) flags
+		if (static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()) {
+			DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()->Lock(
+				0,
+				0,
+				(void**)&Vertices,
+				0));	// Default (no) flags
+		} else {
+			Vertices = static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_CPU_Buffer();
+		}
 		break;
 	case BUFFER_TYPE_SORTING:
 		Vertices=static_cast<SortingVertexBufferClass*>(VertexBuffer)->VertexBuffer;
@@ -198,7 +208,9 @@ VertexBufferClass::WriteLockClass::~WriteLockClass()
 		WWDEBUG_SAY(("VertexBuffer->Unlock()\n"));
 #endif
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()->Unlock());
+		if (static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()) {
+			DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()->Unlock());
+		}
 		break;
 	case BUFFER_TYPE_SORTING:
 		break;
@@ -238,11 +250,15 @@ VertexBufferClass::AppendLockClass::AppendLockClass(VertexBufferClass* VertexBuf
 		}
 #endif
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()->Lock(
-			start_index*VertexBuffer->FVF_Info().Get_FVF_Size(),
-			index_range*VertexBuffer->FVF_Info().Get_FVF_Size(),
-			(void**)&Vertices,
-			0));	// Default (no) flags
+		if (static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()) {
+			DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()->Lock(
+				start_index*VertexBuffer->FVF_Info().Get_FVF_Size(),
+				index_range*VertexBuffer->FVF_Info().Get_FVF_Size(),
+				(void**)&Vertices,
+				0));	// Default (no) flags
+		} else {
+			Vertices = (unsigned char*)static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_CPU_Buffer() + start_index * VertexBuffer->FVF_Info().Get_FVF_Size();
+		}
 		break;
 	case BUFFER_TYPE_SORTING:
 		Vertices=static_cast<SortingVertexBufferClass*>(VertexBuffer)->VertexBuffer+start_index;
@@ -264,7 +280,9 @@ VertexBufferClass::AppendLockClass::~AppendLockClass()
 #ifdef VERTEX_BUFFER_LOG
 		WWDEBUG_SAY(("VertexBuffer->Unlock()\n"));
 #endif
-		DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()->Unlock());
+		if (static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()) {
+			DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(VertexBuffer)->Get_DX8_Vertex_Buffer()->Unlock());
+		}
 		break;
 	case BUFFER_TYPE_SORTING:
 		break;
@@ -308,7 +326,8 @@ SortingVertexBufferClass::~SortingVertexBufferClass()
 DX8VertexBufferClass::DX8VertexBufferClass(unsigned FVF, unsigned short vertex_count_, UsageType usage)
 	:
 	VertexBufferClass(BUFFER_TYPE_DX8, FVF, vertex_count_),
-	VertexBuffer(NULL)
+	VertexBuffer(NULL),
+		cpu_buffer(NULL)
 {
 	Create_Vertex_Buffer(usage);
 }
@@ -323,7 +342,8 @@ DX8VertexBufferClass::DX8VertexBufferClass(
 	UsageType usage)
 	:
 	VertexBufferClass(BUFFER_TYPE_DX8, D3DFVF_XYZ|D3DFVF_TEX1|D3DFVF_NORMAL, VertexCount),
-	VertexBuffer(NULL)
+	VertexBuffer(NULL),
+		cpu_buffer(NULL)
 {
 	WWASSERT(vertices);
 	WWASSERT(normals);
@@ -344,7 +364,8 @@ DX8VertexBufferClass::DX8VertexBufferClass(
 	UsageType usage)
 	:
 	VertexBufferClass(BUFFER_TYPE_DX8, D3DFVF_XYZ|D3DFVF_TEX1|D3DFVF_NORMAL|D3DFVF_DIFFUSE, VertexCount),
-	VertexBuffer(NULL)
+	VertexBuffer(NULL),
+		cpu_buffer(NULL)
 {
 	WWASSERT(vertices);
 	WWASSERT(normals);
@@ -365,7 +386,8 @@ DX8VertexBufferClass::DX8VertexBufferClass(
 	UsageType usage)
 	:
 	VertexBufferClass(BUFFER_TYPE_DX8, D3DFVF_XYZ|D3DFVF_TEX1|D3DFVF_DIFFUSE, VertexCount),
-	VertexBuffer(NULL)
+	VertexBuffer(NULL),
+		cpu_buffer(NULL)
 {
 	WWASSERT(vertices);
 	WWASSERT(tex_coords);
@@ -384,7 +406,8 @@ DX8VertexBufferClass::DX8VertexBufferClass(
 	UsageType usage)
 	:
 	VertexBufferClass(BUFFER_TYPE_DX8, D3DFVF_XYZ|D3DFVF_TEX1, VertexCount),
-	VertexBuffer(NULL)
+	VertexBuffer(NULL),
+		cpu_buffer(NULL)
 {
 	WWASSERT(vertices);
 	WWASSERT(tex_coords);
@@ -402,7 +425,13 @@ DX8VertexBufferClass::~DX8VertexBufferClass()
 	_DX8VertexBufferCount--;
 	WWDEBUG_SAY(("Current vertex buffer count: %d\n",_DX8VertexBufferCount));
 #endif
-	VertexBuffer->Release();
+	if (VertexBuffer) {
+		VertexBuffer->Release();
+	}
+	if (cpu_buffer) {
+		free(cpu_buffer);
+		cpu_buffer = NULL;
+	}
 }
 
 // ----------------------------------------------------------------------------
@@ -437,6 +466,12 @@ void DX8VertexBufferClass::Create_Vertex_Buffer(UsageType usage)
 		((usage&USAGE_SOFTWAREPROCESSING) ? D3DUSAGE_SOFTWAREPROCESSING : 0);
 	if (!DX8Wrapper::Get_Current_Caps()->Support_TnL()) {
 		usage_flags|=D3DUSAGE_SOFTWAREPROCESSING;
+	}
+
+	if (!DX8Wrapper::_Get_D3D_Device8()) {
+		cpu_buffer = new uint8_t[FVF_Info().Get_FVF_Size() * VertexCount];
+		memset(cpu_buffer, 0, FVF_Info().Get_FVF_Size() * VertexCount);
+		return;
 	}
 
 	HRESULT ret=DX8Wrapper::_Get_D3D_Device8()->CreateVertexBuffer(
@@ -837,12 +872,16 @@ DynamicVBAccessClass::WriteLockClass::WriteLockClass(DynamicVBAccessClass* dynam
 //		WWASSERT(!_DynamicDX8VertexBuffer->Engine_Refs());
 
 		DX8_Assert();
-		// Lock with discard contents if the buffer offset is zero
-		DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(DynamicVBAccess->VertexBuffer)->Get_DX8_Vertex_Buffer()->Lock(
-			DynamicVBAccess->VertexBufferOffset*_DynamicDX8VertexBuffer->FVF_Info().Get_FVF_Size(),
-			DynamicVBAccess->Get_Vertex_Count()*DynamicVBAccess->VertexBuffer->FVF_Info().Get_FVF_Size(),
-			(void**)&Vertices,
-			D3DLOCK_NOSYSLOCK | (!DynamicVBAccess->VertexBufferOffset ? D3DLOCK_DISCARD : D3DLOCK_NOOVERWRITE)));
+		if (static_cast<DX8VertexBufferClass*>(DynamicVBAccess->VertexBuffer)->Get_DX8_Vertex_Buffer()) {
+			DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(DynamicVBAccess->VertexBuffer)->Get_DX8_Vertex_Buffer()->Lock(
+				DynamicVBAccess->VertexBufferOffset*_DynamicDX8VertexBuffer->FVF_Info().Get_FVF_Size(),
+				DynamicVBAccess->Get_Vertex_Count()*DynamicVBAccess->VertexBuffer->FVF_Info().Get_FVF_Size(),
+				(void**)&Vertices,
+				D3DLOCK_NOSYSLOCK | (!DynamicVBAccess->VertexBufferOffset ? D3DLOCK_DISCARD : D3DLOCK_NOOVERWRITE)));
+		} else {
+			Vertices = static_cast<VertexFormatXYZNDUV2*>(static_cast<DX8VertexBufferClass*>(DynamicVBAccess->VertexBuffer)->Get_CPU_Buffer());
+			Vertices += DynamicVBAccess->VertexBufferOffset;
+		}
 		break;
 	case BUFFER_TYPE_DYNAMIC_SORTING:
 		Vertices=static_cast<SortingVertexBufferClass*>(DynamicVBAccess->VertexBuffer)->VertexBuffer;
@@ -869,7 +908,9 @@ DynamicVBAccessClass::WriteLockClass::~WriteLockClass()
 */
 #endif
 		DX8_Assert();
-		DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(DynamicVBAccess->VertexBuffer)->Get_DX8_Vertex_Buffer()->Unlock());
+		if (static_cast<DX8VertexBufferClass*>(DynamicVBAccess->VertexBuffer)->Get_DX8_Vertex_Buffer()) {
+			DX8_ErrorCode(static_cast<DX8VertexBufferClass*>(DynamicVBAccess->VertexBuffer)->Get_DX8_Vertex_Buffer()->Unlock());
+		}
 		break;
 	case BUFFER_TYPE_DYNAMIC_SORTING:
 		break;

--- a/Code/ww3d2/dx8vertexbuffer.h
+++ b/Code/ww3d2/dx8vertexbuffer.h
@@ -46,6 +46,7 @@
 #include "always.h"
 #include "wwdebug.h"
 #include "refcount.h"
+#include <cstdint>
 #include "dx8fvf.h"
 
 const unsigned dynamic_fvf_type=D3DFVF_XYZ|D3DFVF_NORMAL|D3DFVF_TEX2|D3DFVF_DIFFUSE;
@@ -218,6 +219,7 @@ public:
 	DX8VertexBufferClass(const Vector3* vertices, const Vector2* tex_coords, unsigned short VertexCount,UsageType usage=USAGE_DEFAULT);
 
 	IDirect3DVertexBuffer9* Get_DX8_Vertex_Buffer() { return VertexBuffer; }
+	void* Get_CPU_Buffer() { return cpu_buffer; }
 
 	void Copy(const Vector3* loc, unsigned first_vertex, unsigned count);
 	void Copy(const Vector3* loc, const Vector2* uv, unsigned first_vertex, unsigned count);
@@ -228,6 +230,7 @@ public:
 
 protected:
 	IDirect3DVertexBuffer9*		VertexBuffer;
+	void*							cpu_buffer;
 
 	void Create_Vertex_Buffer(UsageType usage);
 };

--- a/Code/ww3d2/dx8wrapper.cpp
+++ b/Code/ww3d2/dx8wrapper.cpp
@@ -1593,6 +1593,9 @@ void DX8Wrapper::Clear(bool clear_color, bool clear_z_stencil, const Vector3 &co
 void DX8Wrapper::Set_Viewport(CONST D3DVIEWPORT9* pViewport)
 {
 	DX8_THREAD_ASSERT();
+	if (!D3DDevice) {
+		return;
+	}
 	DX8CALL(SetViewport(pViewport));
 }
 
@@ -3395,6 +3398,9 @@ const char* DX8Wrapper::Get_DX8_Blend_Op_Name(unsigned value)
 
 void DX8Wrapper::Set_DX8_ZBias(int zbias)
 {
+	if (!D3DDevice) {
+		return;
+	}
 	if (zbias==ZBias) return;
 	if (zbias>15) zbias=15;
 	if (zbias<0) zbias=0;
@@ -3417,6 +3423,9 @@ void DX8Wrapper::Set_DX8_ZBias(int zbias)
 
 void DX8Wrapper::Set_DX8_Render_State(D3DRENDERSTATETYPE state, unsigned value)
 {
+	if (!D3DDevice) {
+		return;
+	}
 	// Can't monitor state changes because setShader call to GERD may change the states!
 	if (RenderStates[state]==value) return;
 

--- a/Code/ww3d2/sortingrenderer.cpp
+++ b/Code/ww3d2/sortingrenderer.cpp
@@ -419,6 +419,9 @@ void SortingRendererClass::Insert_To_Sorting_Pool(SortingNodeStruct* state)
 
 static void Apply_Render_State(RenderStateStruct& render_state)
 {
+	if (!DX8Wrapper::_Get_D3D_Device8()) {
+		return;
+	}
 /*	state->sorting_state.shader.Apply();
 */
 	DX8Wrapper::Set_Shader(render_state.shader);


### PR DESCRIPTION
Adds defensive infrastructure for render backends that don't use D3D9 vertex/index buffers directly (BGFX, DXVK, etc.).

### Changes
- **DX8VertexBufferClass / DX8IndexBufferClass**: Add  for CPU-side staging, NULL-guard destructors/lock/unlock, bypass lock/unlock in  functions to write directly to  when no D3D9 buffer exists.
- **DX8Wrapper**: NULL-guard , ,  to prevent segfaults when  is null.
- **DX8Caps**: Add default constructor +  factory for backends that need capability bits without a real D3D device.
- **DX8MeshRendererClass::Flush()**: NULL-guard  to prevent crash when skin rendering hasn't been initialized.
- **SortingRendererClass::Apply_Render_State()**: Return early when  is null.

All changes are additive and defensive — zero impact on existing D3D9 builds.