### PR TITLE
feature(freetype): Implement font rendering with freetype.

### DIFF
--- a/.github/workflows/openw3d.yml
+++ b/.github/workflows/openw3d.yml
@@ -109,7 +109,7 @@ jobs:
       if: ${{ !!matrix.linux }}
       run: |
         sudo apt update -qq > /dev/null
-        sudo apt install -qq libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libopenal-dev > /dev/null
+        sudo apt install -qq libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libopenal-dev libfreetype-dev > /dev/null
         wget --no-verbose \
           -O /tmp/dxvk-native.tar.gz \
           "https://github.com/doitsujin/dxvk/releases/download/v2.7.1/dxvk-native-2.7.1-steamrt-sniper.tar.gz"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,10 @@ add_feature_info(FFMpegBuild W3D_BUILD_OPTION_FFMPEG "Build OpenW3D with FFMpeg"
 cmake_dependent_option(W3D_BUILD_OPTION_OPENAL "Build with openal." ON W3D_BUILD_OPTION_FFMPEG OFF)
 add_feature_info(OpenALBuild W3D_BUILD_OPTION_OPENAL "Build OpenW3D with OpenAL")
 
+# Do we want to build with freetype and fontconfig for font rendering?
+cmake_dependent_option(W3D_BUILD_OPTION_FREETYPE "Build with freetype." OFF WIN32 ON)
+add_feature_info(FreetypeBuild W3D_BUILD_OPTION_FREETYPE "Build OpenW3D with freetype")
+
 option(W3D_BUILD_QT_TOOLS "Build Qt-based GUI tools." OFF)
 add_feature_info(QtTools W3D_BUILD_QT_TOOLS "Build Qt front-end tools")
 
@@ -89,6 +93,10 @@ add_compile_definitions(-DWEBBROWSER_ENABLED=$<BOOL:${W3D_BUILD_OPTION_WEBBROWSE
 
 if(W3D_BUILD_OPTION_OPENAL)
     include(openal)
+endif()
+
+if(W3D_BUILD_OPTION_FREETYPE)
+    include(freetype)
 endif()
 
 if(W3D_BUILD_QT_TOOLS)

--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -66,6 +66,10 @@ else()
     )
 endif()
 
+if(TARGET Freetype::Freetype AND TARGET Fontconfig::Fontconfig)
+    target_compile_definitions(wwcommon INTERFACE OPENW3D_FREETYPE_BUILD)
+endif()
+
 # Module static libraries
 add_subdirectory(WWAudio)
 add_subdirectory(BinkMovie)

--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -229,6 +229,10 @@ target_link_libraries(ww3d2 PRIVATE
     winmm
 )
 
+if(TARGET Freetype::Freetype AND TARGET Fontconfig::Fontconfig)
+    target_link_libraries(ww3d2 PUBLIC Freetype::Freetype Fontconfig::Fontconfig)
+endif()
+
 target_sources(ww3d2 PRIVATE ${WW3D2_SRC})
 
 # This module needs building differently for the level editor
@@ -242,6 +246,10 @@ if (W3D_TOOLS)
         vfw32
         winmm
     )
+
+    if(TARGET Freetype::Freetype AND TARGET Fontconfig::Fontconfig)
+        target_link_libraries(ww3d2e PUBLIC Freetype::Freetype Fontconfig::Fontconfig)
+    endif()
 
     target_compile_definitions(ww3d2e PRIVATE PARAM_EDITING_ON)
 

--- a/Code/ww3d2/assetmgr.cpp
+++ b/Code/ww3d2/assetmgr.cpp
@@ -1320,6 +1320,15 @@ FontCharsClass *	WW3DAssetManager::Get_FontChars( const char * name, int point_s
 	return font;							// return it
 }
 
+void WW3DAssetManager::Add_Font( const char * filename )
+{
+	FontCharsClass::Add_Font(filename);
+}
+
+void WW3DAssetManager::Remove_Font( const char * filename )
+{
+	FontCharsClass::Remove_Font(filename);
+}
 
 /***********************************************************************************************
  * WW3DAssetManager::Release_All_FontChars -- Release all FontChars from the asset manager     *

--- a/Code/ww3d2/assetmgr.h
+++ b/Code/ww3d2/assetmgr.h
@@ -277,6 +277,8 @@ public:
 	** Access to FontChars. Used by Render2DSentenceClass
 	*/
 	virtual FontCharsClass *		Get_FontChars( const char * name, int point_size, bool is_bold = false );
+	virtual void								Add_Font( const char * filename );
+	virtual void								Remove_Font( const char * filename );
 
 	/*
 	** Access to HTrees, Used by Animatable3DObj's

--- a/Code/ww3d2/render2dsentence.cpp
+++ b/Code/ww3d2/render2dsentence.cpp
@@ -42,6 +42,21 @@
 #include "dx8wrapper.h"
 #include <algorithm>
 
+#ifdef OPENW3D_FREETYPE_BUILD
+// freeetype implementation adapted from https://github.com/Fighter19/CnC_Generals_Zero_Hour/commit/e99e2dcf0a61169363f09897dc0748705256ae58
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_SFNT_NAMES_H
+#include FT_TRUETYPE_IDS_H
+
+std::unordered_map<std::string, std::string> FontCharsClass::FontFiles;
+
+static void LogFtError([[maybe_unused]] const char *text, [[maybe_unused]] FT_Error error)
+{
+    WWDEBUG_SAY(("%s: %s\n", text, FT_Error_String(error)));
+}
+#endif
+
 
 ////////////////////////////////////////////////////////////////////////////////////
 //	Local constants
@@ -1028,12 +1043,19 @@ void	Render2DSentenceClass::Force_Alpha( float alpha )
 //
 ////////////////////////////////////////////////////////////////////////////////////
 FontCharsClass::FontCharsClass (void) :
+#ifdef OPENW3D_FREETYPE_BUILD
+	CharAscent(0),
+	PixelOverlap(0),
+	FtLibrary(	NULL ),
+	FtFace(	NULL ),
+#elif defined _WIN32
 	OldGDIFont(	NULL ),
 	OldGDIBitmap( NULL ),
 	GDIFont( NULL ),
 	GDIBitmap( NULL ),
 	GDIBitmapBits ( NULL ),
 	MemDC( NULL ),
+#endif
 	CurrPixelOffset( 0 ),
 	PointSize( 0 ),
 	CharHeight( 0 ),
@@ -1044,6 +1066,13 @@ FontCharsClass::FontCharsClass (void) :
 	BufferList(sizeof(PreAllocatedBufferList)/sizeof(uint16*),PreAllocatedBufferList)
 {
 	::memset( ASCIICharArray, 0, sizeof (ASCIICharArray) );
+
+#ifdef OPENW3D_FREETYPE_BUILD
+	FT_Error error = FT_Init_FreeType(&FtLibrary);
+	if (error != FT_Err_Ok) {
+		WWDEBUG_SAY(("Failed to initialize freetype library\n"));
+	}
+#endif
 	return ;
 }
 
@@ -1059,8 +1088,11 @@ FontCharsClass::~FontCharsClass (void)
 		delete [] BufferList[i];
 	}
 	BufferList.Reset_Active();
-
+#ifdef OPENW3D_FREETYPE_BUILD
+	Free_Freetype_Font();
+#elif defined _WIN32
 	Free_GDI_Font();
+#endif
 	Free_Character_Arrays();
 	return ;
 }
@@ -1087,7 +1119,11 @@ FontCharsClass::Get_Char_Data (unichar_t ch)
 	//	If the character wasn't found, then add it to our list
 	//
 	if ( retval == NULL ) {
+#ifdef OPENW3D_FREETYPE_BUILD
+		retval = Store_Freetype_Char( ch );
+#elif defined _WIN32
 		retval = Store_GDI_Char( ch );
+#endif
 	}
 
 	WWASSERT( retval->Value == ch );
@@ -1163,7 +1199,80 @@ FontCharsClass::Blit_Char (unichar_t ch, uint16 *dest_ptr, int dest_stride, int 
 	return ;
 }
 
+#ifdef OPENW3D_FREETYPE_BUILD
+const FontCharsClass::CharDataStruct *FontCharsClass::Store_Freetype_Char(unichar_t ch)
+{
+    WWASSERT_PRINT(FtFace != nullptr, "FreetypeFace not initialized");
+    FT_UInt glyph_index = FT_Get_Char_Index(FtFace, ch);
+    // load glyph image into the slot (erase previous one)
+    FT_Error error = FT_Load_Glyph(FtFace, glyph_index, FT_LOAD_DEFAULT);
+    if (error) {
+        WWDEBUG_SAY(("Failed to load character(%i) from font\n", ch));
+        return nullptr;
+    }
+    // convert to an anti-aliased bitmap
+    error = FT_Render_Glyph(FtFace->glyph, FT_RENDER_MODE_NORMAL);
+    if (error) {
+			WWDEBUG_SAY(("Failed to render character(%i) from font\n", ch));
+			return nullptr;
+    }
+    int x_pos = 0;
+    if (ch == 'W') {
+        x_pos = 1;
+    }
+    unsigned int char_width = FtFace->glyph->advance.x >> 6;
+    // Sometimes for some reason the bitmap is wider than the advancement.
+    // This does not work with this font rendering approach
+    if (char_width < FtFace->glyph->bitmap.width + FtFace->glyph->bitmap_left) {
+        char_width = FtFace->glyph->bitmap.width + FtFace->glyph->bitmap_left;
+    }
+    char_width += PixelOverlap + x_pos;
 
+		//
+		//	Get a pointer to the surface that this character should use
+		//
+    Update_Current_Buffer(char_width);
+    uint16* curr_buffer_p = BufferList[BufferList.Count () - 1];
+		curr_buffer_p += CurrPixelOffset;
+    // We might need a memset
+
+    int x_offset = FtFace->glyph->bitmap_left;
+    int descent = (CharHeight - CharAscent) / 2;
+    int y_offset = (CharHeight - FtFace->glyph->bitmap_top) - descent ;
+
+    // Render the bitmap
+    unsigned int cols_to_render = std::min(FtFace->glyph->bitmap.width + x_offset, char_width) - x_offset;
+    unsigned int rows_to_render = std::min(FtFace->glyph->bitmap.rows + y_offset, (unsigned int)CharHeight) - y_offset;
+    for (unsigned int row = 0; row < rows_to_render; row++) {
+        int index = row * FtFace->glyph->bitmap.pitch;
+        int dst_index = (y_offset + row) * char_width;
+        for (unsigned int col = 0u; col < cols_to_render; col++) {
+            uint8_t pixel_value = FtFace->glyph->bitmap.buffer[index + col];
+            uint16_t pixel_color = 0;
+
+            if (pixel_value != 0) {
+                pixel_color = 0x0FFF;
+            }
+
+            curr_buffer_p[dst_index + x_offset + col] = pixel_color | ((pixel_value >> 4) << 12);
+        }
+    }
+
+    CharDataStruct *char_data = new CharDataStruct;
+    char_data->Value = ch;
+    char_data->Width = (int16_t)char_width;
+    char_data->Buffer = BufferList[BufferList.Count () - 1] + CurrPixelOffset;
+
+    if (ch < 256) {
+        ASCIICharArray[ch] = char_data;
+    } else {
+        UnicodeCharArray[ch - FirstUnicodeChar] = char_data;
+    }
+
+    CurrPixelOffset += (char_width * CharHeight);
+    return char_data;
+}
+#elif defined _WIN32
 ////////////////////////////////////////////////////////////////////////////////////
 //
 //	Store_GDI_Char
@@ -1267,7 +1376,7 @@ FontCharsClass::Store_GDI_Char (unichar_t ch)
 	//
 	return char_data;
 }
-
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////
 //
@@ -1296,6 +1405,7 @@ FontCharsClass::Update_Current_Buffer (int char_width)
 	//
 	if (needs_new_buffer) {
 		uint16 *new_buffer = new uint16[CHAR_BUFFER_LEN];
+		memset(new_buffer, 0, sizeof(uint16) * CHAR_BUFFER_LEN);
 		BufferList.Add( new_buffer );
 		CurrPixelOffset = 0;
 	}
@@ -1303,6 +1413,153 @@ FontCharsClass::Update_Current_Buffer (int char_width)
 	return ;
 }
 
+#ifdef OPENW3D_FREETYPE_BUILD
+void FontCharsClass::Add_Font(const char *filename)
+{
+	FT_Library lib;
+	FT_Face face;
+	FT_Init_FreeType(&lib);
+	FT_Error error = FT_Init_FreeType(&lib);
+
+	if (error != FT_Err_Ok) {
+		WWDEBUG_SAY(("Failed to initialize freetype library\n"));
+	}
+
+	error = FT_New_Face(lib, filename, 0, &face);
+	if (error != FT_Err_Ok) {
+			LogFtError("Failed to load Freetype face from file", error);
+			FT_Done_FreeType(lib);
+			return;
+	}
+	
+	
+	FT_UInt name_count = FT_Get_Sfnt_Name_Count(face);
+	std::string font_name;
+
+	// get family
+	for (unsigned i = 0; i < name_count; ++i) {
+		FT_SfntName name;
+		FT_Get_Sfnt_Name(face, i, &name);
+
+		if(name.name_id == TT_NAME_ID_FONT_FAMILY && *name.string != '\0') {
+			font_name.append(
+				reinterpret_cast<char *>(name.string),
+				name.string_len);
+			break;
+		}
+	}
+
+	WWDEBUG_SAY(("Loaded font called '%s' from file at '%s'\n", font_name.c_str(), filename));
+	
+	auto it = FontFiles.find(font_name);
+
+	if (it == FontFiles.end()) {
+		FontFiles[font_name] = filename;
+	}
+
+	FT_Done_Face(face);
+	FT_Done_FreeType(lib);
+}
+
+void FontCharsClass::Remove_Font(const char *filename)
+{
+	for (auto &it : FontFiles) {
+		if (it.second == filename) {
+			FontFiles.erase(it.first);
+			return;
+		}
+	}
+}
+
+bool FontCharsClass::Locate_Font_FontConfig(const char *font_name, StringClass &font_file_path)
+{
+	font_file_path = FontFiles[font_name].c_str();
+	WWDEBUG_SAY(("Found font file '%s' for font '%s\n", font_file_path.Peek_Buffer(), font_name));
+	if (!font_file_path.Is_Empty()) {
+		return true;
+	}
+
+    return false;
+}
+
+bool FontCharsClass::Locate_Font(const char *font_name, StringClass &font_file_path)
+{
+    return Locate_Font_FontConfig(font_name, font_file_path);
+}
+
+void FontCharsClass::Create_Freetype_Font(const char *font_name)
+{
+	//
+	//	Calculate the height of the font in logical units
+	//
+	const int dotsPerInch = 96; // always use 96.	jba.
+	int font_height = FT_MulDiv (PointSize, dotsPerInch, 72);
+	PixelOverlap = (-font_height)/8;
+
+	// Sanity check in case of perversion. :)
+	if (PixelOverlap<0) PixelOverlap = 0;
+	if (PixelOverlap>4) PixelOverlap = 4;
+
+	//
+	//	Locate the font
+	//
+	StringClass font_file_path;
+	if (!Locate_Font(font_name, font_file_path)) {
+			WWDEBUG_SAY(("Failed to locate font: %s\n", font_name));
+			font_name = "Arial";
+			WWDEBUG_SAY(("Trying '%s' as a fallback\n", font_name));
+			if (!Locate_Font(font_name, font_file_path)) {
+					WWDEBUG_SAY(("Failed to find fallback font: %s\n", font_name));
+					return;
+			}
+	}
+
+	//
+	//	Create the Freetype font
+	//
+	FT_Error error = FT_New_Face(FtLibrary, font_file_path, 0, &FtFace);
+	if (error != FT_Err_Ok) {
+			LogFtError("Failed to load Freetype face from file", error);
+			return;
+	}
+
+	error = FT_Set_Pixel_Sizes(FtFace, 0, font_height);
+	if (error != FT_Err_Ok) {
+			LogFtError("Failed to set character size", error);
+			return;
+	}
+
+	// Use the same metric calculation as Wine does in their GDI emulation layer
+	// See https://github.com/NVIDIA/winex_lgpl/blob/master/winex/dlls/gdi/freetype.c#L3027
+	if (FT_IS_SCALABLE(FtFace)) {
+			CharAscent = FT_MulFix(FtFace->ascender, FtFace->size->metrics.y_scale) >> 6;
+			int descent = -FT_MulFix(FtFace->descender, FtFace->size->metrics.y_scale) >> 6;
+			CharHeight = CharAscent + descent;
+	} else {
+			WWDEBUG_SAY(("Require a scalable font. Font=%s\n", font_name));
+	}
+}
+
+void FontCharsClass::Free_Freetype_Font()
+{
+	if (FtFace != nullptr) {
+			FT_Done_Face(FtFace);
+	}
+	if (FtLibrary != nullptr) {
+			FT_Done_FreeType(FtLibrary);
+	}
+}
+#elif defined _WIN32
+
+void FontCharsClass::Add_Font(const char *filename)
+{
+	::AddFontResourceA(filename);
+}
+
+void FontCharsClass::Remove_Font(const char *filename)
+{
+	::RemoveFontResourceA(filename);
+}
 
 ////////////////////////////////////////////////////////////////////////////////////
 //
@@ -1449,7 +1706,7 @@ FontCharsClass::Free_GDI_Font (void)
 
 	return ;
 }
-
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////////
 //
@@ -1474,7 +1731,11 @@ FontCharsClass::Initialize_GDI_Font (const char *font_name, int point_size, bool
 	//
 	//	Create the actual font object
 	//
+#ifdef OPENW3D_FREETYPE_BUILD
+	Create_Freetype_Font (font_name);
+#elif defined _WIN32
 	Create_GDI_Font (font_name);
+#endif
 	return ;
 }
 

--- a/Code/ww3d2/render2dsentence.h
+++ b/Code/ww3d2/render2dsentence.h
@@ -53,6 +53,14 @@
 */
 class	SurfaceClass;
 
+#ifdef OPENW3D_FREETYPE_BUILD
+#include <unordered_map>
+struct FT_LibraryRec_;
+typedef struct FT_LibraryRec_ *FT_Library;
+struct FT_FaceRec_;
+typedef struct FT_FaceRec_ *FT_Face;
+#endif
+
 class FontCharsClass : public RefCountClass {
 
 public:
@@ -69,6 +77,8 @@ public:
 
 	void	Blit_Char( unichar_t ch, uint16 *dest_ptr, int dest_stride, int x, int y );
 
+	static void Add_Font(const char *filename);
+	static void Remove_Font(const char *filename);
 private:
 
 	//
@@ -83,9 +93,18 @@ private:
 	//
 	//	Private methods
 	//
+	bool 							Locate_Font(const char *font_name, StringClass &font_file_path);
+	#ifdef OPENW3D_FREETYPE_BUILD
+	bool 							Locate_Font_FontConfig(const char *font_name, StringClass &font_file_path);
+	void 							Create_Freetype_Font(const char *font_name);
+	void 							Free_Freetype_Font();
+	const FontCharsClass::CharDataStruct *Store_Freetype_Char( unichar_t ch);
+	#elif defined _WIN32
 	void							Create_GDI_Font( const char *font_name );
 	void							Free_GDI_Font( void );
 	const CharDataStruct *	Store_GDI_Char( unichar_t ch );
+	#endif
+
 	void							Update_Current_Buffer( int char_width );
 	const CharDataStruct	*	Get_Char_Data( unichar_t ch );
 
@@ -102,12 +121,20 @@ private:
 	int									CharHeight;
 	int									PointSize;
 	StringClass							GDIFontName;
+#ifdef OPENW3D_FREETYPE_BUILD
+	static std::unordered_map<std::string, std::string> FontFiles;
+	int CharAscent;
+	int PixelOverlap;
+	FT_Library FtLibrary;
+	FT_Face FtFace;
+#elif defined _WIN32
 	HFONT									OldGDIFont;
 	HBITMAP								OldGDIBitmap;
 	HBITMAP								GDIBitmap;
 	HFONT									GDIFont;
 	uint8 *								GDIBitmapBits;
 	HDC									MemDC;
+#endif
 	CharDataStruct *					ASCIICharArray[256];
 	CharDataStruct **					UnicodeCharArray;
 	unichar_t								FirstUnicodeChar;

--- a/Code/wwui/stylemgr.cpp
+++ b/Code/wwui/stylemgr.cpp
@@ -225,7 +225,7 @@ StyleMgrClass::Initialize_From_INI (const char *filename)
 			//
 			//	Install the font into windows
 			//
-			::AddFontResourceA (font_filename);
+			WW3DAssetManager::Get_Instance()->Add_Font(font_filename);
 			FontFileList.Add (font_filename);
 		}
 
@@ -317,7 +317,7 @@ StyleMgrClass::Shutdown (void)
 	//	Unregister this font with windows
 	//
 	for (index = 0; index < FontFileList.Count (); index ++) {
-		::RemoveFontResourceA (FontFileList[index]);
+		WW3DAssetManager::Get_Instance()->Remove_Font(FontFileList[index]);
 	}
 
 	//

--- a/cmake/freetype.cmake
+++ b/cmake/freetype.cmake
@@ -1,0 +1,1 @@
+find_package(Freetype REQUIRED)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
     "icu",
     "openal-soft",
     "sdl3",
+    "freetype",
     "qtbase",
     "qttools",
     "qtimageformats",


### PR DESCRIPTION
Loads fonts from game directory as directed by stylemgr.ini, assume all needed fonts will be shipped with the game data.

Code ported from feliwirs work at https://github.com/Fighter19/CnC_Generals_Zero_Hour/commit/e99e2dcf0a61169363f09897dc0748705256ae58
