### PR TITLE
Address some formatting issues in ICU build.

### DIFF
--- a/Code/Commando/ConsoleMode.cpp
+++ b/Code/Commando/ConsoleMode.cpp
@@ -322,7 +322,7 @@ void ConsoleModeClass::Print(char const * string, ...)
 		va_list va;
 
 		va_start(va, string);
-		vsprintf(&buffer[0], string, va);
+		u_vsnprintf_n(buffer, sizeof(buffer), string, va);
 		va_end(va);
 
 		/*
@@ -358,7 +358,7 @@ void ConsoleModeClass::Print_Maybe(char const * string, ...)
 		char buffer[8192];
 		va_list va;
 		va_start(va, string);
-		vsprintf(&buffer[0], string, va);
+		u_vsnprintf_n(buffer, sizeof(buffer), string, va);
 		va_end(va);
 		Log_To_Disk(buffer);
 
@@ -420,7 +420,7 @@ void ConsoleModeClass::cprintf(char const * string, ...)
 
 		buffer[sizeof(buffer)-1] = 0;
 		va_start(va, string);
-		vsnprintf(&buffer[0], sizeof(buffer)-1, string, va);
+		u_vsnprintf_n(buffer, sizeof(buffer)-1, string, va);
 		va_end(va);
 
 		/*

--- a/Code/wwdebug/wwdebug.cpp
+++ b/Code/wwdebug/wwdebug.cpp
@@ -44,6 +44,7 @@
 
 #include "wwdebug.h"
 #include "wwdialog.h"
+#include "unichar.h"
 #ifdef _WIN32
 #include <windows.h>
 #endif
@@ -211,7 +212,7 @@ void WWDebug_Printf(const char * format,...)
 		char buffer[4096];
 
 		va_start(va, format);
-		vsprintf(buffer, format, va);
+		u_vsnprintf_n(buffer, sizeof(buffer), format, va);
 		WWASSERT((strlen(buffer) < sizeof(buffer)));
 
 		_CurMessageHandler(WWDEBUG_TYPE_INFORMATION, buffer);
@@ -241,7 +242,7 @@ void WWDebug_Printf_Warning(const char * format,...)
 		char buffer[4096];
 
 		va_start(va, format);
-		vsprintf(buffer, format, va);
+		u_vsnprintf_n(buffer, sizeof(buffer), format, va);
 		WWASSERT((strlen(buffer) < sizeof(buffer)));
 
 		_CurMessageHandler(WWDEBUG_TYPE_WARNING, buffer);
@@ -271,7 +272,7 @@ void WWDebug_Printf_Error(const char * format,...)
 		char buffer[4096];
 
 		va_start(va, format);
-		vsprintf(buffer, format, va);
+		u_vsnprintf_n(buffer, sizeof(buffer), format, va);
 		WWASSERT((strlen(buffer) < sizeof(buffer)));
 
 		_CurMessageHandler(WWDEBUG_TYPE_ERROR, buffer);

--- a/Code/wwlib/icu/unichar.h
+++ b/Code/wwlib/icu/unichar.h
@@ -37,11 +37,11 @@ inline size_t u_mbtows(unichar_t* dst, const char* src, size_t len)
 	UErrorCode error = U_ZERO_ERROR;
 	u_strFromUTF8(dst, int32_t(len), &length, src, -1, &error);
 
-	if (U_FAILURE(error) || size_t(length) > len) {
+	if (size_t(length) > len) {
 		return size_t(-1);
 	}
 
-	return size_t(length);
+	return size_t(length) + 1;
 }
 
 inline size_t u_wstomb(char* dst, const unichar_t* src, size_t len)
@@ -50,11 +50,21 @@ inline size_t u_wstomb(char* dst, const unichar_t* src, size_t len)
 	UErrorCode error = U_ZERO_ERROR;
 	u_strToUTF8(dst, int32_t(len), &length, src, -1, &error);
 
-	if (U_FAILURE(error) || size_t(length) > len) {
+	if (size_t(length) > len) {
 		return size_t(-1);
 	}
 
-	return size_t(length);
+	return size_t(length) + 1;
+}
+
+inline int u_vsnprintf_n(char *buffer, const size_t buffer_count, const char *format, va_list args)
+{
+	// No char buffer that vsprintf is used for is larger than this in game.
+	unichar_t fmt_buffer[8192];
+	
+	// Maybe it truncated, maybe it didn't. If it did, it would have in the orignal code too or worse overflowed.
+	u_vsnprintf(fmt_buffer, sizeof(fmt_buffer) / sizeof(*fmt_buffer), format, args);
+	return int(u_wstomb(buffer, fmt_buffer, buffer_count));
 }
 
 #endif // UNICHAR_H

--- a/Code/wwlib/wchar/unichar.h
+++ b/Code/wwlib/wchar/unichar.h
@@ -41,6 +41,7 @@ typedef wchar_t unichar_t;
 #define u_strstr(x, y) wcsstr(x, y)
 #define u_snprintf_u(x, y, z, ...) swprintf(x, y, z, ##__VA_ARGS__)
 #define u_sscanf_u(x, y, ...) swscanf(x, y, ##__VA_ARGS__)
+#define u_vsnprintf_n(w, x, y, z) vsnprintf(w, x, y, z)
 
 #define U_COMPARE_CODE_POINT_ORDER 0x8000
 #define U_CHAR(str) (L##str)

--- a/Code/wwlib/widestring.cpp
+++ b/Code/wwlib/widestring.cpp
@@ -286,6 +286,34 @@ WideStringClass::Format (const unichar_t *format, ...)
 		return 0;
 	}
 
+#if W3D_USING_ICU
+	// If format exceeds this result will anyhow. 
+	unichar_t conv_buffer[512] = { 0 };
+	u_strncpy(conv_buffer, format, sizeof(conv_buffer) / sizeof(unichar_t));
+	conv_buffer[511] = U_CHAR('\0');
+
+	// Wide stdio classes on windows flip meaning of %s and %S relative to ICU so need to fix it here.
+	for (size_t i = 0; i < sizeof(conv_buffer) / sizeof(unichar_t) && conv_buffer[i] != U_CHAR('\0'); ++i)
+	{
+		if (conv_buffer[i] == U_CHAR('%')) {
+			++i;
+			if (conv_buffer[i] == U_CHAR('\0')) {
+				break;
+			}
+
+			if (conv_buffer[i] == U_CHAR('s')) {
+				conv_buffer[i] = U_CHAR('S');
+			}
+
+			if (conv_buffer[i] == U_CHAR('S')) {
+				conv_buffer[i] = U_CHAR('s');
+			}
+		}
+	}
+
+	format = conv_buffer;
+#endif
+
 	va_list arg_list;
 	va_start (arg_list, format);
 
@@ -333,41 +361,19 @@ WideStringClass::Release_Resources (void)
 bool WideStringClass::Convert_From (const char *text)
 {
 	if (text != NULL) {
-#ifdef W3D_USING_ICU
-		int32_t length;
-		UErrorCode error = U_ZERO_ERROR;
-		u_strFromUTF8(nullptr, 0, &length, text, -1, &error);
-		++length; // Add space for null termination as ICU does not include that in calculated length.
+		size_t length = u_mbtows(nullptr, text, 0);
 
-		if (length > 0) {
-			error = U_ZERO_ERROR;
-			u_strFromUTF8(Get_Buffer(length), length, nullptr, text, -1, &error);
+		if (length > 0 && length != size_t(-1)) {
+			length = u_mbtows(Get_Buffer(length), text, length);
 
-			if (U_SUCCESS(error)) {
+			if (length > 0 && length != size_t(-1)) {
 				Store_Length(length - 1);
-				return true;
+				return (true);
 			}
 		}
 
 		WWDEBUG_SAY(("Conversion from utf-8 to utf-16 failed\n"));
-#else
-		int length;
-
-		length = MultiByteToWideChar (CP_UTF8, 0, text, -1, NULL, 0);
-		if (length > 0) {
-
-			size_t wide_length = static_cast<size_t>(length);
-			Uninitialised_Grow(wide_length);
-			Store_Length(wide_length - 1);
-
-			// Convert.
-			MultiByteToWideChar (CP_UTF8, 0, text, -1, m_Buffer, length);
-
-			// Success.
-			return (true);
-		}
-#endif
-   }
+	}
 
 	// Failure.
 	return (false);

--- a/Code/wwlib/wwstring.cpp
+++ b/Code/wwlib/wwstring.cpp
@@ -249,7 +249,7 @@ StringClass::Format_Args (const char *format, va_list arg_list )
 	//	Format the string
 	//
 
-	retval = vsnprintf (temp_buffer, 512, format, arg_list);
+	retval = u_vsnprintf_n (temp_buffer, sizeof(temp_buffer), format, arg_list);
 
 	//
 	//	Copy the string into our buffer
@@ -280,7 +280,7 @@ StringClass::Format (const char *format, ...)
 	//
 	//	Format the string
 	//
-	retval = vsnprintf (temp_buffer, 512, format, arg_list);
+	retval = u_vsnprintf_n (temp_buffer, sizeof(temp_buffer), format, arg_list);
 
 	//
 	//	Copy the string into our buffer
@@ -310,44 +310,18 @@ StringClass::Release_Resources (void)
 bool StringClass::Copy_Wide (const unichar_t *source)
 {
 	if (source != NULL) {
-#ifdef W3D_USING_ICU
-		int32_t length;
-		UErrorCode error = U_ZERO_ERROR;
-		u_strToUTF8(nullptr, 0, &length, source, -1, &error);
-		++length; // Add space for null termination as ICU does not include that in calculated length.
+		size_t length = u_wstomb(nullptr, source, 0);
 
-		if (length > 0) {
-			error = U_ZERO_ERROR;
-			u_strToUTF8(Get_Buffer(length), length, nullptr, source, -1, &error);
+		if (length > 0 && length != size_t(-1)) {
+			length = u_wstomb(Get_Buffer(length), source, length);
 
-			if (U_SUCCESS(error)) {
+			if (length > 0 && length != size_t(-1)) {
 				Store_Length(length - 1);
 				return (true);
 			}
 		}
 
 		WWDEBUG_SAY(("Conversion from utf-16 to utf-8 failed\n"));
-#else
-		int  length;
-
-		length = WideCharToMultiByte (CP_UTF8, 0 , source, -1, nullptr, 0, nullptr, nullptr);
-		if (length > 0) {
-
-			size_t buffer_length = static_cast<size_t>(length);
-
-			// Convert.
-			length = WideCharToMultiByte(CP_UTF8, 0, source, -1, Get_Buffer(buffer_length), length, nullptr, nullptr);
-
-			// Update length.
-			Store_Length(buffer_length - 1);
-		}
-
-		if(length <= 0) {
-			WWDEBUG_SAY(("Conversion from utf-16 to utf-8 failed"));
-		}
-
-		return (length > 0);
-#endif
 	}
 
 	// Failure.


### PR DESCRIPTION
Win API switches meaning of %s and %S for its wide stdio functions while ICU does not. Some functions pass %S to narrow stdio functions which will give incorrect results on none windows platforms.