### PR TITLE
Silence MSVC C4456 warnings.

### DIFF
--- a/.github/workflows/openw3d.yml
+++ b/.github/workflows/openw3d.yml
@@ -23,7 +23,7 @@ jobs:
             cmake-args: -GNinja -DCMAKE_BUILD_TYPE=Release
             shell: pwsh
             arch: x86
-            options: "/W4;/WX;/wd4244;/wd4456"
+            options: "/W4;/WX;/wd4244"
           - name: MSVC x64
             os: windows-latest
             cmake-args: -GNinja -DCMAKE_BUILD_TYPE=Release

--- a/Code/BandTest/BandTest.cpp
+++ b/Code/BandTest/BandTest.cpp
@@ -802,7 +802,7 @@ unsigned int Upstream_Detect(unsigned int server_ip, unsigned int my_ip, int &fa
 			if (ttl > max_ttl) {
 				ttl = base_ttl;
 			}
-			int result = setsockopt(test_socket, IPPROTO_IP, IP_TTL, (char*)&ttl, sizeof(ttl));
+			result = setsockopt(test_socket, IPPROTO_IP, IP_TTL, (char*)&ttl, sizeof(ttl));
 			if (result == SOCKET_ERROR) {
 				DebugString("setsockopt failed to set IP_TTL = %d on test socket - error code %d\n", ttl, WSAGetLastError());
 				failure_code = BANDTEST_NO_TTL_SET;
@@ -1059,7 +1059,7 @@ unsigned int Upstream_Detect(unsigned int server_ip, unsigned int my_ip, int &fa
 		** Set the TTL back to max.
 		*/
 		int new_ttl = 255;
-		int result = setsockopt(ICMPRawSocket, IPPROTO_IP, IP_TTL, (char*)&new_ttl, sizeof(new_ttl));
+		result = setsockopt(ICMPRawSocket, IPPROTO_IP, IP_TTL, (char*)&new_ttl, sizeof(new_ttl));
 		if (result == SOCKET_ERROR) {
 			DebugString("setsockopt failed to set IP_TTL = %d - error code %d\n", new_ttl, WSAGetLastError());
 			failure_code = BANDTEST_NO_TTL_SET;
@@ -1084,7 +1084,7 @@ unsigned int Upstream_Detect(unsigned int server_ip, unsigned int my_ip, int &fa
 			** Do more pings if the ping time is low. User a smaller timeout too.
 			*/
 			int num_pings = 15;
-			unsigned int timeout = ping_times[0] * 3;
+			timeout = ping_times[0] * 3;
 			if (ping_times[0] < 100) {
 				num_pings = 50;
 				timeout = 200;

--- a/Code/Combat/WeatherMgr.cpp
+++ b/Code/Combat/WeatherMgr.cpp
@@ -492,8 +492,6 @@ bool WeatherSystemClass::Update (WindClass *wind, const Vector3 &cameraposition)
 	Vector3				minrayendposition;
 	float					l, boxoffset;
 	ParticleStruct	  *particleptr;
-	float					s;
-	unsigned				spawncount;
 	float					time;
 
 	oldemitterposition = EmitterPosition;
@@ -810,8 +808,8 @@ bool WeatherSystemClass::Update (WindClass *wind, const Vector3 &cameraposition)
 
 	// Spawn any new particles that need to be spawned on this update.
 	// NOTE: For accuracy, accumulate fractional spawncounts so that they can be used on a later iteration.
-	s = Spawn_Count (time);
-	spawncount = floor (s);
+	float s = Spawn_Count (time);
+	unsigned spawncount = floor (s);
 	SpawnCountFraction += s - spawncount;
 	if (SpawnCountFraction >= 1.0f) {
 		SpawnCountFraction -= 1.0f;

--- a/Code/Combat/action.cpp
+++ b/Code/Combat/action.cpp
@@ -1826,7 +1826,7 @@ public:
 	// Attack the given absolute position, return nothing
 	void	Attack_Absolute( Vector3 & abs_pos )
 	{
-		WWPROFILE( "Attack Absolute" );
+		WWPROFILENAMED( "Attack Absolute", top );
 		IsAttacking = true;
 
 		float range = Action->Get_Parameters().AttackRange;

--- a/Code/Combat/backgroundmgr.cpp
+++ b/Code/Combat/backgroundmgr.cpp
@@ -635,10 +635,10 @@ void StarfieldClass::Render()
 			DynamicVBAccessClass::WriteLockClass lock (&dynamicvb);
 			VertexFormatXYZNDUV2 *vertex = lock.Get_Formatted_Vertex_Array();
 
-			for (unsigned v = 0; v < ActiveVertexCount; v += VERTICES_PER_TRIANGLE) {
+			for (v = 0; v < ActiveVertexCount; v += VERTICES_PER_TRIANGLE) {
 				for (unsigned t = 0; t < VERTICES_PER_TRIANGLE; t++) {
 
-					unsigned i = v + t;
+					i = v + t;
 
 					vertex->x		 = VertexArray [i].X;
 					vertex->y		 = VertexArray [i].Y;

--- a/Code/Combat/basecontroller.cpp
+++ b/Code/Combat/basecontroller.cpp
@@ -614,9 +614,9 @@ BaseControllerClass::Request_Harvester (int def_id)
 	//
 	//	Find our vehicle factory
 	//
-	BuildingGameObj *building = Find_Building (TYPE_VEHICLE_FACTORY);
-	if (building != NULL) {
-		VehicleFactoryGameObj *factory = building->As_VehicleFactoryGameObj ();
+	BuildingGameObj *factory_building = Find_Building (TYPE_VEHICLE_FACTORY);
+	if (factory_building != NULL) {
+		VehicleFactoryGameObj *factory = factory_building->As_VehicleFactoryGameObj ();
 
 		//
 		//	If we have a vehicle factory that isn't busy, then start building a harvester
@@ -629,9 +629,9 @@ BaseControllerClass::Request_Harvester (int def_id)
 
 		//	Find our refinery (if we have one)
 		//
-		BuildingGameObj *building = Find_Building (TYPE_REFINERY);
-		if (building != NULL) {
-			RefineryGameObj *refinery = building->As_RefineryGameObj ();
+		BuildingGameObj *refinery_building = Find_Building (TYPE_REFINERY);
+		if (refinery_building != NULL) {
+			RefineryGameObj *refinery = refinery_building->As_RefineryGameObj ();
 
 			//
 			//	If there is no vehicle factory in this level, then

--- a/Code/Combat/bullet.cpp
+++ b/Code/Combat/bullet.cpp
@@ -399,9 +399,9 @@ CollisionReactionType BulletDataClass::Bullet_Collision_Occurred( const Collisio
 				)
 			{
 				DamageableStaticPhysClass * damphys = (DamageableStaticPhysClass *)event.OtherObj;
-				OffenseObjectClass offense( AmmoDefinition->Damage, (int)AmmoDefinition->Warhead, Get_Owner() );
-				offense.EnableClientDamage = true;	// Only bullets apply to client damage;
-				damphys->Apply_Damage_Static( offense );
+				OffenseObjectClass static_offense( AmmoDefinition->Damage, (int)AmmoDefinition->Warhead, Get_Owner() );
+				static_offense.EnableClientDamage = true;	// Only bullets apply to client damage;
+				damphys->Apply_Damage_Static( static_offense );
 			}
 
 			// check for a non-stopping surface
@@ -824,12 +824,12 @@ void	BulletClass::Think( void )
 
 				cross.Normalize();
 				Matrix3D tm(cross,angle);
-				Vector3	current_vector;
-				Projectile->Get_Velocity( &current_vector );
-				WWASSERT(current_vector.Is_Valid());
-				current_vector = tm.Rotate_Vector( current_vector );
-				WWASSERT(current_vector.Is_Valid());
-				Projectile->Set_Velocity( current_vector );
+				Vector3	turn_vector;
+				Projectile->Get_Velocity( &turn_vector );
+				WWASSERT(turn_vector.Is_Valid());
+				turn_vector = tm.Rotate_Vector( turn_vector );
+				WWASSERT(turn_vector.Is_Valid());
+				Projectile->Set_Velocity( turn_vector );
 			}
 		}
 	}
@@ -840,7 +840,7 @@ void	BulletClass::Think( void )
 */
 void	Simulate_Instant_Bullet( BulletDataClass & data, float /* progress_time */ )
 {
-	WWPROFILE("Simulate_Instant_Bullet");
+	WWPROFILENAMED("Simulate_Instant_Bullet", top);
 //	WWASSERT(data.Position.Is_Valid());
 //	WWASSERT(data.Velocity.Is_Valid());
 

--- a/Code/Combat/c4.cpp
+++ b/Code/Combat/c4.cpp
@@ -782,12 +782,12 @@ void	C4GameObj::Import_Rare( BitStreamClass &packet )
 		packet.Get(pos.X, BITPACK_WORLD_POSITION_X);
 		packet.Get(pos.Y, BITPACK_WORLD_POSITION_Y);
 		packet.Get(pos.Z, BITPACK_WORLD_POSITION_Z);
-		ProjectileClass * po = Peek_Physical_Object()->As_ProjectileClass();
-		if ( po )  {
+		ProjectileClass * stuck_po = Peek_Physical_Object()->As_ProjectileClass();
+		if ( stuck_po )  {
 			Vector3 local_pos;
-			po->Get_Position(&local_pos);
+			stuck_po->Get_Position(&local_pos);
 			if ((local_pos - pos).Length2() > 0.5f * 0.5f) {
-				po->Set_Position(pos);
+				stuck_po->Set_Position(pos);
 			}
 		}
 		WWDEBUG_SAY(("C4 %p is now STUCK, pos= %f, %f, %f", this, pos.X,pos.Y,pos.Z));

--- a/Code/Combat/ccamera.cpp
+++ b/Code/Combat/ccamera.cpp
@@ -979,7 +979,7 @@ void CCameraClass::Update()
 */
 bool	CCameraClass::Determine_Targeting_Position( void )
 {
-	WWPROFILE( "Determining Targeting" );
+	WWPROFILENAMED( "Determining Targeting", top );
 	bool	looking_at_object = false;
 
 	Matrix3D tm = Get_Transform();
@@ -1127,7 +1127,7 @@ bool	CCameraClass::Determine_Targeting_Position( void )
 
 void	CCameraClass::Apply_Weapon_Help( void )
 {
-	WWPROFILE( "Weapon Help" );
+	WWPROFILENAMED( "Weapon Help", top );
 	WeaponHelpTimer -= TimeManager::Get_Frame_Seconds();
 	if ( WeaponHelpTimer <= 0 ) {
 

--- a/Code/Combat/combat.cpp
+++ b/Code/Combat/combat.cpp
@@ -666,7 +666,7 @@ void 	CombatManager::Think()
 {
 	SyncTime += (int)((TimeManager::Get_Frame_Seconds() * 1000.0f) + 0.5f);
 
-	WWPROFILE( "CombatManager Think" );
+	WWPROFILENAMED( "CombatManager Think", top );
 
 	IsGameplayPermitted=NetworkHandler->Is_Gameplay_Permitted();
 
@@ -1058,7 +1058,7 @@ void CombatManager::Update_Star( void )
 
 void CombatManager::Update_Star_Targeting( void )
 {
-	WWPROFILE( "Targeting" );
+	WWPROFILENAMED( "Targeting", top );
 	SmartGameObj * star = NULL;
 
 	if ( COMBAT_STAR != NULL ) {
@@ -1279,9 +1279,9 @@ void	CombatManager::Update_Combat_Mode( void )
 			}
 #endif
 
-			Vector3	pos;
-			vehicle->Get_Position( &pos );
-			COMBAT_CAMERA->Set_Anchor_Position( pos );
+			Vector3	vehicle_pos;
+			vehicle->Get_Position( &vehicle_pos );
+			COMBAT_CAMERA->Set_Anchor_Position( vehicle_pos );
 
 //			bool target_2d = ( !vehicle->Use_2D_Aiming() ^ Input::Get_State(INPUT_FUNCTION_CURSOR_TARGETING) ^ VehicleGameObj::Is_Target_Steering() );
 

--- a/Code/Combat/damage.cpp
+++ b/Code/Combat/damage.cpp
@@ -185,7 +185,7 @@ void	ArmorWarheadManager::Init( void )
 		for ( armor_num = 0; armor_num < ArmorNames.Count(); armor_num++ ) {
 			char section_name[80];
 			sprintf( section_name, SECTION_SCALE, (const char *)ArmorNames[armor_num] );
-			for ( int warhead_num = 0; warhead_num < WarheadNames.Count(); warhead_num++ ) {
+			for ( warhead_num = 0; warhead_num < WarheadNames.Count(); warhead_num++ ) {
 				Multipliers[ armor_num * Get_Num_Warhead_Types() + warhead_num ]  =
 					armorINI->Get_Float( section_name, WarheadNames[warhead_num], 1.0f );
 			}
@@ -196,7 +196,7 @@ void	ArmorWarheadManager::Init( void )
 		for ( armor_num = 0; armor_num < ArmorNames.Count(); armor_num++ ) {
 			char section_name[80];
 			sprintf( section_name, SECTION_SHIELD, (const char *)ArmorNames[armor_num] );
-			for ( int warhead_num = 0; warhead_num < WarheadNames.Count(); warhead_num++ ) {
+			for ( warhead_num = 0; warhead_num < WarheadNames.Count(); warhead_num++ ) {
 				Absorbsion[ armor_num * Get_Num_Warhead_Types() + warhead_num ]  =
 					armorINI->Get_Float( section_name, WarheadNames[warhead_num], 0.0f );
 			}
@@ -284,7 +284,7 @@ void	ArmorWarheadManager::Init( void )
 			};
 			StringClass section = ImperviousSectionNames[damage];
 
-			int count =  armorINI->Entry_Count( section );
+			count =  armorINI->Entry_Count( section );
 			for ( entry = 0; entry < count; entry++ )	{
 				StringClass	entry_name = armorINI->Get_String( temp_string, section, armorINI->Get_Entry( section, entry) );
 				if ( !entry_name.Is_Empty() ) {

--- a/Code/Combat/explosion.cpp
+++ b/Code/Combat/explosion.cpp
@@ -85,6 +85,7 @@ ExplosionDefinitionClass::ExplosionDefinitionClass( void ) :
 	EDITABLE_PARAM( ExplosionDefinitionClass, ParameterClass::TYPE_FLOAT,					DamageStrength );
 
 //	EDITABLE_PARAM( ExplosionDefinitionClass, ParameterClass::TYPE_INT,						DamageWarhead );
+	{
 	EnumParameterClass *param;
 	param = new EnumParameterClass( &DamageWarhead );
 	param->Set_Name ( "Warhead" );
@@ -92,7 +93,8 @@ ExplosionDefinitionClass::ExplosionDefinitionClass( void ) :
 		param->Add_Value ( ArmorWarheadManager::Get_Warhead_Name( i ), i );
 	}
 	GENERIC_EDITABLE_PARAM(ExplosionDefinitionClass,param)
-
+	}
+	
 	EDITABLE_PARAM( ExplosionDefinitionClass, ParameterClass::TYPE_BOOL,						DamageIsScaled );
 	EDITABLE_PARAM( ExplosionDefinitionClass, ParameterClass::TYPE_FILENAME, 				DecalFilename );
 	EDITABLE_PARAM( ExplosionDefinitionClass, ParameterClass::TYPE_FLOAT,					DecalSize );
@@ -320,9 +322,9 @@ void	ExplosionManager::Create_Explosion_At( int explosion_def_id, const Matrix3D
 #ifdef WWDEBUG
 if (!WWMath::Is_Valid_Float(dist)) {
 	WWDEBUG_SAY(("Explosion Distance Bug!\r\n"));
-	Vector3 obj_pos;
-	obj->Get_Position(&obj_pos);
-	WWDEBUG_SAY(("  explosion pos: %f, %f, %f  object pos: %f, %f, %f\r\n",pos.X,pos.Y,pos.Z,obj_pos.X,obj_pos.Y,obj_pos.Z));
+	Vector3 dbg_obj_pos;
+	obj->Get_Position(&dbg_obj_pos);
+	WWDEBUG_SAY(("  explosion pos: %f, %f, %f  object pos: %f, %f, %f\r\n",pos.X,pos.Y,pos.Z,dbg_obj_pos.X,dbg_obj_pos.Y,dbg_obj_pos.Z));
 	WWDEBUG_SAY(("  object definition name: %s\r\n", obj->Get_Definition().Get_Name()));
 	WWDEBUG_SAY(("  explosion definition name; %s\r\n", explosion_def->Get_Name()));
 }

--- a/Code/Combat/hud.cpp
+++ b/Code/Combat/hud.cpp
@@ -1983,10 +1983,10 @@ static	void	Objective_Update( void )
 					dont_clear = true;
 
 					// AND, make an extra renderer for the radar star
-					Render2DClass * renderer = new Render2DClass();
-					if ( renderer ) {
-						renderer->Set_Texture( "HUD_STAR.TGA" );
-						renderer->Set_Coordinate_Range( Render2DClass::Get_Screen_Resolution() );
+					Render2DClass * star_renderer = new Render2DClass();
+					if ( star_renderer ) {
+						star_renderer->Set_Texture( "HUD_STAR.TGA" );
+						star_renderer->Set_Coordinate_Range( Render2DClass::Get_Screen_Resolution() );
 
 						RectClass	star_box( -32, -32, 32, 32 );
 						star_box.Scale( fly );
@@ -1999,17 +1999,17 @@ static	void	Objective_Update( void )
 						star_fly_end.Y *= 0.8f;
 
 						star_box += star_fly_end;
-						Vector2	offset = star_fly_start - star_fly_end;
-						offset *= fly;
-						star_box += offset;
+						Vector2	star_offset = star_fly_start - star_fly_end;
+						star_offset *= fly;
+						star_box += star_offset;
 
 						Vector3 color3( 0,1,0 );
 						if ( ObjectiveManager::Get_Objective(index) != NULL ) {
 							color3 = ObjectiveManager::Get_Objective(index)->Type_To_Color();
 						}
 						unsigned int color = color3.Convert_To_ARGB();
-						renderer->Add_Quad( star_box, color  );
-						ObjectivePogRenderers.Add( renderer );
+						star_renderer->Add_Quad( star_box, color  );
+						ObjectivePogRenderers.Add( star_renderer );
 					}
 
 				} else {
@@ -2458,7 +2458,6 @@ static	void	Info_Update_Health_Shield( void )
 //		StringClass	text;
 //		text.Format( "%03d", (int)shield );
 		int lshield=WWMath::Float_To_Long(shield);
-		unichar_t tmp_text[5];
 		Generate_WChar_Text_From_Number(tmp_text,4,3,lshield);
 		InfoShieldCountRenderer->Set_Location( draw.Upper_Left() + Vector2( 4,4) );
 		InfoShieldCountRenderer->Draw_Text( tmp_text );
@@ -2839,7 +2838,7 @@ static bool	Is_HUD_Displayed( void )
 */
 void 	HUDClass::Think()
 {
-	WWPROFILE( "HUD Think" );
+	WWPROFILENAMED( "HUD Think", top );
 
 #ifndef ATI_DEMO_HACK
 	if ( COMBAT_CAMERA && COMBAT_CAMERA->Draw_Sniper() ) {

--- a/Code/Combat/purchasesettings.cpp
+++ b/Code/Combat/purchasesettings.cpp
@@ -145,10 +145,12 @@ PurchaseSettingsDefClass::PurchaseSettingsDefClass (void)	:
 		NAMED_EDITABLE_PARAM (PurchaseSettingsDefClass, ParameterClass::TYPE_STRING,			TextureList[index], "Texture");
 
 		#ifdef PARAM_EDITING_ON
+		{
 			GenericDefParameterClass *param = new GenericDefParameterClass (&(DefinitionList[index]));
 			param->Set_Class_ID (CLASSID_GAME_OBJECTS);
 			param->Set_Name ("Object");
 			GENERIC_EDITABLE_PARAM(PurchaseSettingsDefClass, param)
+		}
 
 			//
 			//	Insert the alternate textures and definitions

--- a/Code/Combat/radar.cpp
+++ b/Code/Combat/radar.cpp
@@ -348,8 +348,8 @@ float	RadarManager::Add_Blip( const Vector3 & pos, int shape_type, int color_typ
 				if ( bracket ) {
 					color = 0x0000FF00;	// Make Green
 					color |= (unsigned int)(RadarIntensity * alpha * 255) << 24;
-					RectClass uv = BlipUV[ BLIP_BRACKET ];
-					Renderer->Add_Quad( blip, uv, color );
+					RectClass braket_uv = BlipUV[ BLIP_BRACKET ];
+					Renderer->Add_Quad( blip, braket_uv, color );
 				}
 			}
 		}
@@ -363,7 +363,7 @@ float	RadarManager::Add_Blip( const Vector3 & pos, int shape_type, int color_typ
 
 void	RadarManager::Update( const Matrix3D & player_tm, const Vector2 & center )
 {
-	WWPROFILE( "Radar Update" );
+	WWPROFILENAMED( "Radar Update", top );
 
 	OldRadarCenter=RadarCenter;
 	RadarCenter = center;
@@ -541,7 +541,7 @@ void	RadarManager::Update( const Matrix3D & player_tm, const Vector2 & center )
 {WWPROFILE( "Objectives" );
 	// for all objectives with a position
 	int count = ObjectiveManager::Get_Objective_Count();
-	for ( int i = 0; i < count; i++ ) {
+	for ( i = 0; i < count; i++ ) {
 		Objective * objective = ObjectiveManager::Get_Objective( i );
 		if ( objective->DrawBlip && objective->Status == ObjectiveManager::STATUS_IS_PENDING ) {
 			float intensity = objective->BlipIntensity;

--- a/Code/Combat/repairbaygameobj.cpp
+++ b/Code/Combat/repairbaygameobj.cpp
@@ -844,9 +844,9 @@ RepairBayGameObj::Emit_Welding_Arc (RenderObjClass *vehicle_model)
 	//
 	RenderObjClass *aggregate_model = RepairMesh->Peek_Model ();
 	int count		= 8;//aggregate_model->Get_Num_Bones ();
-	int bone_index	= FreeRandom.Get_Int (count) + 1;
+	int rnd_bone_index	= FreeRandom.Get_Int (count) + 1;
 	StringClass bone_name;
-	bone_name.Format ("REP^NODRIM_FX%d", bone_index);
+	bone_name.Format ("REP^NODRIM_FX%d", rnd_bone_index);
 	startpoint = aggregate_model->Get_Bone_Transform (bone_name).Get_Translation ();
 
 	//

--- a/Code/Combat/scriptablegameobj.cpp
+++ b/Code/Combat/scriptablegameobj.cpp
@@ -655,9 +655,9 @@ void	ScriptableGameObj::Post_Think( void )
 			if ( !found ) {
 				Debug_Say(( "Failed to find observer id %d for timer expired....\n", ObserverTimerList[i]->ObserverID ));
 
-				const GameObjObserverList & observer_list = Get_Observers();
-				for( int index = 0; index < observer_list.Count(); index++ ) {
-					Debug_Say(( "have %d\n", observer_list[ index ]->Get_ID() ));
+				const GameObjObserverList & dbg_observer_list = Get_Observers();
+				for( int index = 0; index < dbg_observer_list.Count(); index++ ) {
+					Debug_Say(( "have %d\n", dbg_observer_list[ index ]->Get_ID() ));
 				}
 			}
 

--- a/Code/Combat/scriptzone.cpp
+++ b/Code/Combat/scriptzone.cpp
@@ -340,7 +340,7 @@ void	ScriptZoneGameObj::Think()
 		return;
 	}
 
-	WWPROFILE( "ScriptZone Think" );
+	WWPROFILENAMED( "ScriptZone Think", top );
 
 	// check current objects for exiting
 	SLNode<GameObjReference> *pobjrefnode;

--- a/Code/Combat/smartgameobj.cpp
+++ b/Code/Combat/smartgameobj.cpp
@@ -700,7 +700,7 @@ void SmartGameObj::Apply_Control( void )
 void SmartGameObj::Think()
 {
 	{
-		WWPROFILE( "Smart Think" );
+		WWPROFILENAMED( "Smart Think", top );
 
 		// React to the controls
 		{

--- a/Code/Combat/soldier.cpp
+++ b/Code/Combat/soldier.cpp
@@ -2274,7 +2274,7 @@ static const char * _profile_name = "Soldier Think";
 //------------------------------------------------------------------------------------
 void	SoldierGameObj::Think( void )
 {
-	{	WWPROFILE( _profile_name );
+	{	WWPROFILENAMED( _profile_name, top );
 
 		if ( this == COMBAT_STAR ) {
 			_shake_delay -= TimeManager::Get_Frame_Seconds();
@@ -2361,7 +2361,7 @@ void	SoldierGameObj::Think( void )
 	}
 
 {
-	WWPROFILE( _profile_name );
+	WWPROFILENAMED( _profile_name, top );
 
 	if ( CombatManager::I_Am_Server() ) {
 		WWPROFILE("Handle C4");
@@ -3137,7 +3137,7 @@ float		SoldierGameObj::Get_Weapon_Length( void )
 //------------------------------------------------------------------------------------
 bool	SoldierGameObj::Internal_Set_Targeting( const Vector3 & target_pos, bool do_tilt )
 {
-	WWPROFILE( "Soldier Set Targeting" );
+	WWPROFILENAMED( "Soldier Set Targeting", top );
 
 	if ( CombatManager::Is_Skeleton_Slider_Demo_Enabled() ) {
 		return false;
@@ -3805,7 +3805,7 @@ void	SoldierGameObj::Apply_Damage_Extended( const OffenseObjectClass & damager, 
 		if ( FreeRandom.Get_Float() < probability ) {
 			// if skin is not impervious to the damage
 			int skin = Get_Defense_Object()->Get_Skin();
-			ArmorWarheadManager::SpecialDamageType special_damage = ArmorWarheadManager::Get_Special_Damage_Type( warhead );
+			special_damage = ArmorWarheadManager::Get_Special_Damage_Type( warhead );
 			if ( !ArmorWarheadManager::Is_Skin_Impervious( special_damage, skin ) ) {
 				Set_Special_Damage_Mode( special_damage, damager.Get_Owner() );
 			}
@@ -3841,8 +3841,8 @@ void	SoldierGameObj::Apply_Damage_Extended( const OffenseObjectClass & damager, 
 
 		// Check for creating visceroids
 		if ( IS_MISSION ) {
-			int warhead = damager.Get_Warhead();
-			float visceroid_probability = ArmorWarheadManager::Get_Visceroid_Probability( warhead );
+			int viceroid_warhead = damager.Get_Warhead();
+			float visceroid_probability = ArmorWarheadManager::Get_Visceroid_Probability( viceroid_warhead );
 			if ( !Is_Human_Controlled() && visceroid_probability != 0 ) {
 				if ( FreeRandom.Get_Float() < visceroid_probability ) {
 

--- a/Code/Combat/spawn.cpp
+++ b/Code/Combat/spawn.cpp
@@ -97,6 +97,7 @@ SpawnerDefClass::SpawnerDefClass( void ) :
 	DEFIDLIST_PARAM( SpawnerDefClass, SpawnDefinitionIDList, CLASSID_GAME_OBJECTS );
 
 #ifdef	PARAM_EDITING_ON
+	{
 	EnumParameterClass *param;
 	param = new EnumParameterClass( (int*)&PlayerType );
 	param->Set_Name ("PlayerType");
@@ -105,6 +106,7 @@ SpawnerDefClass::SpawnerDefClass( void ) :
 	param->Add_Value ( "GDI",			PLAYERTYPE_GDI );
 
 	GENERIC_EDITABLE_PARAM(SpawnerDefClass,param)
+	}
 #endif
 
 	EDITABLE_PARAM( SpawnerDefClass, ParameterClass::TYPE_INT, SpawnMax );

--- a/Code/Combat/surfaceeffects.cpp
+++ b/Code/Combat/surfaceeffects.cpp
@@ -462,7 +462,7 @@ void	SurfaceEffectsManager::Apply_Effect
 	bool allow_emitters
 )
 {
-	WWPROFILE( "Apply Surface Effect" );
+	WWPROFILENAMED( "Apply Surface Effect", top );
 
 	bool ok = (	(surface_type >= 0) &&
 					(surface_type < SURFACE_TYPE_MAX) &&

--- a/Code/Combat/teampurchasesettings.cpp
+++ b/Code/Combat/teampurchasesettings.cpp
@@ -121,10 +121,12 @@ TeamPurchaseSettingsDefClass::TeamPurchaseSettingsDefClass (void)	:
 	NAMED_EDITABLE_PARAM (TeamPurchaseSettingsDefClass, ParameterClass::TYPE_INT,				BeaconCost, "Beacon Cost");
 
 	#ifdef PARAM_EDITING_ON
+	{
 		GenericDefParameterClass *param = new GenericDefParameterClass (&BeaconDefinitionID);
 		param->Set_Class_ID (CLASSID_GAME_OBJECTS);
 		param->Set_Name ("Beacon Object");
 		GENERIC_EDITABLE_PARAM (TeamPurchaseSettingsDefClass, param)
+	}
 	#endif //PARAM_EDITING_ON
 
 	//

--- a/Code/Combat/vehicle.cpp
+++ b/Code/Combat/vehicle.cpp
@@ -163,6 +163,7 @@ VehicleGameObjDef::VehicleGameObjDef( void ) :
 	EDITABLE_PARAM( VehicleGameObjDef, ParameterClass::TYPE_BOOL,		Aim2D );
 
 #ifdef	PARAM_EDITING_ON
+	{
 	EnumParameterClass *param;
 	param = new EnumParameterClass( (int*)&Type );
 	param->Set_Name ("Type");
@@ -173,6 +174,7 @@ VehicleGameObjDef::VehicleGameObjDef( void ) :
 	param->Add_Value ( "Turret", 	VEHICLE_TYPE_TURRET );
 
 	GENERIC_EDITABLE_PARAM(VehicleGameObjDef,param)
+	}
 #endif
 
 	EDITABLE_PARAM( VehicleGameObjDef, ParameterClass::TYPE_BOOL, 	OccupantsVisible );

--- a/Code/Combat/vehicledriver.cpp
+++ b/Code/Combat/vehicledriver.cpp
@@ -681,9 +681,9 @@ VehicleDriverClass::Drive_Tracked (void)
 		//
 		//	Calculate our (current) normalized speed
 		//
-		Vector3 vel_vector;
-		Get_Velocity (tm, vel_vector);
-		float speed				= vel_vector.X;
+		Vector3 norm_vel_vector;
+		Get_Velocity (tm, norm_vel_vector);
+		float speed				= norm_vel_vector.X;
 		float norm_speed		= speed / max_speed;
 
 		//

--- a/Code/Combat/weaponmanager.cpp
+++ b/Code/Combat/weaponmanager.cpp
@@ -100,6 +100,7 @@ WeaponDefinitionClass::WeaponDefinitionClass( void ) :
 #ifdef PARAM_EDITING_ON
 	int i;
 //	EDITABLE_PARAM( WeaponDefinitionClass, ParameterClass::TYPE_INT,			Style);
+	{
 	EnumParameterClass *param;
 	param = new EnumParameterClass( &Style );
 	param->Set_Name ( "Style" );
@@ -108,7 +109,7 @@ WeaponDefinitionClass::WeaponDefinitionClass( void ) :
 	}
 	param->Add_Value ( WeaponStyleNames[WEAPON_HOLD_STYLE_BEACON], WEAPON_HOLD_STYLE_BEACON );
 	GENERIC_EDITABLE_PARAM(WeaponDefinitionClass,param)
-
+	}
 	EDITABLE_PARAM( WeaponDefinitionClass, ParameterClass::TYPE_FILENAME,	Model);
 	EDITABLE_PARAM( WeaponDefinitionClass, ParameterClass::TYPE_FILENAME,	IdleAnim);
 	EDITABLE_PARAM( WeaponDefinitionClass, ParameterClass::TYPE_FILENAME,	FireAnim);
@@ -380,6 +381,7 @@ AmmoDefinitionClass::AmmoDefinitionClass( void ) :
 {
 #ifdef	PARAM_EDITING_ON
 	int i;
+	{
 	EnumParameterClass *param;
 	param = new EnumParameterClass( &AmmoType );
 	param->Set_Name ( "Ammo Type" );
@@ -399,7 +401,7 @@ AmmoDefinitionClass::AmmoDefinitionClass( void ) :
 		param->Add_Value ( ArmorWarheadManager::Get_Warhead_Name( i ), i );
 	}
 	GENERIC_EDITABLE_PARAM(AmmoDefinitionClass,param)
-
+	}
 	EDITABLE_PARAM( AmmoDefinitionClass, ParameterClass::TYPE_FLOAT,		Damage);
 	EDITABLE_PARAM( AmmoDefinitionClass, ParameterClass::TYPE_FLOAT,		Range);
 	EDITABLE_PARAM( AmmoDefinitionClass, ParameterClass::TYPE_FLOAT,		EffectiveRange);
@@ -438,12 +440,12 @@ AmmoDefinitionClass::AmmoDefinitionClass( void ) :
 	EDITABLE_PARAM( AmmoDefinitionClass, ParameterClass::TYPE_SOUNDDEFINITIONID,	C4TimingSound3ID );
 	EDITABLE_PARAM( AmmoDefinitionClass, ParameterClass::TYPE_FLOAT,		AliasedSpeed );
 
-	param = new EnumParameterClass( &HitterType );
-	param->Set_Name ( "HitterType" );
+	EnumParameterClass *hitter_param = new EnumParameterClass( &HitterType );
+	hitter_param->Set_Name ( "HitterType" );
 	for ( i = 0; i < SurfaceEffectsManager::Num_Hitter_Types(); i++ ) {
-		param->Add_Value ( SurfaceEffectsManager::Hitter_Type_Name( i ), i );
+		hitter_param->Add_Value ( SurfaceEffectsManager::Hitter_Type_Name( i ), i );
 	}
-	GENERIC_EDITABLE_PARAM(AmmoDefinitionClass,param)
+	GENERIC_EDITABLE_PARAM(AmmoDefinitionClass,hitter_param)
 
 	GenericDefParameterClass *beacon_param = new GenericDefParameterClass (&BeaconDefID);
 	beacon_param->Set_Class_ID (CLASSID_GAME_OBJECT_DEF_BEACON);

--- a/Code/Combat/weapons.cpp
+++ b/Code/Combat/weapons.cpp
@@ -714,7 +714,7 @@ void	WeaponClass::Do_Fire( bool primary )
 */
 void	WeaponClass::Fire_Bullet( const AmmoDefinitionClass *ammo_def, bool primary )
 {
-	WWPROFILE( "Fire Bullet" );
+	WWPROFILENAMED( "Fire Bullet", top );
 
 	if ( Get_Owner() == COMBAT_STAR ) {
 		Vector3 pos;
@@ -1014,7 +1014,7 @@ void	WeaponClass::Do_Firing_Effects( void )
 		return;	// No sounds when time stops
 	}
 
-	WWPROFILE( "Firing Effects" );
+	WWPROFILENAMED( "Firing Effects", top );
 
 	Matrix3D	muzzle = Get_Muzzle();
 
@@ -1286,7 +1286,7 @@ void	WeaponClass::Do_Continuous_Effects( bool enable )
 			}
 
 			ContinuousEmitters.Resize( num_muzzles );
-			for ( int i = 0; i < ContinuousEmitters.Length(); i++ ) {
+			for ( i = 0; i < ContinuousEmitters.Length(); i++ ) {
 				ContinuousEmitters[i] = NULL;
 			}
 		}
@@ -1725,7 +1725,7 @@ void	WeaponClass::Stop_Firing_Sound( void )
 
 void	WeaponClass::Display_Targeting( void )
 {
-	WWPROFILE( "Cast_Star_Weapon" );
+	WWPROFILENAMED( "Cast_Star_Weapon", top );
 	int muzzle_index = Get_Total_Rounds_Fired() & 1;
 
 	// vehicles that don't have a turret bone and do have homing weapons target from the camera

--- a/Code/Combat/weaponview.cpp
+++ b/Code/Combat/weaponview.cpp
@@ -227,7 +227,7 @@ void 	WeaponViewClass::Enable( bool enable )
 */
 void 	WeaponViewClass::Think()
 {
-	WWPROFILE( "WeaponView Think" );
+	WWPROFILENAMED( "WeaponView Think", top );
 
 	bool bail = false;
 

--- a/Code/Commando/AutoStart.cpp
+++ b/Code/Commando/AutoStart.cpp
@@ -896,7 +896,7 @@ void AutoRestartClass::Set_Restart_Flag(bool enable)
 		if (game_mode && game_mode->Is_Active()) {
 			GameMode = 1;
 		} else {
-			GameModeClass *game_mode = GameModeManager::Find("LAN");
+			game_mode = GameModeManager::Find("LAN");
 			if (game_mode && game_mode->Is_Active()) {
 				GameMode = 0;
 			}

--- a/Code/Commando/NAT.cpp
+++ b/Code/Commando/NAT.cpp
@@ -2213,7 +2213,7 @@ void FirewallHelperClass::Process_Game_Options(void)
 			case WOLNATInterfaceClass::OPTION_ABORT_NEGOTIATION:
 				WWDEBUG_SAY(("FirewallHelper - Got OPTION_ABORT_NEGOTIATION from %s\n", (char*)user.name));
 			{
-				ThreadLockClass locker(this);
+				ThreadLockClass sub_lock(this);
 				if (WOLNATInterface.Am_I_Server()) {
 					if (stricmp((char*)user.name, PlayersName) == 0) {
 						strcpy(CancelPlayer, (char*)user.name);

--- a/Code/Commando/WOLChatMgr.cpp
+++ b/Code/Commando/WOLChatMgr.cpp
@@ -1139,9 +1139,9 @@ void WOLChatMgr::HandleNotification(ChannelEvent& event)
 
 void WOLChatMgr::HandleNotification(UserEvent& userEvent)
 	{
-	UserEvent::Event event  = userEvent.GetEvent();
+	UserEvent::Event user_event  = userEvent.GetEvent();
 
-	switch (event)
+	switch (user_event)
 		{
 		case UserEvent::Join:
 			{

--- a/Code/Commando/WebBrowser.cpp
+++ b/Code/Commando/WebBrowser.cpp
@@ -121,7 +121,7 @@ bool WebBrowser::InstallPrerequisites(void)
 				"Renegade Warning!");
 
 		// Attempt to create the key.
-		LONG result = RegCreateKeyExA(HKEY_CURRENT_USER, APPLICATION_SUB_KEY_NAME_URL, 0, NULL,
+		result = RegCreateKeyExA(HKEY_CURRENT_USER, APPLICATION_SUB_KEY_NAME_URL, 0, NULL,
 			REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &key, NULL);
 
 		if (ERROR_SUCCESS != result)

--- a/Code/Commando/bandwidthcheck.cpp
+++ b/Code/Commando/bandwidthcheck.cpp
@@ -401,7 +401,7 @@ void BandwidthCheckerClass::Check(void)
 			if (failure_code == BANDTEST_NO_FINAL_PING_TIME ||
 					(cGameSpyAdmin::Is_Gamespy_Game() &&
 					failure_code == BANDTEST_NO_EXTERNAL_ROUTER)) {
-				BandtestSettingsStruct settings = {
+				settings = {
 					0,		//AlwaysICMP
 					0,		//TTLScatter
 					25,	//FastPingPackets

--- a/Code/Commando/bandwidthgraph.cpp
+++ b/Code/Commando/bandwidthgraph.cpp
@@ -154,7 +154,6 @@ cBandwidthGraph::Bandwidth_Graph
 	//
 	if (target_bps >= 0)
 	{
-		StringClass text;
    	text.Format("%d", target_bps);
 		PTextRenderer->Set_Location(Vector2(245, YPosition));
 		PTextRenderer->Draw_Text(text);
@@ -286,7 +285,7 @@ cBandwidthGraph::Think
 		bps = PacketManager.Get_Total_Compressed_Bandwidth_In();
 		Bandwidth_Graph(text, bps, -1, -1, -1.0f, false);
 
-	   for (int i = cNetwork::PServerConnection->Get_Min_RHost(); i <= cNetwork::PServerConnection->Get_Max_RHost(); i++)
+	   for (i = cNetwork::PServerConnection->Get_Min_RHost(); i <= cNetwork::PServerConnection->Get_Max_RHost(); i++)
 		{
 			cRemoteHost * p_rhost = cNetwork::Get_Server_Rhost(i);
 

--- a/Code/Commando/campaign.cpp
+++ b/Code/Commando/campaign.cpp
@@ -104,7 +104,7 @@ void	CampaignManager::Init( void )
 		for ( int state = 0; state < 100; state++ ) {
 			StringClass section_name;
 			section_name.Format( "Backdrop%d", state );
-			int count =  campaignINI->Entry_Count( section_name );
+			count =  campaignINI->Entry_Count( section_name );
 			if ( count != 0 ) {
 				int index = BackdropDescriptions.Count();
 				BackdropDescriptions.Uninitialized_Add();

--- a/Code/Commando/cnetwork.cpp
+++ b/Code/Commando/cnetwork.cpp
@@ -862,7 +862,7 @@ void cNetwork::Connection_Status_Change_Feedback(void)
 //-----------------------------------------------------------------------------
 void cNetwork::Update(void)
 {
-	WWPROFILE( "cNetwork::Update" );
+	WWPROFILENAMED( "cNetwork::Update", top );
 	WWMEMLOG(MEM_GAMEDATA);
 
 	bool flush_packets = false;
@@ -909,7 +909,7 @@ void cNetwork::Update(void)
 //			GameSpyQnR.Think();
 //		}
 
-		WWPROFILE( "Server Read" );
+		WWPROFILENAMED( "Server Read", mid );
 		PServerConnection->Service_Read();
 
 		if (!g_is_loading) {

--- a/Code/Commando/combatgmode.cpp
+++ b/Code/Commando/combatgmode.cpp
@@ -1175,7 +1175,7 @@ void CombatGameModeClass::Core_Restart(void)
 					TimeManager::Reset();
 					GenericDataSafeClass::Reset_Timers();
 
-					GameModeClass* game_mode = GameModeManager::Find("WOL");
+					game_mode = GameModeManager::Find("WOL");
 
 					if (game_mode && game_mode->Is_Active()) {
 						WolGameModeClass* wol_game = reinterpret_cast<WolGameModeClass*>(game_mode);
@@ -1238,7 +1238,7 @@ void CombatGameModeClass::Save_Registry_Keys(void)
 */
 void 	CombatGameModeClass::Think()
 {
-	WWPROFILE( "Combat Think" );
+	WWPROFILENAMED( "Combat Think", top );
 
 	if ( !Is_Active() ) {
 		return;

--- a/Code/Commando/console.cpp
+++ b/Code/Commando/console.cpp
@@ -192,7 +192,7 @@ void ConsoleGameModeClass::Save_Registry_Keys(void)
 */
 void 	ConsoleGameModeClass::Think()
 {
-	WWPROFILE( "Console Think" );
+	WWPROFILENAMED( "Console Think", top );
 
    /*
 	//

--- a/Code/Commando/diagnostics.cpp
+++ b/Code/Commando/diagnostics.cpp
@@ -161,24 +161,24 @@ void cDiagnostics::Render(void)
 
 #ifdef BETACLIENT
 	PRenderer->Reset();
-	RectClass rect = Render2DClass::Get_Screen_Resolution();
-	PRenderer->Set_Location(Vector2(rect.Left + 5, rect.Bottom - 10));
+	RectClass beta_rect = Render2DClass::Get_Screen_Resolution();
+	PRenderer->Set_Location(Vector2(beta_rect.Left + 5, beta_rect.Bottom - 10));
 	PRenderer->Draw_Text("BETACLIENT");
 	PRenderer->Render();
 #endif // BETACLIENT
 
 #ifdef FREEDEDICATEDSERVER
 	PRenderer->Reset();
-	RectClass rect = Render2DClass::Get_Screen_Resolution();
-	PRenderer->Set_Location(Vector2(rect.Left + 5, rect.Bottom - 10));
+	RectClass fds_rect = Render2DClass::Get_Screen_Resolution();
+	PRenderer->Set_Location(Vector2(fds_rect.Left + 5, fds_rect.Bottom - 10));
 	PRenderer->Draw_Text("FREEDEDICATEDSERVER");
 	PRenderer->Render();
 #endif // FREEDEDICATEDSERVER
 
 #ifdef MULTIPLAYERDEMO
 	PRenderer->Reset();
-	RectClass rect = Render2DClass::Get_Screen_Resolution();
-	PRenderer->Set_Location(Vector2(rect.Left + 5, rect.Bottom - 10));
+	RectClass mpd_rect = Render2DClass::Get_Screen_Resolution();
+	PRenderer->Set_Location(Vector2(mpd_rect.Left + 5, mpd_rect.Bottom - 10));
 	PRenderer->Draw_Text("MULTIPLAYER DEMO");
 	PRenderer->Render();
 #endif // MULTIPLAYERDEMO

--- a/Code/Commando/dlgcncpurchasemenu.cpp
+++ b/Code/Commando/dlgcncpurchasemenu.cpp
@@ -347,7 +347,7 @@ CNCPurchaseMenuClass::Add_Item_To_Shopping_Cart (int ctrl_id)
 		//
 		//	Update the counter on the merchandise control
 		//
-		MerchandiseCtrlClass *ctrl = (MerchandiseCtrlClass *)Get_Dlg_Item (ITEM_CTRL_IDS[item_index]);
+		ctrl = (MerchandiseCtrlClass *)Get_Dlg_Item (ITEM_CTRL_IDS[item_index]);
 		if (ctrl != NULL) {
 			ctrl->Increment_Purchase_Count ();
 		}

--- a/Code/Commando/dlgmovieoptions.cpp
+++ b/Code/Commando/dlgmovieoptions.cpp
@@ -110,7 +110,7 @@ MovieOptionsMenuClass::On_Init_Dialog (void)
 				//	Add an entry for this movie
 				//
 				const unichar_t *wide_desc = TRANSLATE_BY_DESC(string_id_des);
-				int item_index = list_ctrl->Insert_Entry (0xFF, wide_desc);
+				item_index = list_ctrl->Insert_Entry (0xFF, wide_desc);
 				if (item_index != -1) {
 					list_ctrl->Set_Entry_Data (item_index, 0, (uintptr_t)new StringClass (list[index]));
 				}

--- a/Code/Commando/dlgsavegame.cpp
+++ b/Code/Commando/dlgsavegame.cpp
@@ -578,7 +578,7 @@ SaveGameMenuClass::Reload_List (const char *current_filename)
 		//
 		//	Add this entry to the list control
 		//
-		int item_index = list_ctrl->Insert_Entry (index ++, time_string);
+		item_index = list_ctrl->Insert_Entry (index ++, time_string);
 		if (item_index >= 0) {
 			list_ctrl->Set_Entry_Text (item_index, 1, date_string);
 			list_ctrl->Set_Entry_Text (item_index, 2, description);

--- a/Code/Commando/gamechanlist.cpp
+++ b/Code/Commando/gamechanlist.cpp
@@ -41,7 +41,7 @@ void cGameChannelList::Add_Channel(cGameData * p_game_data, const RefPtr<WWOnlin
 
    cGameChannel * p_game_channel = Find_Channel(p_game_data->Get_Owner());
 	if (p_game_channel == NULL) {
-		cGameChannel * p_game_channel = new cGameChannel(p_game_data, p_channel);
+		p_game_channel = new cGameChannel(p_game_data, p_channel);
 		WWASSERT(p_game_channel != NULL);
 		ChanList.Add_Tail(p_game_channel);
    } else {

--- a/Code/Commando/gamedata.cpp
+++ b/Code/Commando/gamedata.cpp
@@ -1132,8 +1132,8 @@ void cGameData::Load_From_Server_Config(LPCSTR config_file)
 		StringClass item_name(0,true);
 		item_name.Format("MapName%02d", j);
 		p_ini->Get_String(	INI_SECTION_NAME, item_name, "", map_name, sizeof(map_name));
-		StringClass map(map_name,true);
-		MapCycle[j] = map;
+		StringClass tmp_map(map_name,true);
+		MapCycle[j] = tmp_map;
 	}
 
 	//char motd[2 * MAX_MOTD_LENGTH];

--- a/Code/Commando/gamemode.cpp
+++ b/Code/Commando/gamemode.cpp
@@ -210,7 +210,7 @@ void GameModeManager::Safely_Deactivate(void)
 */
 void	GameModeManager::Render( void )
 {
-	WWPROFILE( "Render" );
+	WWPROFILENAMED( "Render", top );
 
 	if (!ConsoleBox.Is_Exclusive()) {
 

--- a/Code/Commando/level.cpp
+++ b/Code/Commando/level.cpp
@@ -53,7 +53,7 @@
 */
 void		LevelManager::Release_Level( void )
 {
-WWPROFILE( "Release Level" );
+WWPROFILENAMED( "Release Level", top );
 	SaveGameManager::Set_Map_Filename( NULL );
 	ConversationMgrClass::Reset_Active_Conversations ();
 

--- a/Code/Commando/mainloop.cpp
+++ b/Code/Commando/mainloop.cpp
@@ -82,7 +82,7 @@ void Stop_Main_Loop(int exitCode)
 
 void _Game_Main_Loop_Loop(void)
 {
-	WWPROFILE( "Main Loop" );
+	WWPROFILENAMED( "Main Loop", top );
 
 	unsigned int time1 = TIMEGETTIME();
 

--- a/Code/Commando/messages.cpp
+++ b/Code/Commando/messages.cpp
@@ -111,7 +111,7 @@ void cNetwork::Tell_Client_About_Dynamic_Objects
 
 if (cDevOptions::UseNewTCADO.Is_False()) {
 
-	WWPROFILE("TCADO");
+	WWPROFILENAMED("TCADO", top);
 
 	WWASSERT(client_id >= 0);
    WWASSERT(cNetwork::I_Am_Server());
@@ -452,7 +452,7 @@ if (cDevOptions::UseNewTCADO.Is_False()) {
 
 	const unsigned char dirty_check = (NetworkObjectClass::BIT_FREQUENT ^ 0xffffffff) & (NetworkObjectClass::BIT_CREATION | NetworkObjectClass::BIT_RARE | NetworkObjectClass::BIT_OCCASIONAL);
 
-	WWPROFILE("TCADO");
+	WWPROFILENAMED("TCADO", top);
 
 	WWASSERT(client_id >= 0);
    WWASSERT(cNetwork::I_Am_Server());

--- a/Code/Commando/multihud.cpp
+++ b/Code/Commando/multihud.cpp
@@ -209,7 +209,7 @@ void MultiHUDClass::Show_Player_Names(void)
 		return;
 	}
 
-	WWPROFILE("Show_Player_Name");
+	WWPROFILENAMED("Show_Player_Name", top);
    if (GameModeManager::Find("Menu")->Is_Active() ||
 		COMBAT_CAMERA == NULL ||
 		!cNetwork::I_Am_Client() ||
@@ -706,34 +706,34 @@ void MultiHUDClass::Show_Player_Rhost_Data(SmartGameObj * smart_obj)
 
 				y = 50;
 
-				StringClass text("Name         ", true);
-				StringClass sub_string;
+				StringClass tmp_text("Name         ", true);
+				StringClass tmp_sub_string;
 
-				sub_string.Format( "RHost ID   ");
-				text += sub_string;
+				tmp_sub_string.Format( "RHost ID   ");
+				tmp_text += tmp_sub_string;
 
-				sub_string.Format( "Ave Pri    ");
-				text += sub_string;
+				tmp_sub_string.Format( "Ave Pri    ");
+				tmp_text += tmp_sub_string;
 
-				sub_string.Format( "Band Mult   ");
-				text += sub_string;
+				tmp_sub_string.Format( "Band Mult   ");
+				tmp_text += tmp_sub_string;
 
-				sub_string.Format( "Target BPS     ");
-				text += sub_string;
+				tmp_sub_string.Format( "Target BPS     ");
+				tmp_text += tmp_sub_string;
 
-				sub_string.Format( "Resend dly  ");
-				text += sub_string;
+				tmp_sub_string.Format( "Resend dly  ");
+				tmp_text += tmp_sub_string;
 
-				sub_string.Format( "Min/Max/Ave ping      ");
-				text += sub_string;
+				tmp_sub_string.Format( "Min/Max/Ave ping      ");
+				tmp_text += tmp_sub_string;
 
-				sub_string.Format( "Tot rsnds ");
-				text += sub_string;
+				tmp_sub_string.Format( "Tot rsnds ");
+				tmp_text += tmp_sub_string;
 
-				sub_string.Format( "Duration");
-				text += sub_string;
+				tmp_sub_string.Format( "Duration");
+				tmp_text += tmp_sub_string;
 
-				Render_Debug_Text(text, x, y);
+				Render_Debug_Text(tmp_text, x, y);
 			}
 		}
    }
@@ -911,7 +911,7 @@ void MultiHUDClass::Think(void)
 	}
 
 	{
-	int count = StaticNetworkObjectClass::Get_Static_Network_Object_Count ();
+	count = StaticNetworkObjectClass::Get_Static_Network_Object_Count ();
 	for (int index = 0; index < count; index ++) {
 
 		StaticNetworkObjectClass * p_object = (StaticNetworkObjectClass * ) StaticNetworkObjectClass::Get_Static_Network_Object (index);

--- a/Code/Commando/netgraphs.cpp
+++ b/Code/Commando/netgraphs.cpp
@@ -614,7 +614,7 @@ void cNetwork::Watch_Bandwidth(Render2DTextClass * renderer)
          false,
 			-1);
 
-	   for (int i = PServerConnection->Get_Min_RHost(); i <= PServerConnection->Get_Max_RHost(); i++) {
+	   for (i = PServerConnection->Get_Min_RHost(); i <= PServerConnection->Get_Max_RHost(); i++) {
 
 			WWASSERT(
 				i >= cNetwork::PServerConnection->Get_Min_RHost() &&

--- a/Code/Commando/purchaserequestevent.cpp
+++ b/Code/Commando/purchaserequestevent.cpp
@@ -92,7 +92,7 @@ cPurchaseRequestEvent::Act(void)
 	//
 	//	Lookup the data needed to make the purchase
 	//
-	SoldierGameObj *player = GameObjManager::Find_Soldier_Of_Client_ID(SenderId);
+	SoldierGameObj *soldier = GameObjManager::Find_Soldier_Of_Client_ID(SenderId);
 
 	VendorClass::PURCHASE_ERROR result = VendorClass::PERR_UNKNOWN;
 
@@ -102,7 +102,7 @@ cPurchaseRequestEvent::Act(void)
 		//
 		//	Attempt to make the purchase
 		//
-		result = VendorClass::Purchase_Item (player, (VendorClass::PURCHASE_TYPE)PurchaseType, ItemIndex, AltSkinIndex, false);
+		result = VendorClass::Purchase_Item (soldier, (VendorClass::PURCHASE_TYPE)PurchaseType, ItemIndex, AltSkinIndex, false);
 	}
 	else
 	{

--- a/Code/Commando/slavemaster.cpp
+++ b/Code/Commando/slavemaster.cpp
@@ -643,8 +643,8 @@ void SlaveMasterClass::Shutdown_Slaves(void)
 {
 	if (!SlaveMode) {
 		char password[64] = DEFAULT_SERVER_CONTROL_PASSWORD;
-		RegistryClass reg(APPLICATION_SUB_KEY_NAME_NET_SERVER_CONTROL);
-		reg.Get_String(SERVER_CONTROL_PASSWORD_KEY, password, sizeof(password), password);
+		RegistryClass control_reg(APPLICATION_SUB_KEY_NAME_NET_SERVER_CONTROL);
+		control_reg.Get_String(SERVER_CONTROL_PASSWORD_KEY, password, sizeof(password), password);
 
 		for (int i=0 ; i<NumSlaveServers ; i++) {
 			if (SlaveServers[i].IsRunning) {
@@ -703,8 +703,8 @@ bool SlaveMasterClass::Shutdown_Slave(char *slave_login)
 {
 	if (!SlaveMode && slave_login) {
 		char password[64] = DEFAULT_SERVER_CONTROL_PASSWORD;
-		RegistryClass reg(APPLICATION_SUB_KEY_NAME_NET_SERVER_CONTROL);
-		reg.Get_String(SERVER_CONTROL_PASSWORD_KEY, password, sizeof(password), password);
+		RegistryClass control_reg(APPLICATION_SUB_KEY_NAME_NET_SERVER_CONTROL);
+		control_reg.Get_String(SERVER_CONTROL_PASSWORD_KEY, password, sizeof(password), password);
 
 		for (int i=0 ; i<NumSlaveServers ; i++) {
 			if (SlaveServers[i].IsRunning && stricmp(slave_login, SlaveServers[i].NickName) == 0) {
@@ -809,9 +809,9 @@ void SlaveMasterClass::Create_Registry_Copies(void)
 	/*
 	** Make sure the Process ID isn't set in our base registry. It's shouldn't be unless I ran with the --slave command during dev.
 	*/
-	RegistryClass reg(APPLICATION_SUB_KEY_NAME);
-	if (reg.Is_Valid()) {
-		reg.Delete_Value("ProcessId");
+	RegistryClass app_reg(APPLICATION_SUB_KEY_NAME);
+	if (app_reg.Is_Valid()) {
+		app_reg.Delete_Value("ProcessId");
 	}
 
 	RegistryClass::Save_Registry(RegistryFileName, APPLICATION_SUB_KEY_NAME);

--- a/Code/Commando/wolgmode.cpp
+++ b/Code/Commando/wolgmode.cpp
@@ -342,7 +342,7 @@ void WolGameModeClass::Think(void)
 		//
 		if (cNetwork::I_Am_Server() && mGameInProgress) {
 
-			unsigned int time = TIMEGETTIME();
+			time = TIMEGETTIME();
 
 			//
 			// Clear out old kicklist entries.

--- a/Code/Scripts/Mission01.cpp
+++ b/Code/Scripts/Mission01.cpp
@@ -2545,8 +2545,6 @@ DECLARE_SCRIPT(M01_HON_Medlab_DropOff_Guy_JDG, "")
 
 	void Action_Complete( GameObject * obj, int action_id, ActionCompleteReason complete_reason ) override
 	{
-		ActionParamsStruct params;
-
 		if (action_id == M01_WALKING_WAYPATH_01_JDG && complete_reason == ACTION_COMPLETE_NORMAL)
 		{
 			Commands->Destroy_Object ( obj );
@@ -9081,8 +9079,6 @@ DECLARE_SCRIPT(M01_BuggyScript_New_JDG, "")
 
 			else
 			{
-				ActionParamsStruct params;
-
 				params.Set_Basic( this, 100, M01_WALKING_WAYPATH_01_JDG );
 				params.Set_Movement( Vector3(0,0,0), 0.5f, 5 );
 				params.WaypathID = 103289;
@@ -12359,7 +12355,6 @@ DECLARE_SCRIPT(M01_Church_Interior_Nun_JDG, "")
 		else if (param == M01_GOING_TO_EVAC_SPOT_JDG)//your ride is here--go get in
 		{
 			Vector3 evacSpot = Commands->Get_Position ( Commands->Find_Object ( 103394 ) );
-			ActionParamsStruct params;
 			Commands->Action_Reset ( obj, 100 );
 			params.Set_Basic(this, 100, M01_GOING_TO_EVAC_SPOT_JDG);
 			params.Set_Movement( evacSpot, RUN, 1 );
@@ -12503,7 +12498,6 @@ DECLARE_SCRIPT(M01_Church_LoveShack_Nun_JDG, "")
 		else if (param == M01_GOING_TO_EVAC_SPOT_JDG)//your ride is here--go get in
 		{
 			Vector3 evacSpot = Commands->Get_Position ( Commands->Find_Object ( 103394 ) );
-			ActionParamsStruct params;
 			Commands->Action_Reset ( obj, 100 );
 			params.Set_Basic(this, 100, M01_GOING_TO_EVAC_SPOT_JDG);
 			params.Set_Movement( evacSpot, RUN, 1 );
@@ -12851,7 +12845,6 @@ DECLARE_SCRIPT(M01_Barn_Prisoner_01_JDG, "")//this guys ID is M01_BARN_PRISONER_
 		{
 			Commands->Enable_Hibernation(obj, false );
 			Vector3 evacSpot = Commands->Get_Position ( Commands->Find_Object ( M01_BARNAREA_EVAC_MONITOR_JDG ) );
-			ActionParamsStruct params;
 			params.Set_Basic(this, 100, M01_GOING_TO_EVAC_SPOT_JDG);
 			params.Set_Movement( evacSpot, RUN, 1 );
 
@@ -13012,7 +13005,6 @@ DECLARE_SCRIPT(M01_Barn_Prisoner_02_JDG, "")//this guys ID is M01_BARN_PRISONER_
 		{
 			Commands->Enable_Hibernation(obj, false );
 			Vector3 evacSpot = Commands->Get_Position ( Commands->Find_Object ( M01_BARNAREA_EVAC_MONITOR_JDG ) );
-			ActionParamsStruct params;
 			params.Set_Basic(this, 100, M01_GOING_TO_EVAC_SPOT_JDG);
 			params.Set_Movement( evacSpot, RUN, 1 );
 
@@ -13169,7 +13161,6 @@ DECLARE_SCRIPT(M01_Barn_Prisoner_03_JDG, "")//this guys ID is M01_BARN_PRISONER_
 
 			//Commands->Action_Face_Location ( obj, params );
 
-			ActionParamsStruct params;
 			params.Set_Basic(this, 100, M01_MODIFY_YOUR_ACTION_JDG);
 			//params.Set_Look( STAR, 15 );
 			params.Set_Attack( STAR, 0, 0, true );
@@ -13190,7 +13181,6 @@ DECLARE_SCRIPT(M01_Barn_Prisoner_03_JDG, "")//this guys ID is M01_BARN_PRISONER_
 			Commands->Set_Innate_Is_Stationary ( obj, false );
 
 			Vector3 evacSpot = Commands->Get_Position ( Commands->Find_Object ( M01_BARNAREA_EVAC_MONITOR_JDG ) );
-			ActionParamsStruct params;
 			params.Set_Basic(this, 100, M01_GOING_TO_EVAC_SPOT_JDG);
 			params.Set_Movement( evacSpot, RUN, 1 );
 
@@ -13208,7 +13198,6 @@ DECLARE_SCRIPT(M01_Barn_Prisoner_03_JDG, "")//this guys ID is M01_BARN_PRISONER_
 			if (action_id == M01_WALKING_WAYPATH_01_JDG)//civ is at hiding spot--crouch
 			{
 				Commands->Set_Innate_Is_Stationary ( obj, true );
-				ActionParamsStruct params;
 				params.Set_Basic(this, 100, M01_MODIFY_YOUR_ACTION_JDG);
 				params.Set_Look( STAR, 15 );
 				//params.Set_Attack( STAR, 0, 0, true );
@@ -18302,8 +18291,6 @@ DECLARE_SCRIPT(M01_TurretBeach_Turret_01_Script_JDG, "")//M01_TURRETBEACH_TURRET
 
 	void Action_Complete( GameObject * obj, int action_id, ActionCompleteReason /* complete_reason */ ) override
 	{
-		ActionParamsStruct params;
-
 		if (action_id == M01_START_ATTACKING_01_JDG)//hovercraft is dead...go back to attacking gunboat
 		{
 			GameObject * gunboat = Commands->Find_Object ( M01_TURRETBEACH_GUNBOAT_ID );
@@ -19849,8 +19836,6 @@ DECLARE_SCRIPT(M01_GuardTower02_Sniper_Target01_JDG, "")
 
 	void Action_Complete( GameObject * obj, int action_id, ActionCompleteReason complete_reason ) override
 	{
-		ActionParamsStruct params;
-
 		if (complete_reason == ACTION_COMPLETE_NORMAL)
 		{
 			if (action_id == M01_WALKING_WAYPATH_01_JDG )//youre now in middle of field--start conversation
@@ -21734,7 +21719,6 @@ DECLARE_SCRIPT(M01_Base_GDI_Minigunner_JDG, "")//116382
 			else if (param == M01_MODIFY_YOUR_ACTION_03_JDG)//greet havoc M01_GDI01_Conversation_01
 			{
 				Vector3 playersPosition = Commands->Get_Position ( STAR );
-				ActionParamsStruct params;
 				params.Set_Basic( this, 100, M01_START_ACTING_JDG );
 				params.Set_Face_Location( playersPosition, 2 );
 				Commands->Action_Face_Location ( obj, params );
@@ -21796,7 +21780,6 @@ DECLARE_SCRIPT(M01_Base_GDI_Minigunner_JDG, "")//116382
 				if (havocDownPath == false)
 				{
 					Vector3 playersPosition = Commands->Get_Position ( STAR );
-					ActionParamsStruct params;
 					params.Set_Basic( this, 100, M01_START_ACTING_JDG );
 					params.Set_Face_Location( playersPosition, 2 );
 					Commands->Action_Face_Location ( obj, params );

--- a/Code/Scripts/Mission02.cpp
+++ b/Code/Scripts/Mission02.cpp
@@ -837,8 +837,8 @@ DECLARE_SCRIPT(M02_Objective_Zone, "")
 				}
 			case (400193):
 				{
-					GameObject * object = Commands->Create_Object("Invisible_Object", Vector3(0,0,0));
-					if (object)
+					GameObject * invis_object = Commands->Create_Object("Invisible_Object", Vector3(0,0,0));
+					if (invis_object)
 					{
 						Commands->Control_Enable (STAR, false);
 						Commands->Start_Timer (obj, this, 1.0f, 9);
@@ -847,7 +847,7 @@ DECLARE_SCRIPT(M02_Objective_Zone, "")
 						{
 							Commands->Send_Custom_Event (obj, controller, 1000, 1002, 25.0f);
 						}
-						Commands->Attach_Script (object, "Test_Cinematic", "X2K_Midtro.txt");
+						Commands->Attach_Script (invis_object, "Test_Cinematic", "X2K_Midtro.txt");
 					}
 					break;
 				}

--- a/Code/Scripts/Mission03.cpp
+++ b/Code/Scripts/Mission03.cpp
@@ -5167,7 +5167,7 @@ DECLARE_SCRIPT(M03_Beach_Scenario_Controller, "")
 			GameObject * obj_con = Commands->Find_Object(1100004);
 			if (obj_con && Commands->Find_Object (1100003))
 			{
-				GameObject * obj_con = Commands->Find_Object(1100004);
+				obj_con = Commands->Find_Object(1100004);
 
 				Commands->Send_Custom_Event(obj, obj_con, 301, 3, 0.0f);
 				Commands->Send_Custom_Event(obj, obj_con, 301, 1, 0.0f);

--- a/Code/Scripts/Mission04.cpp
+++ b/Code/Scripts/Mission04.cpp
@@ -690,7 +690,7 @@ The following are params for when the individual objectives are completed.
 					Commands->Join_Conversation( NULL, reminderConv, false, false, true );
 					Commands->Start_Conversation( reminderConv,  reminderConv );
 
-					GameObject * objectiveReminder = Commands->Find_Object ( 105760 );
+					objectiveReminder = Commands->Find_Object ( 105760 );
 					if (objectiveReminder != NULL)
 					{
 						Commands->Send_Custom_Event( obj, objectiveReminder, M01_ADD_OBJECTIVE_POG_JDG, 6, 0 );
@@ -1404,7 +1404,6 @@ DECLARE_SCRIPT(M04_MissileRoom_UpperGuard_01_JDG, "")//left side
 		if (param == M01_START_ACTING_JDG)//player has entered area--back peddle towards the engine room
 		{
 			Vector3 gotoSpot (4.302f, -67.224f, -9);
-			ActionParamsStruct params;
 
 			params.Set_Basic(this, 100, M01_WALKING_WAYPATH_01_JDG);
 			params.Set_Movement( gotoSpot, RUN, .25f );
@@ -1444,7 +1443,6 @@ DECLARE_SCRIPT(M04_MissileRoom_UpperGuard_02_JDG, "")//right side
 		if (param == M01_START_ACTING_JDG)//player has entered area--back peddle towards the engine room
 		{
 			Vector3 gotoSpot (-4.336f, -66.975f, -9);
-			ActionParamsStruct params;
 
 			params.Set_Basic(this, 100, M01_WALKING_WAYPATH_01_JDG);
 			params.Set_Movement( gotoSpot, RUN, .25f );
@@ -2529,11 +2527,6 @@ DECLARE_SCRIPT(M04_EngineRoom_ChiefEngineer_JDG, "")// M04_ENGINEROOM_CHIEF_ENGI
 				Vector3 myPosition = Commands->Get_Position ( obj );
 				Commands->Create_Sound ( "TargetHasBeenEngaged_2", myPosition, obj );
 
-				GameObject * jimmy = Commands->Find_Object (M04_ENGINEROOM_TECH_01_JDG);
-				GameObject * johnny = Commands->Find_Object (M04_ENGINEROOM_TECH_02_JDG);
-				GameObject * bobby = Commands->Find_Object (M04_ENGINEROOM_TECH_03_JDG);
-				GameObject * williams = Commands->Find_Object (M04_ENGINEROOM_TECH_04_JDG);
-
 				if (jimmy != NULL)
 				{
 					float delayTimer = Commands->Get_Random ( 0, 0.5f );
@@ -2692,11 +2685,6 @@ DECLARE_SCRIPT(M04_EngineRoom_ChiefEngineer_JDG, "")// M04_ENGINEROOM_CHIEF_ENGI
 		else if (complete_reason == ACTION_COMPLETE_CONVERSATION_ENDED)
 		{
 			Commands->Send_Custom_Event( obj, obj, 0, M01_PICK_A_NEW_LOCATION_JDG, 1 );
-
-			GameObject * jimmy = Commands->Find_Object (M04_ENGINEROOM_TECH_01_JDG);
-			GameObject * johnny = Commands->Find_Object (M04_ENGINEROOM_TECH_02_JDG);
-			GameObject * bobby = Commands->Find_Object (M04_ENGINEROOM_TECH_03_JDG);
-			GameObject * williams = Commands->Find_Object (M04_ENGINEROOM_TECH_04_JDG);
 
 			if (chiefs_location == GOING_TO_WILLIAMS_01)
 			{
@@ -3017,8 +3005,6 @@ DECLARE_SCRIPT(M04_EngineRoom_Prison_Guard_02_JDG, "")//M04_ENGINEROOM_PRISONGUA
 
 	void Custom (GameObject* obj, int /* type */, intptr_t param, GameObject* /* sender */) override
 	{
-		ActionParamsStruct params;
-
 		if (param == M01_START_ACTING_JDG && engineDestroyed == false)//controller is telling you to start acting
 		{
 		}
@@ -3164,8 +3150,6 @@ DECLARE_SCRIPT(M04_EngineRoom_Prisoner_01_JDG, "")//this guys ID number is M04_P
 			if ((prison_guard_01_dead == true) && (prison_guard_02_dead == true) && freedYet == false && seenHavoc == false)
 			{
 				seenHavoc = true;
-
-				ActionParamsStruct params;
 				params.Set_Basic( this, 100, M01_FACING_SPECIFIED_DIRECTION_01_JDG);
 				params.Set_Attack( STAR, 0, 0, true );
 				Commands->Action_Attack ( obj, params );
@@ -3417,7 +3401,6 @@ DECLARE_SCRIPT(M04_EngineRoom_Prisoner_03_JDG, "")//this guys ID number is M04_P
 		if (param == 3000)
 		{
 			Commands->Action_Reset (  obj, 100 );
-			ActionParamsStruct params;
 			params.Set_Basic( this, 100, M01_START_ATTACKING_01_JDG );
 			params.Set_Attack( STAR, 0, 0, true);
 			Commands->Action_Attack(obj, params);
@@ -6107,7 +6090,6 @@ DECLARE_SCRIPT(M04_EngineRoom_Stationary_Tech_JDG, "Console_ID :int")
 				GameObject * myConsole = Commands->Find_Object ( myConsole_id );
 				if (myConsole != NULL)
 				{
-					ActionParamsStruct params;
 					params.Set_Basic(this, 100, M01_START_ACTING_JDG);
 					params.Set_Attack( myConsole, 0, 0, true );
 
@@ -6334,7 +6316,6 @@ DECLARE_SCRIPT(M04_Doorway_Enterer_JDG, "first_location:vector3")
 
 						case M01_DOING_ANIMATION_01_JDG:
 							{
-								ActionParamsStruct params;
 								params.Set_Basic( this, 45, M01_WALKING_WAYPATH_02_JDG );
 								params.Set_Movement( leavePosition, WALK, 1);
 
@@ -6393,7 +6374,7 @@ DECLARE_SCRIPT(M04_Hunter_Controller_JDG, "")//M04_ENGINEROOM_HUNTING_CONTROLLER
 				{
 					messagePlayed = false;
 					Vector3 hunter01_spawnlocation (-13.523f, 48.665f, -9.003f);
-					GameObject *hunter_01 = Commands->Create_Object ( "Nod_Minigunner_2SF_AutoRifle", hunter01_spawnlocation );
+					hunter_01 = Commands->Create_Object ( "Nod_Minigunner_2SF_AutoRifle", hunter01_spawnlocation );
 					hunter_01_id = Commands->Get_ID ( hunter_01 );
 					Commands->Attach_Script(hunter_01, "M04_Hunter_JDG", "");
 				}
@@ -6402,7 +6383,7 @@ DECLARE_SCRIPT(M04_Hunter_Controller_JDG, "")//M04_ENGINEROOM_HUNTING_CONTROLLER
 				if (hunter_02 == NULL)
 				{
 					Vector3 hunter02_spawnlocation (11.943f, 42.201f, -15.000f);
-					GameObject *hunter_02 = Commands->Create_Object ( "Nod_Minigunner_2SF_AutoRifle", hunter02_spawnlocation );
+					hunter_02 = Commands->Create_Object ( "Nod_Minigunner_2SF_AutoRifle", hunter02_spawnlocation );
 					hunter_02_id = Commands->Get_ID ( hunter_02 );
 					Commands->Attach_Script(hunter_02, "M04_Hunter_JDG", "");
 				}
@@ -6411,7 +6392,7 @@ DECLARE_SCRIPT(M04_Hunter_Controller_JDG, "")//M04_ENGINEROOM_HUNTING_CONTROLLER
 				if (hunter_03 == NULL)
 				{
 					Vector3 hunter03_spawnlocation (3.834f, 60.196f, -15.000f);
-					GameObject *hunter_03 = Commands->Create_Object ( "Nod_Minigunner_2SF_AutoRifle", hunter03_spawnlocation );
+					hunter_03 = Commands->Create_Object ( "Nod_Minigunner_2SF_AutoRifle", hunter03_spawnlocation );
 					hunter_03_id = Commands->Get_ID ( hunter_03 );
 					Commands->Attach_Script(hunter_03, "M04_Hunter_JDG", "");
 				}
@@ -9967,7 +9948,7 @@ DECLARE_SCRIPT(M04_Pog_Controller_JDG, "")//104693
 
 					if (missile_target02_poked == false)
 					{
-						GameObject * missile_target02 = Commands->Find_Object ( 100422 );
+						missile_target02 = Commands->Find_Object ( 100422 );
 						if (missile_target02 != NULL)
 						{
 							missile_target02_active = true;
@@ -9978,7 +9959,7 @@ DECLARE_SCRIPT(M04_Pog_Controller_JDG, "")//104693
 
 					else if (missile_target03_poked == false)
 					{
-						GameObject * missile_target03 = Commands->Find_Object ( 100423 );
+						missile_target03 = Commands->Find_Object ( 100423 );
 						if (missile_target03 != NULL)
 						{
 							missile_target03_active = true;
@@ -9989,7 +9970,7 @@ DECLARE_SCRIPT(M04_Pog_Controller_JDG, "")//104693
 
 					else if (missile_target04_poked == false)
 					{
-						GameObject * missile_target04 = Commands->Find_Object ( 100420 );
+						missile_target04 = Commands->Find_Object ( 100420 );
 						if (missile_target04 != NULL)
 						{
 							missile_target04_active = true;
@@ -10005,7 +9986,7 @@ DECLARE_SCRIPT(M04_Pog_Controller_JDG, "")//104693
 
 					if (missile_target03_poked == false)
 					{
-						GameObject * missile_target03 = Commands->Find_Object ( 100423 );
+						missile_target03 = Commands->Find_Object ( 100423 );
 						if (missile_target03 != NULL)
 						{
 							missile_target03_active = true;
@@ -10016,7 +9997,7 @@ DECLARE_SCRIPT(M04_Pog_Controller_JDG, "")//104693
 
 					else if (missile_target04_poked == false)
 					{
-						GameObject * missile_target04 = Commands->Find_Object ( 100420 );
+						missile_target04 = Commands->Find_Object ( 100420 );
 						if (missile_target04 != NULL)
 						{
 							missile_target04_active = true;
@@ -10032,7 +10013,7 @@ DECLARE_SCRIPT(M04_Pog_Controller_JDG, "")//104693
 
 					if (missile_target04_poked == false)
 					{
-						GameObject * missile_target04 = Commands->Find_Object ( 100420 );
+						missile_target04 = Commands->Find_Object ( 100420 );
 						if (missile_target04 != NULL)
 						{
 							missile_target04_active = true;
@@ -10060,7 +10041,7 @@ DECLARE_SCRIPT(M04_Pog_Controller_JDG, "")//104693
 
 				if (torpedo_target01_poked == true )
 				{
-					GameObject * torpedo_target02 = Commands->Find_Object ( 100409 );
+					torpedo_target02 = Commands->Find_Object ( 100409 );
 					if (torpedo_target02 != NULL && torpedo_target02_poked == false)
 					{
 						torpedo_target02_active = true;

--- a/Code/Scripts/Mission05.cpp
+++ b/Code/Scripts/Mission05.cpp
@@ -1714,7 +1714,6 @@ DECLARE_SCRIPT(M05_Triangle_Tank, "")
 
 		if(timer_id == TANK_TIMER)
 		{
-			ActionParamsStruct params;
 			attacking = false;
 			int random = Commands->Get_Random_Int(0,ARRAY_ELEMENT_COUNT(fire_loc));
 
@@ -1782,7 +1781,6 @@ DECLARE_SCRIPT(M05_TownSquare_Tank, "")
 
 		if(timer_id == TANK_TIMER)
 		{
-			ActionParamsStruct params;
 
 			int random = Commands->Get_Random_Int(0, ARRAY_ELEMENT_COUNT(fire_loc));
 
@@ -1850,7 +1848,6 @@ DECLARE_SCRIPT(M05_Bridge_Tank, "")
 
 		if(timer_id == TANK_TIMER)
 		{
-			ActionParamsStruct params;
 			attacking = false;
 			int random = Commands->Get_Random_Int(0, ARRAY_ELEMENT_COUNT(fire_loc));
 
@@ -5400,7 +5397,6 @@ DECLARE_SCRIPT(M05_Inn_Tank, "")
 
 		if(timer_id == TANK_TIMER)
 		{
-			ActionParamsStruct params;
 			attacking = false;
 			int random = Commands->Get_Random_Int(0,ARRAY_ELEMENT_COUNT(fire_loc));
 
@@ -7341,7 +7337,6 @@ DECLARE_SCRIPT(M05_Cathedral_Artillery, "Fire_Loc1=0:int, Fire_Loc2=0:int")
 
 		if(timer_id == TANK_TIMER)
 		{
-			ActionParamsStruct params;
 
 			int random = Commands->Get_Random_Int(0,ARRAY_ELEMENT_COUNT(fire_loc));
 

--- a/Code/Scripts/Mission09.cpp
+++ b/Code/Scripts/Mission09.cpp
@@ -1772,7 +1772,6 @@ DECLARE_SCRIPT (M09_Vehicle_Attack_01, "")
 			{
 				Commands->Action_Reset ( obj, 100 );
 				charge = true;
-				ActionParamsStruct params;
 				params.Set_Basic( this, INNATE_PRIORITY_ENEMY_SEEN + 5, 10 );
 				params.Set_Movement( STAR, 1.5f, 0 );
 				params.Set_Attack(STAR, 100.0f, 5.0f, true);
@@ -1790,7 +1789,6 @@ DECLARE_SCRIPT (M09_Vehicle_Attack_01, "")
 			charge = false;
 			charging = false;
 
-			ActionParamsStruct params;
 			params.Set_Basic( this, INNATE_PRIORITY_ENEMY_SEEN +5, 10 );
 			params.Set_Movement( Vector3(0,0,0), 1.0f, 0 );
 			params.WaypathID = 2000095;
@@ -3530,8 +3528,6 @@ DECLARE_SCRIPT (M09_Mutant_Attack, "Target_num:int")
 	void Sound_Heard(GameObject* obj, const CombatSound & sound) override
 	{
 		target = Get_Int_Parameter ("Target_num");
-
-		ActionParamsStruct params;
 
 		if ( sound.Type == M09_INNATE_ENABLE )
 		{

--- a/Code/Scripts/Mission10.cpp
+++ b/Code/Scripts/Mission10.cpp
@@ -2801,7 +2801,6 @@ DECLARE_SCRIPT (M10_Mammoth_Grant_Controller, "") //2001634
 
 		if (type == GRANT)
 		{
-			GameObject *mammoth = Commands->Find_Object (2000787);
 			float curr_health = Commands->Get_Health(mammoth);
 			Vector3 mammoth_loc = Commands->Get_Position (mammoth);
 			float mammoth_face = Commands->Get_Facing (mammoth);

--- a/Code/Scripts/Mission11.cpp
+++ b/Code/Scripts/Mission11.cpp
@@ -1913,19 +1913,19 @@ DECLARE_SCRIPT(M11_WetBar_NeighborRoom_SpawnerController_JDG, "")
 
 			if (spawnedGuy01 == NULL)
 			{
-				GameObject * spawnedGuy01 = Commands->Trigger_Spawner( M11_WETBAR_SPAWNER_01_JDG );
+				spawnedGuy01 = Commands->Trigger_Spawner( M11_WETBAR_SPAWNER_01_JDG );
 				spawn_01_ID = Commands->Get_ID ( spawnedGuy01 );
 			}
 
 			if (spawnedGuy02 == NULL)
 			{
-				GameObject * spawnedGuy02 = Commands->Trigger_Spawner( M11_WETBAR_SPAWNER_02_JDG );
+				spawnedGuy02 = Commands->Trigger_Spawner( M11_WETBAR_SPAWNER_02_JDG );
 				spawn_02_ID = Commands->Get_ID ( spawnedGuy02 );
 			}
 
 			if (spawnedGuy03 == NULL)
 			{
-				GameObject * spawnedGuy03 = Commands->Trigger_Spawner( M11_WETBAR_SPAWNER_03_JDG );
+				spawnedGuy03 = Commands->Trigger_Spawner( M11_WETBAR_SPAWNER_03_JDG );
 				spawn_03_ID = Commands->Get_ID ( spawnedGuy03 );
 			}
 		}
@@ -2389,21 +2389,21 @@ DECLARE_SCRIPT(M11_Barracks_SpawnerController_JDG, "")//M11_BARRACKS_SPAWNER_CON
 
 			if (spawnedGuy01 == NULL)
 			{
-				GameObject * spawnedGuy01 = Commands->Trigger_Spawner( M11_BARRACKS_SPAWNER_01_JDG );
+				spawnedGuy01 = Commands->Trigger_Spawner( M11_BARRACKS_SPAWNER_01_JDG );
 				Commands->Attach_Script(spawnedGuy01, "M11_Barracks_SpawnedDude_JDG", "");
 				spawn_01_ID = Commands->Get_ID ( spawnedGuy01 );
 			}
 
 			if (spawnedGuy02 == NULL)
 			{
-				GameObject * spawnedGuy02 = Commands->Trigger_Spawner( M11_BARRACKS_SPAWNER_02_JDG );
+				spawnedGuy02 = Commands->Trigger_Spawner( M11_BARRACKS_SPAWNER_02_JDG );
 				Commands->Attach_Script(spawnedGuy02, "M11_Barracks_SpawnedDude_JDG", "");
 				spawn_02_ID = Commands->Get_ID ( spawnedGuy02 );
 			}
 
 			if (spawnedGuy03 == NULL)
 			{
-				GameObject * spawnedGuy03 = Commands->Trigger_Spawner( M11_BARRACKS_SPAWNER_03_JDG );
+				spawnedGuy03 = Commands->Trigger_Spawner( M11_BARRACKS_SPAWNER_03_JDG );
 				Commands->Attach_Script(spawnedGuy03, "M11_Barracks_SpawnedDude_JDG", "");
 				spawn_03_ID = Commands->Get_ID ( spawnedGuy03 );
 			}
@@ -2669,7 +2669,6 @@ DECLARE_SCRIPT(M11_Barracks_Scientist_JDG, "")//M11_BARRACKS_SCIENTIST_JDG 10040
 
 					Commands->Monitor_Conversation(  obj, scientist_conv02 );
 
-					ActionParamsStruct params;
 					params.Set_Basic( this, 100, M01_DOING_ANIMATION_01_JDG );
 					params.Set_Animation ("H_A_HOST_L2B", true);
 					Commands->Action_Play_Animation (obj, params);
@@ -3209,8 +3208,6 @@ DECLARE_SCRIPT(M11_Barracks_ToiletMutant01_JDG, "")//this guys ID is M11_BARRACK
 
 	void Custom( GameObject * obj, int /* type */, intptr_t param, GameObject * /* sender */ ) override
 	{
-		ActionParamsStruct params;
-
 		if (param == M01_START_ACTING_JDG)
 		{
 			Commands->Innate_Enable(obj);
@@ -3251,8 +3248,6 @@ DECLARE_SCRIPT(M11_Barracks_ToiletMutant02_JDG, "")//this guys ID is M11_BARRACK
 
 	void Custom( GameObject * obj, int /* type */, intptr_t param, GameObject * /* sender */ ) override
 	{
-		ActionParamsStruct params;
-
 		if (param == M01_START_ACTING_JDG)
 		{
 			Commands->Innate_Enable(obj);
@@ -3713,7 +3708,6 @@ DECLARE_SCRIPT(M11_MutantCrypt_Spawner06_Guy_JDG, "")//this one has been fixed f
 		{
 			if (obj && action_id == M01_PICK_A_NEW_LOCATION_JDG)
 			{
-				ActionParamsStruct params;
 				params.Set_Basic(this, 80, M01_WALKING_WAYPATH_01_JDG);
 				params.Set_Movement( Vector3(0,0,0), .1f, 1 );
 
@@ -4236,7 +4230,6 @@ DECLARE_SCRIPT(M11_MutantCrypt_Spawner03_Guy_JDG, "")
 		{
 			if (obj && action_id == M01_PICK_A_NEW_LOCATION_JDG)
 			{
-				ActionParamsStruct params;
 				params.Set_Basic(this, 80, M01_WALKING_WAYPATH_01_JDG);
 				params.Set_Movement( Vector3(0,0,0), .1f, 1 );
 
@@ -4286,7 +4279,6 @@ DECLARE_SCRIPT(M11_MutantCrypt_Spawner03_Guy_JDG, "")
 
 			else if (obj && action_id == M01_DOING_ANIMATION_01_JDG)
 			{
-				ActionParamsStruct params;
 				params.Set_Basic(this, 80, M01_PICK_A_NEW_LOCATION_JDG);
 				params.Set_Movement( Vector3(-15.128f, 17.965f, -63.748f), .1f, 1 );
 
@@ -6753,8 +6745,6 @@ DECLARE_SCRIPT(M11_Barracks_MutantUprising_BlackhandGuy_JDG, "")//M11_BARRACKS_M
 
 	void Action_Complete( GameObject * obj, int action_id, ActionCompleteReason complete_reason ) override
 	{
-		ActionParamsStruct params;
-
 		switch (complete_reason)
 		{
 			case ACTION_COMPLETE_NORMAL:
@@ -7229,8 +7219,6 @@ DECLARE_SCRIPT(M11_Cell_Mutant02_JDG, "")
 
 	void Custom( GameObject * obj, int /* type */, intptr_t param, GameObject * /* sender */ ) override
 	{
-		ActionParamsStruct params;
-
 		if (param == M01_START_ACTING_JDG)
 		{
 			ActionParamsStruct params;
@@ -7300,8 +7288,6 @@ DECLARE_SCRIPT(M11_Cell_Visceroid_JDG, "")
 
 	void Custom( GameObject * obj, int /* type */, intptr_t param, GameObject * /* sender */ ) override
 	{
-		ActionParamsStruct params;
-
 		if (param == M01_START_ACTING_JDG)
 		{
 			//Commands->Set_Player_Type ( obj, SCRIPT_PLAYERTYPE_MUTANT );

--- a/Code/Scripts/MissionX0.cpp
+++ b/Code/Scripts/MissionX0.cpp
@@ -1986,7 +1986,6 @@ DECLARE_SCRIPT (MX0_A03_CONTROLLER_DAK, "" )
 			{
 				if (Trooper_One)
 				{
-					GameObject *Trooper_One = Commands->Find_Object( Trooper_One_Id );
 					// Trooper1: "Nice! That'll cost 'em!"
 					int conv_id = Commands->Create_Conversation ( "MX0_A03_08" , 0, 0, true);
 					Commands->Join_Conversation( Trooper_One, conv_id, false, false, true);

--- a/Code/Scripts/Test_Cinematic.cpp
+++ b/Code/Scripts/Test_Cinematic.cpp
@@ -736,7 +736,7 @@ public:
 			if ( obj ) {
 
 				if ( host_slot != -1 ) {
-					int id = ObjectSlots[ host_slot ];
+					id = ObjectSlots[ host_slot ];
 					GameObject * host = Commands->Find_Object( id );
 					if	( host ) {
 						Commands->Attach_To_Object_Bone( obj, host, bone_name );
@@ -791,9 +791,9 @@ public:
 			GameObject * obj = Commands->Find_Object( id );
 			if ( obj ) {
 				Commands->Enable_Hibernation( obj, false );
-				char id[12];
-				sprintf( id, "%d", MyID );
-				Commands->Attach_Script( obj, "Test_Cinematic_Primary_Killed", id );
+				char id_str[12];
+				sprintf( id_str, "%d", MyID );
+				Commands->Attach_Script( obj, "Test_Cinematic_Primary_Killed", id_str );
 			} else {
 //				Commands->Debug_Message( "Slot Object not found %d\n", obj_slot );
 			}

--- a/Code/Scripts/Test_DLS.cpp
+++ b/Code/Scripts/Test_DLS.cpp
@@ -2916,8 +2916,6 @@ DECLARE_SCRIPT (MX0_GDI_Soldier_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Atta
 			{
 				Commands->Innate_Disable(obj);
 
-				ActionParamsStruct params;
-
 				params.Set_Basic( this, 100, 1 );
 				params.Set_Animation ("H_A_A0A0_L51", true);
 				Commands->Action_Play_Animation (obj, params);

--- a/Code/Scripts/Test_RAD.cpp
+++ b/Code/Scripts/Test_RAD.cpp
@@ -564,7 +564,7 @@ DECLARE_SCRIPT (MX0_A02_Controller, "")
 
 						if (space_available)
 						{
-							int count = MX0_A02_ACTOR_NOD_START;
+							count = MX0_A02_ACTOR_NOD_START;
 							while (count < MX0_A02_ACTOR_HEADCOUNT)
 							{
 								if (!MX0_A02_UNIT_ID[count])

--- a/Code/Scripts/mission08.cpp
+++ b/Code/Scripts/mission08.cpp
@@ -4666,7 +4666,6 @@ DECLARE_SCRIPT(M08_Patrol_Inactive, "Waypath_ID=0:int, Waypath_Loc:Vector3, Cont
 
 	void Custom (GameObject * obj, int type, intptr_t /* param */, GameObject * /* sender */) override
 	{
-		ActionParamsStruct params;
 		if(type == M08_INNATE_ON)
 		{
 			// No starting units can hear footsteps until otherwise alerted
@@ -4936,7 +4935,6 @@ DECLARE_SCRIPT(M08_Facility_Scientist_Inactive, "Point1_ID=0:int, Point2_ID=0:in
 
 	void Custom (GameObject * obj, int type, intptr_t /* param */, GameObject * /* sender */) override
 	{
-		ActionParamsStruct params;
 		if(type == M08_INNATE_ON)
 		{
 			enemy_seen = false;
@@ -6691,7 +6689,6 @@ DECLARE_SCRIPT(M08_Mutant_Behavior, "")
 
 	void Custom (GameObject * obj, int type, intptr_t /* param */, GameObject * /* sender */) override
 	{
-		ActionParamsStruct params;
 		if(type == M08_INNATE_ON && !freed)
 		{
 

--- a/Code/Tools/LevelEdit/ColorBar.cpp
+++ b/Code/Tools/LevelEdit/ColorBar.cpp
@@ -756,7 +756,7 @@ ColorBarClass::Paint_Screen (HDC hwnd_dc)
 				//	Calculate the current frame marker's current rectangle
 				//
 				CRect focus_rect;
-				LONG style = ::GetWindowLong (m_hWnd, GWL_STYLE);
+				style = ::GetWindowLong (m_hWnd, GWL_STYLE);
 				if (style & CBRS_HORZ) {
 					focus_rect.left = m_ColorPoints[m_iCurrentKey].StartPos - (m_iMarkerWidth >> 1);
 					focus_rect.top = m_ColorArea.Height () - (m_iMarkerHeight >> 1);
@@ -898,8 +898,8 @@ ColorBarClass::Insert_Point (CPoint point, DWORD /* flags */)
 		//
 		// Insert the new point
 		//
-		float position = m_MinPos + ((m_MaxPos - m_MinPos) * percent);
-		retval = Insert_Point (new_index, position, red, green, blue);
+		float new_position = m_MinPos + ((m_MaxPos - m_MinPos) * percent);
+		retval = Insert_Point (new_index, new_position, red, green, blue);
 		if (retval) {
 			Set_Graph_Percent (new_index, graph_percent);
 			m_iCurrentKey = new_index;
@@ -1084,7 +1084,7 @@ ColorBarClass::Update_Point_Info (void)
 				//
 				// Assign color increments to the previous color point
 				//
-				int width = m_ColorPoints[index-1].EndPos - m_ColorPoints[index-1].StartPos;
+				width = m_ColorPoints[index-1].EndPos - m_ColorPoints[index-1].StartPos;
 				m_ColorPoints[index-1].RedInc = (m_ColorPoints[index].StartRed - m_ColorPoints[index-1].StartRed) / ((float)width);
 				m_ColorPoints[index-1].GreenInc = (m_ColorPoints[index].StartGreen - m_ColorPoints[index-1].StartGreen) / ((float)width);
 				m_ColorPoints[index-1].BlueInc = (m_ColorPoints[index].StartBlue - m_ColorPoints[index-1].StartBlue) / ((float)width);
@@ -1114,7 +1114,7 @@ ColorBarClass::Update_Point_Info (void)
 				m_ColorPoints[index-1].EndPos = m_ColorPoints[index].StartPos;
 
 				// Assign color increments to the previous color point
-				int height = m_ColorPoints[index-1].EndPos - m_ColorPoints[index-1].StartPos;
+				height = m_ColorPoints[index-1].EndPos - m_ColorPoints[index-1].StartPos;
 				m_ColorPoints[index-1].RedInc = (m_ColorPoints[index].StartRed - m_ColorPoints[index-1].StartRed) / ((float)height);
 				m_ColorPoints[index-1].GreenInc = (m_ColorPoints[index].StartGreen - m_ColorPoints[index-1].StartGreen) / ((float)height);
 				m_ColorPoints[index-1].BlueInc = (m_ColorPoints[index].StartBlue - m_ColorPoints[index-1].StartBlue) / ((float)height);
@@ -1451,7 +1451,7 @@ ColorBarClass::OnMouseMove
 			//	Determine where the marker should be
 			//
 			float new_percent = 0;
-			LONG style = ::GetWindowLong (m_hWnd, GWL_STYLE);
+			style = ::GetWindowLong (m_hWnd, GWL_STYLE);
 			if (style & CBRS_HORZ) {
 				new_percent = ((float)(point.x - m_ColorArea.left)) / ((float)m_ColorArea.Width ());
 			} else {

--- a/Code/Tools/LevelEdit/EditStringTwiddlerDialog.cpp
+++ b/Code/Tools/LevelEdit/EditStringTwiddlerDialog.cpp
@@ -187,13 +187,13 @@ EditStringTwiddlerDialogClass::OnOK (void)
 	//
 	//	Get the strind ID the user entered
 	//
-	CString string_id;
-	GetDlgItemText (IDC_CODEID_EDIT, string_id);
+	CString id_string;
+	GetDlgItemText (IDC_CODEID_EDIT, id_string);
 
 	//
 	//	Is this a valid ID?
 	//
-	if (Validate_String_ID (m_hWnd, string_id)) {
+	if (Validate_String_ID (m_hWnd, id_string)) {
 
 		//
 		//	Create a new twiddler (if necessary)
@@ -206,7 +206,7 @@ EditStringTwiddlerDialogClass::OnOK (void)
 		//	Configure the twiddler
 		//
 		StringObject->Reset_String_List ();
-		StringObject->Set_ID_Desc (string_id);
+		StringObject->Set_ID_Desc (id_string);
 
 		//
 		//	Add the list of strings to the twiddler

--- a/Code/Tools/LevelEdit/EditorAssetMgr.cpp
+++ b/Code/Tools/LevelEdit/EditorAssetMgr.cpp
@@ -159,9 +159,9 @@ EditorAssetMgrClass::Determine_Real_Location
 				//
 				//	Does the file exist in this directoy?
 				//
-				StringClass full_path = static_cast<const char *>(Make_Path (path_list[index], path));
-				if (cPathUtil::PathExists (full_path)) {
-					test_path = full_path;
+				StringClass dir_path = static_cast<const char *>(Make_Path (path_list[index], path));
+				if (cPathUtil::PathExists (dir_path)) {
+					test_path = dir_path;
 					break;
 				}
 			}

--- a/Code/Tools/LevelEdit/EditorSaveLoad.cpp
+++ b/Code/Tools/LevelEdit/EditorSaveLoad.cpp
@@ -209,8 +209,8 @@ EditorSaveLoadClass::Save (ChunkSaveClass &csave)
 	//
 	STRING_LIST &include_list = ::Get_File_Mgr ()->Get_Include_File_List ();
 	for (index = 0; index < include_list.Count (); index ++) {
-		StringClass filename = (LPCTSTR)include_list[index];
-		WRITE_MICRO_CHUNK_WWSTRING (csave, VARID_INCLUDE_FILE, filename);
+		StringClass include_filename = (LPCTSTR)include_list[index];
+		WRITE_MICRO_CHUNK_WWSTRING (csave, VARID_INCLUDE_FILE, include_filename);
 	}
 
 	csave.End_Chunk ();

--- a/Code/Tools/LevelEdit/FileMgr.cpp
+++ b/Code/Tools/LevelEdit/FileMgr.cpp
@@ -1392,9 +1392,9 @@ FileMgrClass::Update (NodeClass *node, bool add_node)
 	//
 	//	Update the files this preset is dependent on
 	//
-	PresetClass *preset = node->Get_Preset ();
-	if (preset != NULL) {
-		Update (preset, add_node);
+	PresetClass *node_preset = node->Get_Preset ();
+	if (node_preset != NULL) {
+		Update (node_preset, add_node);
 	}
 
 	//
@@ -1403,7 +1403,7 @@ FileMgrClass::Update (NodeClass *node, bool add_node)
 	//
 	if (node->Get_Type () == NODE_TYPE_SPAWNER) {
 
-		SpawnerDefClass *definition = static_cast<SpawnerDefClass *> (preset->Get_Definition ());
+		SpawnerDefClass *definition = static_cast<SpawnerDefClass *> (node_preset->Get_Definition ());
 		if (definition != NULL) {
 
 			//

--- a/Code/Tools/LevelEdit/FormToolbar.cpp
+++ b/Code/Tools/LevelEdit/FormToolbar.cpp
@@ -100,10 +100,10 @@ FormToolbarClass::Create
 		retval = m_pCForm->Create (this, 101);
 
 
-		CRect rect;
-		rect = m_pCForm->Get_Form_Rect ();
-		m_minSize.cx = rect.Width ();
-		m_minSize.cy = rect.Height ();
+		CRect form_rect;
+		form_rect = m_pCForm->Get_Form_Rect ();
+		m_minSize.cx = form_rect.Width ();
+		m_minSize.cy = form_rect.Height ();
 		m_minSize.cx += BORDER_LEFT + BORDER_RIGHT;
 		m_minSize.cy += BORDER_TOP + BORDER_BOTTOM;
 		SetWindowPos (NULL, 0, 0, m_minSize.cx, m_minSize.cy, SWP_NOZORDER | SWP_NOMOVE);

--- a/Code/Tools/LevelEdit/GroupMgr.cpp
+++ b/Code/Tools/LevelEdit/GroupMgr.cpp
@@ -243,19 +243,19 @@ GroupMgrClass::Clone_Group (void)
 			//
 			WaypointNodeClass *waypoint	= (WaypointNodeClass *)node;
 			WaypathNodeClass *path			= waypoint->Peek_Waypath ();
-			int index							= path->Find_Index (waypoint);
-			if (index >= 0) {
+			int wp_index							= path->Find_Index (waypoint);
+			if (wp_index >= 0) {
 
 				//
 				//	Insert a new point one after the given point
 				//
-				path->Insert_Point (index + 1, waypoint->Get_Position ());
+				path->Insert_Point (wp_index + 1, waypoint->Get_Position ());
 
 				//
 				//	Add this new point to our group
 				//
 				WaypointNodeClass *new_point = NULL;
-				path->Get_Point (index + 1, &new_point);
+				path->Get_Point (wp_index + 1, &new_point);
 				if (new_point != NULL) {
 					SAFE_ADD_REF (new_point);
 					m_GroupList.Add (new_point);

--- a/Code/Tools/LevelEdit/MainFrm.cpp
+++ b/Code/Tools/LevelEdit/MainFrm.cpp
@@ -786,8 +786,8 @@ CMainFrame::OnCreateClient
 
 		// Initialize the WW3D engine using the window handle from
 		// the main view
-		BOOL retval = (WW3D::Init ((HWND)*pview) == WW3D_ERROR_OK);
-		ASSERT (retval);
+		BOOL init_retval = (WW3D::Init ((HWND)*pview) == WW3D_ERROR_OK);
+		ASSERT (init_retval);
 
 		// Show a dialog to the user asking them which
 		// device they would like to use.
@@ -798,7 +798,7 @@ CMainFrame::OnCreateClient
 		} else {
 			// Stop the application from running
 			PostMessage (WM_CLOSE);
-			retval = false;
+			init_retval = false;
 		}
 	}
 
@@ -4050,17 +4050,17 @@ CMainFrame::OnImportLights (void)
       //
 		// Loop through all the selected files
 		//
-		DynamicVectorClass<StringClass> filename_list;
+		DynamicVectorClass<StringClass> selected_file_list;
 		POSITION pos = dialog.GetStartPosition ();
 		while (pos != NULL) {
 
 			//
 			//	Add this filename to the list
 			//
-			filename_list.Add ((LPCTSTR)dialog.GetNextPathName (pos));
+			selected_file_list.Add ((LPCTSTR)dialog.GetNextPathName (pos));
       }
 
-		::Get_Scene_Editor ()->Import_Lights (filename_list);
+		::Get_Scene_Editor ()->Import_Lights (selected_file_list);
 	}
 
 	return ;

--- a/Code/Tools/LevelEdit/ParameterInheritanceDialog.cpp
+++ b/Code/Tools/LevelEdit/ParameterInheritanceDialog.cpp
@@ -621,8 +621,8 @@ ParameterInheritanceDialogClass::OnOK (void)
 	//	Loop over all the selected presets and propagate the changes
 	//
 	DefinitionClass *base_def = m_Preset->Get_Definition ();
-	for (int index = 0; index < preset_list.Count (); index ++) {
-		PresetClass *preset				= preset_list[index];
+	for (int pindex = 0; pindex < preset_list.Count (); pindex ++) {
+		PresetClass *preset				= preset_list[pindex];
 		DefinitionClass *derived_def	= preset->Get_Definition ();
 
 		if (base_def != NULL) {

--- a/Code/Tools/LevelEdit/PathfindSectorBuilder.cpp
+++ b/Code/Tools/LevelEdit/PathfindSectorBuilder.cpp
@@ -2505,8 +2505,8 @@ PathfindSectorBuilderClass::Post_Process_Floodfill_For_Level_Features (void)
 			//
 			m_BodyBoxCullingSystem.Collect_Boxes (box);
 			DynamicVectorClass<FloodfillBoxClass *> &list = m_BodyBoxCullingSystem.Get_Collection_List ();
-			for (int index = 0; index < list.Count (); index ++) {
-				FloodfillBoxClass *body_box = list[index];
+			for (int list_index = 0; list_index < list.Count (); list_index ++) {
+				FloodfillBoxClass *body_box = list[list_index];
 
 				//
 				//	Force the test to pass in the z-component

--- a/Code/Tools/LevelEdit/PresetTransitionTab.cpp
+++ b/Code/Tools/LevelEdit/PresetTransitionTab.cpp
@@ -419,7 +419,7 @@ PresetTransitionTabClass::Create_Render_Obj (void)
 					//
 					//	Create a 'floor' which we can drop the object onto
 					//
-					PhysClass *phys_obj		= node->Peek_Physics_Obj ();
+					phys_obj		= node->Peek_Physics_Obj ();
 					RenderObjClass *floor	= ::Create_Render_Obj ("GRID");
 					if (floor != NULL) {
 						phys_obj->Set_Transform (Matrix3D (Vector3(0, 0, DROP_POS)));

--- a/Code/Tools/LevelEdit/PresetsLibForm.cpp
+++ b/Code/Tools/LevelEdit/PresetsLibForm.cpp
@@ -1361,8 +1361,7 @@ PresetsFormClass::Save_Presets (FileClass &file_obj, uint32 class_id, bool class
 	//
 	//	Turn saving off for all definitions
 	//
-	DefinitionClass *definition		= NULL;
-	for (	definition = DefinitionMgrClass::Get_First ();
+	for (	DefinitionClass *definition = DefinitionMgrClass::Get_First ();
 			definition != NULL;
 			definition = DefinitionMgrClass::Get_Next (definition))
 	{
@@ -1406,7 +1405,7 @@ PresetsFormClass::Save_Presets (FileClass &file_obj, uint32 class_id, bool class
 	//
 	//	Turn saving back on for all definitions
 	//
-	for (	definition = DefinitionMgrClass::Get_First ();
+	for (	DefinitionClass *definition = DefinitionMgrClass::Get_First ();
 			definition != NULL;
 			definition = DefinitionMgrClass::Get_Next (definition))
 	{
@@ -1671,38 +1670,38 @@ PresetsFormClass::OnDelete (void)
 					//
 					bool save_temp_lib = was_temp;
 					for (int index = 0; index < tree_item_list.Count (); index ++) {
-						PresetClass *preset = Get_Item_Preset (tree_item_list[index]);
-						if (preset != NULL) {
-							::Get_Scene_Editor ()->Delete_Nodes (preset);
-							PresetMgrClass::Remove_Preset (preset);
+						PresetClass *item_preset = Get_Item_Preset (tree_item_list[index]);
+						if (item_preset != NULL) {
+							::Get_Scene_Editor ()->Delete_Nodes (item_preset);
+							PresetMgrClass::Remove_Preset (item_preset);
 
 							//
 							//	Determine if we need to save the temporary preset
 							// library later or not.
 							//
-							if (preset->Get_IsTemporary ()) {
+							if (item_preset->Get_IsTemporary ()) {
 								save_temp_lib = true;
 							}
 
 							//
 							//	Unlink the definition
 							//
-							preset->Set_Definition (NULL);
+							item_preset->Set_Definition (NULL);
 
 							//
 							//	Free the definition
 							//
-							DefinitionClass *definition = preset->Get_Definition ();
-							if (definition != NULL) {
-								DefinitionMgrClass::Unregister_Definition (definition);
-								preset->Set_Definition (NULL);
-								SAFE_DELETE (definition);
+							DefinitionClass *item_definition = item_preset->Get_Definition ();
+							if (item_definition != NULL) {
+								DefinitionMgrClass::Unregister_Definition (item_definition);
+								item_preset->Set_Definition (NULL);
+								SAFE_DELETE (item_definition);
 							}
 
 							//
 							//	Free the preset
 							//
-							SAFE_DELETE (preset);
+							SAFE_DELETE (item_preset);
 						}
 					}
 
@@ -2581,7 +2580,7 @@ PresetsFormClass::OnConvert (void)
 				sel_capture.Restore ();
 
 				item = m_TreeCtrl.GetSelectedItem ();
-				PresetClass *preset = Get_Item_Preset (item);
+				preset = Get_Item_Preset (item);
 				if (preset != NULL) {
 
 					//
@@ -3433,8 +3432,8 @@ PresetsFormClass::Export_File_Dependencies (const char *filename)
 						//
 						//	Now, spit out the list of files
 						//
-						for (int index = 0; index < file_list.Count (); index ++) {
-							entry += file_list[index];
+						for (int file_index = 0; file_index < file_list.Count (); file_index ++) {
+							entry += file_list[file_index];
 							entry += "\t";
 						}
 

--- a/Code/Tools/LevelEdit/Utils.cpp
+++ b/Code/Tools/LevelEdit/Utils.cpp
@@ -1503,13 +1503,13 @@ Fill_Group_Combo
 		if (pgroup != NULL) {
 
 			// Add this group to the combobox
-			int index = ::SendMessage (hcombobox, CB_ADDSTRING, (WPARAM)0, (LPARAM)(LPCTSTR)pgroup->Get_Name ());
-			if (index != CB_ERR) {
-				::SendMessage (hcombobox, CB_SETITEMDATA, (WPARAM)index, (LPARAM)pgroup);
+			int retval = ::SendMessage (hcombobox, CB_ADDSTRING, (WPARAM)0, (LPARAM)(LPCTSTR)pgroup->Get_Name ());
+			if (retval != CB_ERR) {
+				::SendMessage (hcombobox, CB_SETITEMDATA, (WPARAM)retval, (LPARAM)pgroup);
 
 				// If this is the default group, then select it...
 				if (pgroup == pdefault) {
-					::SendMessage (hcombobox, CB_SETCURSEL, (WPARAM)index, 0L);
+					::SendMessage (hcombobox, CB_SETCURSEL, (WPARAM)retval, 0L);
 				}
 			}
 		}

--- a/Code/Tools/LevelEdit/VisMgr.cpp
+++ b/Code/Tools/LevelEdit/VisMgr.cpp
@@ -335,8 +335,7 @@ VisMgrClass::Render_Manual_Vis_Points
 	//	Bulid a list of vis points
 	//
 	DynamicVectorClass<VisPointNodeClass *> point_list;
-	VisPointNodeClass *vis_point = NULL;
-	for (	vis_point = (VisPointNodeClass *)NodeMgrClass::Get_First (NODE_TYPE_VIS_POINT);
+	for (	VisPointNodeClass *vis_point = (VisPointNodeClass *)NodeMgrClass::Get_First (NODE_TYPE_VIS_POINT);
 			vis_point != NULL && keep_going;
 			vis_point = (VisPointNodeClass *)NodeMgrClass::Get_Next (vis_point, NODE_TYPE_VIS_POINT))
 	{

--- a/Code/Tools/MixViewer/MainFrm.cpp
+++ b/Code/Tools/MixViewer/MainFrm.cpp
@@ -212,9 +212,9 @@ CMainFrame::OnCombineDuplicates (void)
 		//
 		//	Determine what directory to search
 		//
-		StringClass full_path	= static_cast<const char *>(dialog.GetPathName ());
-		StringClass directory	= static_cast<const char *>(Strip_Filename_From_Path (full_path));
-		combiner.Set_Destination_File (full_path);
+		StringClass file_path	= static_cast<const char *>(dialog.GetPathName ());
+		StringClass directory	= static_cast<const char *>(Strip_Filename_From_Path (file_path));
+		combiner.Set_Destination_File (file_path);
 
 		WIN32_FIND_DATA find_info	= { 0 };
 		BOOL keep_going				= true;
@@ -315,8 +315,8 @@ CMainFrame::OnExportFiles (void)
 						StringClass dest_folder = dest_name;
 						int length = ::strrchr( dest_folder, '\\' ) - dest_folder;
 						dest_folder.Erase( length, dest_folder.Get_Length() - length );
-						int result = (int)::CreateDirectory( dest_folder, NULL );
-						int error = ::GetLastError();
+						result = (int)::CreateDirectory( dest_folder, NULL );
+						error = ::GetLastError();
 						if ( result == 0 && error != ERROR_ALREADY_EXISTS ) {
 							StringClass message;
 							message.Format ("Failed to create folder %s.", dest_folder.Peek_Buffer() );
@@ -543,18 +543,18 @@ CMainFrame::OnMakeMixPatch(void)
 				//
 				// Ask for the directory containing the old source art.
 				//
-				char path[_MAX_PATH + 256];
-				BROWSEINFO binfo;
-				binfo.hwndOwner = NULL;
-				binfo.pidlRoot = NULL;
-				binfo.pszDisplayName = path;
-    			binfo.lpszTitle = "Select Old Source Art Directory";
-				binfo.ulFlags = 0;
-				binfo.lpfn = NULL;
-				binfo.lParam = 0;
-				binfo.iImage = 0;
+				char old_path[_MAX_PATH + 256];
+				BROWSEINFO old_binfo;
+				old_binfo.hwndOwner = NULL;
+				old_binfo.pidlRoot = NULL;
+				old_binfo.pszDisplayName = old_path;
+    			old_binfo.lpszTitle = "Select Old Source Art Directory";
+				old_binfo.ulFlags = 0;
+				old_binfo.lpfn = NULL;
+				old_binfo.lParam = 0;
+				old_binfo.iImage = 0;
 
-				LPITEMIDLIST itemptr = SHBrowseForFolder(&binfo);
+				LPITEMIDLIST itemptr = SHBrowseForFolder(&old_binfo);
 
 				if (itemptr) {
 
@@ -565,18 +565,18 @@ CMainFrame::OnMakeMixPatch(void)
 						//
 						// Ask for the directory containing the new source art.
 						//
-						char path[_MAX_PATH + 256];
-						BROWSEINFO binfo;
-						binfo.hwndOwner = NULL;
-						binfo.pidlRoot = NULL;
-						binfo.pszDisplayName = path;
-    					binfo.lpszTitle = "Select New Source Art Directory";
-						binfo.ulFlags = 0;
-						binfo.lpfn = NULL;
-						binfo.lParam = 0;
-						binfo.iImage = 0;
+						char new_path[_MAX_PATH + 256];
+						BROWSEINFO new_binfo;
+						new_binfo.hwndOwner = NULL;
+						new_binfo.pidlRoot = NULL;
+						new_binfo.pszDisplayName = new_path;
+    					new_binfo.lpszTitle = "Select New Source Art Directory";
+						new_binfo.ulFlags = 0;
+						new_binfo.lpfn = NULL;
+						new_binfo.lParam = 0;
+						new_binfo.iImage = 0;
 
-						itemptr = SHBrowseForFolder(&binfo);
+						itemptr = SHBrowseForFolder(&new_binfo);
 
 						if (itemptr) {
 							char new_art_dir[_MAX_PATH + 256];

--- a/Code/Tools/W3DShellExt/propshet.cpp
+++ b/Code/Tools/W3DShellExt/propshet.cpp
@@ -233,11 +233,11 @@ INT_PTR CALLBACK MeshPageDlgProc(HWND hDlg,UINT uMessage, WPARAM wParam, LPARAM 
 					char pTextureInfo[MAX_TEXUTRE_NAME_LEN * MAX_MESH];
 					id_of_interest = W3D_CHUNK_TEXTURE_NAME;
 					int found_textures(0);
-					int sizeof_struct = MAX_TEXUTRE_NAME_LEN;
+					int sizeof_tex_struct = MAX_TEXUTRE_NAME_LEN;
 					ptr = pData->Chunks.GetHeadPosition();
 					while(ptr){
 						ChunkItem *pItem = pData->Chunks.GetNext(ptr);
-						GetItemName(pItem, id_of_interest, (void*)pTextureInfo, sizeof_struct, found_textures );
+						GetItemName(pItem, id_of_interest, (void*)pTextureInfo, sizeof_tex_struct, found_textures );
 					}
 					for(int t_count(0); t_count < found_textures; t_count ++){
 						if(lpcs->NotAdded(&(pTextureInfo[t_count*MAX_TEXUTRE_NAME_LEN]))){

--- a/Code/Tools/W3DView/BoneMgrDialog.cpp
+++ b/Code/Tools/W3DView/BoneMgrDialog.cpp
@@ -445,8 +445,8 @@ BoneMgrDialogClass::OnAttachButton (void)
 {
 	// Get the name of the currently selected render object
 	CString name;
-	int index = m_ObjectCombo.GetCurSel ();
-	m_ObjectCombo.GetLBText (index, name);
+	int selected_index = m_ObjectCombo.GetCurSel ();
+	m_ObjectCombo.GetLBText (selected_index, name);
 
 	// Lookup the currently selected bone item
 	HTREEITEM hbone_item = Get_Current_Bone_Item ();

--- a/Code/Tools/W3DView/ColorBar.cpp
+++ b/Code/Tools/W3DView/ColorBar.cpp
@@ -755,7 +755,7 @@ ColorBarClass::Paint_Screen (HDC hwnd_dc)
 				//	Calculate the current frame marker's current rectangle
 				//
 				CRect focus_rect;
-				LONG style = ::GetWindowLong (m_hWnd, GWL_STYLE);
+				style = ::GetWindowLong (m_hWnd, GWL_STYLE);
 				if (style & CBRS_HORZ) {
 					focus_rect.left = m_ColorPoints[m_iCurrentKey].StartPos - (m_iMarkerWidth >> 1);
 					focus_rect.top = m_ColorArea.Height () - (m_iMarkerHeight >> 1);
@@ -897,8 +897,8 @@ ColorBarClass::Insert_Point (CPoint point, DWORD /* flags */)
 		//
 		// Insert the new point
 		//
-		float position = m_MinPos + ((m_MaxPos - m_MinPos) * percent);
-		retval = Insert_Point (new_index, position, red, green, blue);
+		float new_position = m_MinPos + ((m_MaxPos - m_MinPos) * percent);
+		retval = Insert_Point (new_index, new_position, red, green, blue);
 		if (retval) {
 			Set_Graph_Percent (new_index, graph_percent);
 			m_iCurrentKey = new_index;
@@ -1083,13 +1083,13 @@ ColorBarClass::Update_Point_Info (void)
 				//
 				// Assign color increments to the previous color point
 				//
-				int width = m_ColorPoints[index-1].EndPos - m_ColorPoints[index-1].StartPos;
-				m_ColorPoints[index-1].RedInc = (m_ColorPoints[index].StartRed - m_ColorPoints[index-1].StartRed) / ((float)width);
-				m_ColorPoints[index-1].GreenInc = (m_ColorPoints[index].StartGreen - m_ColorPoints[index-1].StartGreen) / ((float)width);
-				m_ColorPoints[index-1].BlueInc = (m_ColorPoints[index].StartBlue - m_ColorPoints[index-1].StartBlue) / ((float)width);
+				int point_width = m_ColorPoints[index-1].EndPos - m_ColorPoints[index-1].StartPos;
+				m_ColorPoints[index-1].RedInc = (m_ColorPoints[index].StartRed - m_ColorPoints[index-1].StartRed) / ((float)point_width);
+				m_ColorPoints[index-1].GreenInc = (m_ColorPoints[index].StartGreen - m_ColorPoints[index-1].StartGreen) / ((float)point_width);
+				m_ColorPoints[index-1].BlueInc = (m_ColorPoints[index].StartBlue - m_ColorPoints[index-1].StartBlue) / ((float)point_width);
 
 				// Assign the graph increment to the previous point
-				m_ColorPoints[index-1].GraphPercentInc = (m_ColorPoints[index].StartGraphPercent - m_ColorPoints[index-1].StartGraphPercent) / ((float)width);
+				m_ColorPoints[index-1].GraphPercentInc = (m_ColorPoints[index].StartGraphPercent - m_ColorPoints[index-1].StartGraphPercent) / ((float)point_width);
 			}
 		}
 
@@ -1113,10 +1113,10 @@ ColorBarClass::Update_Point_Info (void)
 				m_ColorPoints[index-1].EndPos = m_ColorPoints[index].StartPos;
 
 				// Assign color increments to the previous color point
-				int height = m_ColorPoints[index-1].EndPos - m_ColorPoints[index-1].StartPos;
-				m_ColorPoints[index-1].RedInc = (m_ColorPoints[index].StartRed - m_ColorPoints[index-1].StartRed) / ((float)height);
-				m_ColorPoints[index-1].GreenInc = (m_ColorPoints[index].StartGreen - m_ColorPoints[index-1].StartGreen) / ((float)height);
-				m_ColorPoints[index-1].BlueInc = (m_ColorPoints[index].StartBlue - m_ColorPoints[index-1].StartBlue) / ((float)height);
+				int point_height = m_ColorPoints[index-1].EndPos - m_ColorPoints[index-1].StartPos;
+				m_ColorPoints[index-1].RedInc = (m_ColorPoints[index].StartRed - m_ColorPoints[index-1].StartRed) / ((float)point_height);
+				m_ColorPoints[index-1].GreenInc = (m_ColorPoints[index].StartGreen - m_ColorPoints[index-1].StartGreen) / ((float)point_height);
+				m_ColorPoints[index-1].BlueInc = (m_ColorPoints[index].StartBlue - m_ColorPoints[index-1].StartBlue) / ((float)point_height);
 			}
 		}
 
@@ -1450,7 +1450,7 @@ ColorBarClass::OnMouseMove
 			//	Determine where the marker should be
 			//
 			float new_percent = 0;
-			LONG style = ::GetWindowLong (m_hWnd, GWL_STYLE);
+			style = ::GetWindowLong (m_hWnd, GWL_STYLE);
 			if (style & CBRS_HORZ) {
 				new_percent = ((float)(point.x - m_ColorArea.left)) / ((float)m_ColorArea.Width ());
 			} else {

--- a/Code/Tools/W3DView/EditLODDialog.cpp
+++ b/Code/Tools/W3DView/EditLODDialog.cpp
@@ -457,7 +457,6 @@ void CEditLODDialog::OnRecalc (void)
     float switchUp = ::atof (stringTemp);
 
     // Get the down switching distance from the edit control
-    stringTemp;
     GetDlgItemText (IDC_SWITCH_DN_EDIT, stringTemp);
     float switchDown = ::atof (stringTemp);
 
@@ -485,7 +484,6 @@ void CEditLODDialog::OnRecalc (void)
                      iObject ++)
                 {
                     // Set the text of the switch up column
-                    CString stringTemp;
                     stringTemp.Format ("%.2f", switchUp);
                     m_hierarchyListCtrl.SetItemText (iObject, COL_SWITCH_UP, stringTemp);
 

--- a/Code/Tools/W3DView/EmitterFramePropPage.cpp
+++ b/Code/Tools/W3DView/EmitterFramePropPage.cpp
@@ -262,11 +262,11 @@ BOOL EmitterFramePropPageClass::OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* 
 					//
 					if ((new_max != m_MaxFrame) || (new_min != m_MinFrame)) {
 
-						int count = m_FrameBar->Get_Point_Count ();
+						count = m_FrameBar->Get_Point_Count ();
 						for (int index = 0; index < count; index ++) {
 
-							float frame = Denormalize_Frame(m_FrameBar->Get_Graph_Percent (index));
-							float new_norm = Normalize_Frame(frame,new_min,new_max);
+							float new_frame = Denormalize_Frame(m_FrameBar->Get_Graph_Percent (index));
+							float new_norm = Normalize_Frame(new_frame,new_min,new_max);
 
 							m_FrameBar->Set_Graph_Percent (index, new_norm);
 						}

--- a/Code/Tools/W3DView/EmitterLineGroupPropPage.cpp
+++ b/Code/Tools/W3DView/EmitterLineGroupPropPage.cpp
@@ -308,7 +308,7 @@ BOOL EmitterLineGroupPropPageClass::OnNotify(WPARAM wParam, LPARAM lParam, LRESU
 					//
 					if ((new_max != m_MaxBlurTime) || (new_min != m_MinBlurTime)) {
 
-						int count = m_BlurTimeBar->Get_Point_Count ();
+						count = m_BlurTimeBar->Get_Point_Count ();
 						for (int index = 0; index < count; index ++) {
 
 							float frame = Denormalize_Blur_Time(m_BlurTimeBar->Get_Graph_Percent (index));

--- a/Code/Tools/W3DView/EmitterRotationPropPage.cpp
+++ b/Code/Tools/W3DView/EmitterRotationPropPage.cpp
@@ -239,11 +239,11 @@ BOOL EmitterRotationPropPageClass::OnNotify(WPARAM wParam, LPARAM lParam, LRESUL
 					//
 					if ((new_max != m_MaxRotation) || (new_min != m_MinRotation)) {
 
-						int count = m_RotationBar->Get_Point_Count ();
+						count = m_RotationBar->Get_Point_Count ();
 						for (int index = 0; index < count; index ++) {
 
-							float rotation = Denormalize_Rotation(m_RotationBar->Get_Graph_Percent (index));
-							float new_norm = Normalize_Rotation(rotation,new_min,new_max);
+							float new_rotation = Denormalize_Rotation(m_RotationBar->Get_Graph_Percent (index));
+							float new_norm = Normalize_Rotation(new_rotation,new_min,new_max);
 
 							m_RotationBar->Set_Graph_Percent (index, new_norm);
 						}

--- a/Code/Tools/W3DView/EmitterSizePropPage.cpp
+++ b/Code/Tools/W3DView/EmitterSizePropPage.cpp
@@ -248,9 +248,9 @@ EmitterSizePropPageClass::OnNotify
 					float new_max = size;
 					int count = m_SizeBar->Get_Point_Count ();
 					for (int index = 0; index < count; index ++) {
-						float size = m_SizeBar->Get_Graph_Percent (index) * m_MaxSize;
-						if (size > new_max) {
-							new_max = size;
+						float new_size = m_SizeBar->Get_Graph_Percent (index) * m_MaxSize;
+						if (new_size > new_max) {
+							new_max = new_size;
 						}
 					}
 
@@ -258,7 +258,7 @@ EmitterSizePropPageClass::OnNotify
 					//	Rescale the key frame points if necessary
 					//
 					if (new_max != m_MaxSize) {
-						int count = m_SizeBar->Get_Point_Count ();
+						count = m_SizeBar->Get_Point_Count ();
 						for (int index = 0; index < count; index ++) {
 							float percent = m_SizeBar->Get_Graph_Percent (index);
 							m_SizeBar->Set_Graph_Percent (index, (percent * m_MaxSize) / new_max);

--- a/Code/Tools/W3DView/GraphicView.cpp
+++ b/Code/Tools/W3DView/GraphicView.cpp
@@ -858,7 +858,7 @@ CGraphicView::OnMouseMove
 	else if ((nFlags & MK_CONTROL) && m_bRMouseDown)
 	{
 		// Get the currently displayed object
-		CW3DViewDoc *doc= (CW3DViewDoc *)GetDocument();
+		doc= (CW3DViewDoc *)GetDocument();
 		LightClass *pscene_light = doc->GetSceneLight ();
 		RenderObjClass *prender_obj = doc->GetDisplayedObject ();
 		if ((pscene_light != NULL) && (prender_obj != NULL)) {
@@ -892,7 +892,7 @@ CGraphicView::OnMouseMove
 	else if (m_bMouseDown)
 	{
 		// Get the document to display
-		CW3DViewDoc* doc = (CW3DViewDoc *)GetDocument();
+		doc = (CW3DViewDoc *)GetDocument();
 
 		// Are we in a valid state?
 		if (m_bInitialized && doc->GetScene ())
@@ -1014,7 +1014,7 @@ CGraphicView::OnMouseMove
 				if (pCMainWnd != NULL)
 				{
 					// Ensure the background camera matches the main camera
-					CW3DViewDoc *doc = (CW3DViewDoc *)GetDocument();
+					doc = (CW3DViewDoc *)GetDocument();
 					doc->GetBackObjectCamera ()->Set_Transform (transform);
 					doc->GetBackObjectCamera ()->Set_Position (Vector3 (0.00F, 0.00F, 0.00F));
 
@@ -1469,12 +1469,12 @@ CGraphicView::SetCameraPos (CAMERA_POS cameraPos)
         CMainFrame *pCMainWnd = (CMainFrame *)::AfxGetMainWnd ();
         if (pCMainWnd != NULL)
         {
-            CW3DViewDoc* doc = (CW3DViewDoc *)GetDocument();
+            doc = (CW3DViewDoc *)GetDocument();
 
             doc->GetBackObjectCamera ()->Set_Transform (transform);
             doc->GetBackObjectCamera ()->Set_Position (Vector3 (0.00F, 0.00F, 0.00F));
 
-            RenderObjClass *pCRenderObj = doc->GetDisplayedObject ();
+            pCRenderObj = doc->GetDisplayedObject ();
             if (pCRenderObj)
             {
                 pCMainWnd->UpdatePolygonCount (pCRenderObj->Get_Num_Polys ());

--- a/Code/Tools/W3DView/MainFrm.cpp
+++ b/Code/Tools/W3DView/MainFrm.cpp
@@ -532,7 +532,7 @@ CMainFrame::OnCreateClient
 
 			// Get a pointer to the 'graphic' pane's window
 			CGraphicView *pCGraphicView = (CGraphicView *)m_wndSplitter.GetPane (0, 1);
-			BOOL bReturn = (pCGraphicView != NULL);
+			BOOL bReturn2 = (pCGraphicView != NULL);
 
 			// Were we successful in view's getting the pointer?
 			ASSERT (pCGraphicView);
@@ -548,8 +548,8 @@ CMainFrame::OnCreateClient
 
 				// Initialize the WW3D engine using the window handle from
 				// the graphic viewer class.
-				bReturn = (WW3D::Init ((HWND)*pCGraphicView) == WW3D_ERROR_OK);
-				ASSERT (bReturn);
+				bReturn2 = (WW3D::Init ((HWND)*pCGraphicView) == WW3D_ERROR_OK);
+				ASSERT (bReturn2);
 				WW3D::Enable_Static_Sort_Lists(true);
 
 				//

--- a/Code/Tools/W3DView/SoundEditDialog.cpp
+++ b/Code/Tools/W3DView/SoundEditDialog.cpp
@@ -272,8 +272,8 @@ SoundEditDialogClass::OnOK (void)
 		//
 		// Create a new prototype for this emitter and add it to the asset manager
 		//
-		SoundRenderObjDefClass *definition			= new SoundRenderObjDefClass (*SoundRObj);
-		SoundRenderObjPrototypeClass *prototype	= new SoundRenderObjPrototypeClass (definition);
+		SoundRenderObjDefClass *obj_definition			= new SoundRenderObjDefClass (*SoundRObj);
+		SoundRenderObjPrototypeClass *prototype	= new SoundRenderObjPrototypeClass (obj_definition);
 
 		//
 		// Update the asset manager with the new prototype

--- a/Code/Tools/W3DView/W3DViewDoc.cpp
+++ b/Code/Tools/W3DView/W3DViewDoc.cpp
@@ -2813,9 +2813,9 @@ CW3DViewDoc::Copy_Assets_To_Dir (LPCTSTR directory)
 			//
 			//	Determine the source and destination filenames
 			//
-			StringClass filename		= dependency_list[counter];
-			CString src_filename		= src_path + CString (filename);
-			CString dest_filename	= dest_path + CString (filename);
+			StringClass dep_filename		= dependency_list[counter];
+			CString src_filename		= src_path + CString (dep_filename);
+			CString dest_filename	= dest_path + CString (dep_filename);
 
 			//
 			//	Copy the file

--- a/Code/Tools/WWConfig/PerformanceConfigDialog.cpp
+++ b/Code/Tools/WWConfig/PerformanceConfigDialog.cpp
@@ -899,12 +899,12 @@ void AutoConfigSettings()
 		display_format=D3DFMT_R5G6B5;
 
 		// Test if the card if new enough to do 32 bit...
-		DX8Caps tmp_caps(d3d,*d3dcaps,WW3D_FORMAT_UNKNOWN,adapter_id);
-		switch (tmp_caps.Get_Vendor()) {
+		DX8Caps test_caps(d3d,*d3dcaps,WW3D_FORMAT_UNKNOWN,adapter_id);
+		switch (test_caps.Get_Vendor()) {
 		default:
 			break;
 		case DX8Caps::VENDOR_NVIDIA:
-			switch (tmp_caps.Get_Device()) {
+			switch (test_caps.Get_Device()) {
 			default:
 				display_format=D3DFMT_A8R8G8B8;
 				ini.Put_Int(W3D_SECTION_RENDER, VALUE_INI_RENDER_DEVICE_DEPTH, 32);
@@ -922,7 +922,7 @@ void AutoConfigSettings()
 			}
 			break;
 		case DX8Caps::VENDOR_ATI:
-			switch (tmp_caps.Get_Device()) {
+			switch (test_caps.Get_Device()) {
 			case DX8Caps::DEVICE_ATI_RAGE_II:
 			case DX8Caps::DEVICE_ATI_RAGE_II_PLUS:
 			case DX8Caps::DEVICE_ATI_RAGE_IIC_PCI:

--- a/Code/Tools/WWConfig/VideoConfigDialog.cpp
+++ b/Code/Tools/WWConfig/VideoConfigDialog.cpp
@@ -406,15 +406,15 @@ VideoConfigDialogClass::Update_Color_Combo (void)
 			//
 			//	Add this entry to the combobox
 			//
-			int item_index = SendDlgItemMessage (IDC_BITDEPTH_COMBO, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)color_string);
-			if (item_index != CB_ERR) {
-				SendDlgItemMessage (IDC_BITDEPTH_COMBO, CB_SETITEMDATA, (WPARAM)item_index, (LPARAM)res_desc.BitDepth);
+			int add_index = SendDlgItemMessage (IDC_BITDEPTH_COMBO, CB_ADDSTRING, 0, (LPARAM)(LPCTSTR)color_string);
+			if (add_index != CB_ERR) {
+				SendDlgItemMessage (IDC_BITDEPTH_COMBO, CB_SETITEMDATA, (WPARAM)add_index, (LPARAM)res_desc.BitDepth);
 
 				//
 				//	Select this entry if its the current bit depth
 				//
 				if (res_desc.BitDepth == CurrentBitDepth) {
-					SendDlgItemMessage (IDC_BITDEPTH_COMBO, CB_SETCURSEL, (WPARAM)item_index);
+					SendDlgItemMessage (IDC_BITDEPTH_COMBO, CB_SETCURSEL, (WPARAM)add_index);
 					selected = true;
 				}
 			}

--- a/Code/WWMath/cardinalspline.cpp
+++ b/Code/WWMath/cardinalspline.cpp
@@ -151,8 +151,8 @@ void CardinalSpline3DClass::Update_Tangents(void)
 		Tangents[i].InTangent.Z = (1.0f - Tightness[i])*(Keys[i+1].Point.Z - Keys[i-1].Point.Z);
 		Tangents[i].OutTangent = Tangents[i].InTangent;
 
-		float in_factor = 2.0f * (Keys[i].Time - Keys[i-1].Time) / (Keys[i+1].Time - Keys[i-1].Time);
-		float out_factor = 2.0f * (Keys[i+1].Time - Keys[i].Time) / (Keys[i+1].Time - Keys[i-1].Time);
+		in_factor = 2.0f * (Keys[i].Time - Keys[i-1].Time) / (Keys[i+1].Time - Keys[i-1].Time);
+		out_factor = 2.0f * (Keys[i+1].Time - Keys[i].Time) / (Keys[i+1].Time - Keys[i-1].Time);
 
 		Tangents[i].InTangent *= in_factor;			// compensating for the un-even keys
 		Tangents[i].OutTangent *= out_factor;
@@ -290,8 +290,8 @@ void CardinalSpline1DClass::Update_Tangents(void)
 		Tangents[i].InTangent = (1.0f - Tightness[i])*(Keys[i+1].Point - Keys[i-1].Point);
 		Tangents[i].OutTangent = Tangents[i].InTangent;
 
-		float in_factor = 2.0f * (Keys[i].Time - Keys[i-1].Time) / (Keys[i+1].Time - Keys[i-1].Time);
-		float out_factor = 2.0f * (Keys[i+1].Time - Keys[i].Time) / (Keys[i+1].Time - Keys[i-1].Time);
+		in_factor = 2.0f * (Keys[i].Time - Keys[i-1].Time) / (Keys[i+1].Time - Keys[i-1].Time);
+		out_factor = 2.0f * (Keys[i+1].Time - Keys[i].Time) / (Keys[i+1].Time - Keys[i-1].Time);
 
 		Tangents[i].InTangent *= in_factor;			// compensating for the un-even keys
 		Tangents[i].OutTangent *= out_factor;

--- a/Code/WWMath/catmullromspline.cpp
+++ b/Code/WWMath/catmullromspline.cpp
@@ -134,8 +134,8 @@ void CatmullRomSpline3DClass::Update_Tangents(void)
 		Tangents[i].InTangent.Z = 0.5f*(Keys[i+1].Point.Z - Keys[i-1].Point.Z);
 		Tangents[i].OutTangent = Tangents[i].InTangent;
 
-		float in_factor = 2.0f * (Keys[i].Time - Keys[i-1].Time) / (Keys[i+1].Time - Keys[i-1].Time);
-		float out_factor = 2.0f * (Keys[i+1].Time - Keys[i].Time) / (Keys[i+1].Time - Keys[i-1].Time);
+		in_factor = 2.0f * (Keys[i].Time - Keys[i-1].Time) / (Keys[i+1].Time - Keys[i-1].Time);
+		out_factor = 2.0f * (Keys[i+1].Time - Keys[i].Time) / (Keys[i+1].Time - Keys[i-1].Time);
 		Tangents[i].InTangent *= in_factor;			// compensating for the un-even keys
 		Tangents[i].OutTangent *= out_factor;
 	}
@@ -273,8 +273,8 @@ void CatmullRomSpline1DClass::Update_Tangents(void)
 		Tangents[i].InTangent = 0.5f*(Keys[i+1].Point - Keys[i-1].Point);
 		Tangents[i].OutTangent = Tangents[i].InTangent;
 
-		float in_factor = 2.0f * (Keys[i].Time - Keys[i-1].Time) / (Keys[i+1].Time - Keys[i-1].Time);
-		float out_factor = 2.0f * (Keys[i+1].Time - Keys[i].Time) / (Keys[i+1].Time - Keys[i-1].Time);
+		in_factor = 2.0f * (Keys[i].Time - Keys[i-1].Time) / (Keys[i+1].Time - Keys[i-1].Time);
+		out_factor = 2.0f * (Keys[i+1].Time - Keys[i].Time) / (Keys[i+1].Time - Keys[i-1].Time);
 		Tangents[i].InTangent *= in_factor;			// compensating for the un-even keys
 		Tangents[i].OutTangent *= out_factor;
 	}

--- a/Code/WWMath/tcbspline.cpp
+++ b/Code/WWMath/tcbspline.cpp
@@ -179,9 +179,9 @@ void TCBSpline3DClass::Update_Tangents(void)
 		Vector3::Add(k0*dp_out, k1*dp_in, &Tangents[pi].InTangent);
 		Vector3::Add(k2*dp_out, k3*dp_in, &Tangents[pi].OutTangent);
 
-		float total_time = (Keys[pi+1].Time - Keys[pi-1].Time);
-		float in_factor = 2.0f * (Keys[pi].Time - Keys[pi-1].Time) / total_time;
-		float out_factor = 2.0f * (Keys[pi+1].Time - Keys[pi].Time) / total_time;
+		total_time = (Keys[pi+1].Time - Keys[pi-1].Time);
+		in_factor = 2.0f * (Keys[pi].Time - Keys[pi-1].Time) / total_time;
+		out_factor = 2.0f * (Keys[pi+1].Time - Keys[pi].Time) / total_time;
 
 		Tangents[pi].InTangent *= in_factor;		// compensating for un-even keys
 		Tangents[pi].OutTangent *= out_factor;

--- a/Code/WWOnline/RefPtr.h
+++ b/Code/WWOnline/RefPtr.h
@@ -75,6 +75,14 @@
 template<typename Type> class RefPtr;
 template<typename Type> class RefPtrConst;
 
+class RefPtrBase;
+template<typename Derived>
+RefPtr<Derived> Dynamic_Cast(RefPtrBase& base);
+template<typename Type>
+RefPtr<Type> Reinterpret_Cast(RefPtrBase& rhs);
+template<typename Type>
+RefPtr<Type> Const_Cast(RefPtrConst<Type>& rhs);
+
 class RefPtrBase
 	{
 	public:

--- a/Code/WWOnline/WOLSession.cpp
+++ b/Code/WWOnline/WOLSession.cpp
@@ -3292,9 +3292,9 @@ const CComPtr<WOL::IIGROptions>& Session::GetIGRObject(void)
 
 		if (SUCCEEDED(hr))
 			{
-			HRESULT hr = igrObject->Init();
+			HRESULT init = igrObject->Init();
 
-			if (S_FALSE == hr)
+			if (S_FALSE == init)
 				{
 				WWDEBUG_SAY(("WOLWARNING: IGR settings not found\n"));
 				}

--- a/Code/ww3d2/dx8renderer.cpp
+++ b/Code/ww3d2/dx8renderer.cpp
@@ -1083,13 +1083,13 @@ void DX8RigidFVFCategoryContainer::Add_Mesh(MeshClass* mesh_)
 	}
 
 	for (int j=0; j<uvcount; j++) {
-		unsigned char *vb=(unsigned char*) l.Get_Vertex_Array();
+		unsigned char *uvvb=(unsigned char*) l.Get_Vertex_Array();
 		const Vector2*uvs=split_table.Get_UV_Array(j);
 		if (uvs) {
 			for (i=0; i<split_table.Get_Vertex_Count(); i++)
 			{
-				*(Vector2*)(vb+fi.Get_Tex_Offset(j))=uvs[i];
-				vb+=fi.Get_FVF_Size();
+				*(Vector2*)(uvvb+fi.Get_Tex_Offset(j))=uvs[i];
+				uvvb+=fi.Get_FVF_Size();
 			}
 		}
 	}
@@ -1139,15 +1139,15 @@ void DX8FVFCategoryContainer::Insert_To_Texture_Category(
 		** the list always having matching texture categories next to each other.
 		*/
 		bool found_similar_category = false;
-		TextureCategoryListIterator it(&texture_category_list[pass]);
-		while (!it.Is_Done()) {
+		TextureCategoryListIterator add_it(&texture_category_list[pass]);
+		while (!add_it.Is_Done()) {
 			// Categorize according to first stage's texture for now
-			if (it.Peek_Obj()->Peek_Texture(0) == texs[0]) {
-				texture_category_list[pass].Add_After(new_tex_category,it.Peek_Obj());
+			if (add_it.Peek_Obj()->Peek_Texture(0) == texs[0]) {
+				texture_category_list[pass].Add_After(new_tex_category,add_it.Peek_Obj());
 				found_similar_category = true;
 				break;
 			}
-			it.Next();
+			add_it.Next();
 		}
 
 		if (!found_similar_category) {

--- a/Code/ww3d2/dx8wrapper.cpp
+++ b/Code/ww3d2/dx8wrapper.cpp
@@ -575,9 +575,9 @@ void DX8Wrapper::Enumerate_Devices()
 
 		D3DADAPTER_IDENTIFIER9 id;
 		::ZeroMemory(&id, sizeof(D3DADAPTER_IDENTIFIER9));
-		HRESULT res = D3DInterface->GetAdapterIdentifier(adapter_index,0/*D3DENUM_WHQL_LEVEL*/,&id);
+		HRESULT id_res = D3DInterface->GetAdapterIdentifier(adapter_index,0/*D3DENUM_WHQL_LEVEL*/,&id);
 
-		if (res == D3D_OK) {
+		if (id_res == D3D_OK) {
 
 			/*
 			** Set up the render device description
@@ -609,9 +609,9 @@ void DX8Wrapper::Enumerate_Devices()
 			for (int mode_index=0; mode_index<mode_count; mode_index++) {
 				D3DDISPLAYMODE d3dmode;
 				::ZeroMemory(&d3dmode, sizeof(D3DDISPLAYMODE));
-				HRESULT res = D3DInterface->EnumAdapterModes(adapter_index,D3DFMT_X8R8G8B8,mode_index,&d3dmode);
+				HRESULT mode_res = D3DInterface->EnumAdapterModes(adapter_index,D3DFMT_X8R8G8B8,mode_index,&d3dmode);
 
-				if (res == D3D_OK) {
+				if (mode_res == D3D_OK) {
 					int bits = 0;
 					switch (d3dmode.Format)
 					{
@@ -1976,9 +1976,9 @@ void DX8Wrapper::Apply_Render_State_Changes()
 		render_state.shader.Apply();
 	}
 
-	unsigned mask=TEXTURE0_CHANGED;
-	for (unsigned i=0;i<MAX_TEXTURE_STAGES;++i,mask<<=1) {
-		if (render_state_changed&mask) {
+	unsigned tex_mask=TEXTURE0_CHANGED;
+	for (unsigned i=0;i<MAX_TEXTURE_STAGES;++i,tex_mask<<=1) {
+		if (render_state_changed&tex_mask) {
 			SNAPSHOT_SAY(("DX8 - apply texture %d (%s)\n",i,render_state.Textures[i] ? static_cast<const char *>(render_state.Textures[i]->Get_Full_Path()) : "NULL"));
 			if (render_state.Textures[i]) render_state.Textures[i]->Apply(i);
 			else TextureClass::Apply_Null(i);
@@ -1999,9 +1999,9 @@ void DX8Wrapper::Apply_Render_State_Changes()
 
 	if (render_state_changed&LIGHTS_CHANGED)
 	{
-		unsigned mask=LIGHT0_CHANGED;
-		for (unsigned index=0;index<4;++index,mask<<=1) {
-			if (render_state_changed&mask) {
+		unsigned light_mask=LIGHT0_CHANGED;
+		for (unsigned index=0;index<4;++index,light_mask<<=1) {
+			if (render_state_changed&light_mask) {
 				SNAPSHOT_SAY(("DX8 - apply light %d\n",index));
 				if (render_state.LightEnable[index]) {
 					Set_DX8_Light(index,&render_state.Lights[index]);

--- a/Code/ww3d2/dynamesh.cpp
+++ b/Code/ww3d2/dynamesh.cpp
@@ -440,11 +440,11 @@ bool DynamicMeshClass::End_Vertex()
 	WWASSERT(VertCount < Model->Get_Vertex_Count());
 
 	// if we are a multi-material object record the material
-	int pass = Get_Pass_Count();
-	while (pass--) {
-		if (MultiVertexMaterial[pass]) {
-			VertexMaterialClass *mat = Peek_Material_Info()->Get_Vertex_Material(VertexMaterialIdx[pass]);
-			Model->Set_Material(VertCount, mat, pass);
+	int mvm_pass = Get_Pass_Count();
+	while (mvm_pass--) {
+		if (MultiVertexMaterial[mvm_pass]) {
+			VertexMaterialClass *mat = Peek_Material_Info()->Get_Vertex_Material(VertexMaterialIdx[mvm_pass]);
+			Model->Set_Material(VertCount, mat, mvm_pass);
 			REF_PTR_RELEASE(mat);
 		}
 
@@ -492,13 +492,13 @@ bool DynamicMeshClass::End_Vertex()
 		}
 
 		// check each pass
-		int pass = Get_Pass_Count();
-		while (pass--) {
+		int mt_pass = Get_Pass_Count();
+		while (mt_pass--) {
 
 			// If we are multi texture
-			if (MultiTexture[pass]) {
-				TextureClass *tex = Peek_Material_Info()->Get_Texture(TextureIdx[pass]);
-				Model->Set_Texture(PolyCount, tex, pass);
+			if (MultiTexture[mt_pass]) {
+				TextureClass *tex = Peek_Material_Info()->Get_Texture(TextureIdx[mt_pass]);
+				Model->Set_Texture(PolyCount, tex, mt_pass);
 				REF_PTR_RELEASE(tex);
 			}
 		}

--- a/Code/ww3d2/hlod.cpp
+++ b/Code/ww3d2/hlod.cpp
@@ -3464,16 +3464,16 @@ void HLodClass::Update_Obj_Space_Bounding_Volumes(void)
 		robj = Get_Sub_Object(i);
 		WWASSERT(robj);
 
-		const Matrix3D & bonetm = HTree->Get_Transform(Get_Sub_Object_Bone_Index(robj));
+		const Matrix3D & sub_bonetm = HTree->Get_Transform(Get_Sub_Object_Bone_Index(robj));
 
 		SphereClass tmpsphere;
 		robj->Get_Obj_Space_Bounding_Sphere(tmpsphere);
-		tmpsphere.Transform(bonetm);
+		tmpsphere.Transform(sub_bonetm);
 		sphere.Add_Sphere(tmpsphere);
 
 		AABoxClass tmpbox;
 		robj->Get_Obj_Space_Bounding_Box(tmpbox);
-		tmpbox.Transform(bonetm);
+		tmpbox.Transform(sub_bonetm);
 		box.Add_Box(tmpbox);
 
 		robj->Release_Ref();

--- a/Code/ww3d2/line3d.cpp
+++ b/Code/ww3d2/line3d.cpp
@@ -269,15 +269,15 @@ void Line3DClass::Render(RenderInfoClass & /*rinfo*/)
 	{
 		DynamicVBAccessClass::WriteLockClass Lock(&vb);
 		const FVFInfoClass &fi=vb.FVF_Info();
-		unsigned char *vb=(unsigned char*)Lock.Get_Formatted_Vertex_Array();
+		unsigned char *fva=(unsigned char*)Lock.Get_Formatted_Vertex_Array();
 		int i;
 		unsigned int color=DX8Wrapper::Convert_Color(Color);
 
 		for (i=0; i<8; i++)
 		{
-			*(Vector3*)(vb+fi.Get_Location_Offset())=vert[i];
-			*(unsigned int*)(vb+fi.Get_Diffuse_Offset())=color;
-			vb+=fi.Get_FVF_Size();
+			*(Vector3*)(fva+fi.Get_Location_Offset())=vert[i];
+			*(unsigned int*)(fva+fi.Get_Diffuse_Offset())=color;
+			fva+=fi.Get_FVF_Size();
 		}
 	}
 

--- a/Code/ww3d2/meshmatdesc.cpp
+++ b/Code/ww3d2/meshmatdesc.cpp
@@ -763,33 +763,33 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 
 		if ((DCGSource[pass] != VertexMaterialClass::MATERIAL) && (ColorArray[0] != NULL)) {
 			unsigned * diffuse_array = ColorArray[0]->Get_Array();
-			Vector3 mtl_diffuse;
-			float mtl_opacity = 1.0f;
+			Vector3 pass_mtl_diffuse;
+			float pass_mtl_opacity = 1.0f;
 
-			VertexMaterialClass * prev_mtl = NULL;
-			VertexMaterialClass * mtl = Peek_Material(0,pass);
+			VertexMaterialClass * pass_prev_mtl = NULL;
+			VertexMaterialClass * pass_mtl = Peek_Material(0,pass);
 
 			for (int vidx=0; vidx<VertexCount; vidx++) {
 
-				mtl = Peek_Material(vidx,pass);
-				if (mtl != prev_mtl) {
-					prev_mtl = mtl;
-					mtl->Get_Diffuse(&mtl_diffuse);
-					mtl_opacity = mtl->Get_Opacity();
+				pass_mtl = Peek_Material(vidx,pass);
+				if (pass_mtl != pass_prev_mtl) {
+					pass_prev_mtl = pass_mtl;
+					pass_mtl->Get_Diffuse(&pass_mtl_diffuse);
+					pass_mtl_opacity = pass_mtl->Get_Opacity();
 				}
 
 				// If only diffuse is used apply diffuse to color channel and set diffuse source to color 1
 				if (diffuse_used && !ambient_used && !emissive_used) {
 					Vector4 diffuse=DX8Wrapper::Convert_Color(diffuse_array[vidx]);
-					diffuse.X *= mtl_diffuse.X;
-					diffuse.Y *= mtl_diffuse.Y;
-					diffuse.Z *= mtl_diffuse.Z;
-					diffuse.W *= mtl_opacity;
+					diffuse.X *= pass_mtl_diffuse.X;
+					diffuse.Y *= pass_mtl_diffuse.Y;
+					diffuse.Z *= pass_mtl_diffuse.Z;
+					diffuse.W *= pass_mtl_opacity;
 					diffuse_array[vidx]=DX8Wrapper::Convert_Color(diffuse);
 
-					mtl->Set_Ambient_Color_Source(VertexMaterialClass::MATERIAL);
-					mtl->Set_Diffuse_Color_Source(VertexMaterialClass::COLOR1);
-					mtl->Set_Emissive_Color_Source(VertexMaterialClass::MATERIAL);
+					pass_mtl->Set_Ambient_Color_Source(VertexMaterialClass::MATERIAL);
+					pass_mtl->Set_Diffuse_Color_Source(VertexMaterialClass::COLOR1);
+					pass_mtl->Set_Emissive_Color_Source(VertexMaterialClass::MATERIAL);
 				}
 
 				// If diffuse and ambient are used, apply diffuse to color channel and set diffuse
@@ -798,15 +798,15 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 				// diffuse and ambient differently anyway?)
 				if (diffuse_used && ambient_used && !emissive_used) {
 					Vector4 diffuse=DX8Wrapper::Convert_Color(diffuse_array[vidx]);
-					diffuse.X *= mtl_diffuse.X;
-					diffuse.Y *= mtl_diffuse.Y;
-					diffuse.Z *= mtl_diffuse.Z;
-					diffuse.W *= mtl_opacity;
+					diffuse.X *= pass_mtl_diffuse.X;
+					diffuse.Y *= pass_mtl_diffuse.Y;
+					diffuse.Z *= pass_mtl_diffuse.Z;
+					diffuse.W *= pass_mtl_opacity;
 					diffuse_array[vidx]=DX8Wrapper::Convert_Color(diffuse);
 
-					mtl->Set_Ambient_Color_Source(VertexMaterialClass::COLOR1);
-					mtl->Set_Diffuse_Color_Source(VertexMaterialClass::COLOR1);
-					mtl->Set_Emissive_Color_Source(VertexMaterialClass::MATERIAL);
+					pass_mtl->Set_Ambient_Color_Source(VertexMaterialClass::COLOR1);
+					pass_mtl->Set_Diffuse_Color_Source(VertexMaterialClass::COLOR1);
+					pass_mtl->Set_Emissive_Color_Source(VertexMaterialClass::MATERIAL);
 				}
 
 				// If only ambient is used apply ambient to color channel and set ambient source to color 1
@@ -815,12 +815,12 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 					diffuse.X *= mtl_ambient.X;
 					diffuse.Y *= mtl_ambient.Y;
 					diffuse.Z *= mtl_ambient.Z;
-					diffuse.W *= mtl_opacity;
+					diffuse.W *= pass_mtl_opacity;
 					diffuse_array[vidx]=DX8Wrapper::Convert_Color(diffuse);
 
-					mtl->Set_Ambient_Color_Source(VertexMaterialClass::COLOR1);
-					mtl->Set_Diffuse_Color_Source(VertexMaterialClass::MATERIAL);
-					mtl->Set_Emissive_Color_Source(VertexMaterialClass::MATERIAL);
+					pass_mtl->Set_Ambient_Color_Source(VertexMaterialClass::COLOR1);
+					pass_mtl->Set_Diffuse_Color_Source(VertexMaterialClass::MATERIAL);
+					pass_mtl->Set_Emissive_Color_Source(VertexMaterialClass::MATERIAL);
 				}
 
 				// If only emissive is used apply emissive to color channel, set diffuse source to color 1, and turn off lighting
@@ -829,12 +829,12 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 					diffuse.X *= mtl_emissive.X;
 					diffuse.Y *= mtl_emissive.Y;
 					diffuse.Z *= mtl_emissive.Z;
-					diffuse.W *= mtl_opacity;
+					diffuse.W *= pass_mtl_opacity;
 					diffuse_array[vidx]=DX8Wrapper::Convert_Color(diffuse);
 
-					mtl->Set_Ambient_Color_Source(VertexMaterialClass::MATERIAL);
-					mtl->Set_Diffuse_Color_Source(VertexMaterialClass::COLOR1);
-					mtl->Set_Emissive_Color_Source(VertexMaterialClass::MATERIAL);
+					pass_mtl->Set_Ambient_Color_Source(VertexMaterialClass::MATERIAL);
+					pass_mtl->Set_Diffuse_Color_Source(VertexMaterialClass::COLOR1);
+					pass_mtl->Set_Emissive_Color_Source(VertexMaterialClass::MATERIAL);
 //					mtl->Set_Lighting(false);
 				}
 				else {
@@ -918,15 +918,15 @@ void MeshMatDescClass::Post_Load_Process(bool lighting_enabled,MeshModelClass * 
 			}
 
 			if ((DCGSource[pass] != VertexMaterialClass::MATERIAL) && (ColorArray[0] != NULL)) {
-				VertexMaterialClass * prev_mtl = NULL;
-				VertexMaterialClass * mtl = Peek_Material(0,pass);
+				VertexMaterialClass * pass_prev_mtl = NULL;
+				VertexMaterialClass * pass_mtl = Peek_Material(0,pass);
 				for (int vidx=0; vidx<VertexCount; vidx++) {
-					mtl = Peek_Material(vidx,pass);
-					if (mtl != prev_mtl) {
-						prev_mtl = mtl;
+					pass_mtl = Peek_Material(vidx,pass);
+					if (pass_mtl != pass_prev_mtl) {
+						pass_prev_mtl = pass_mtl;
 						// If only emissive is used apply emissive to color channel, set diffuse source to color 1, and turn off lighting
 						if (!diffuse_used && !ambient_used && emissive_used) {
-							mtl->Set_Lighting(false);
+							pass_mtl->Set_Lighting(false);
 						}
 					}
 				}

--- a/Code/ww3d2/part_ldr.cpp
+++ b/Code/ww3d2/part_ldr.cpp
@@ -1014,9 +1014,9 @@ ParticleEmitterDefClass::Read_Rotation_Keyframes (ChunkLoadClass &chunk_load)
 	m_InitialOrientationRandom				= header.OrientationRandom;
 
 	// Read in the first key
-	W3dEmitterRotationKeyframeStruct key;
-	if (chunk_load.Read(&key,sizeof(key)) == sizeof(key)) {
-		m_RotationKeyframes.Start = key.Rotation;
+	W3dEmitterRotationKeyframeStruct first_key;
+	if (chunk_load.Read(&first_key,sizeof(first_key)) == sizeof(first_key)) {
+		m_RotationKeyframes.Start = first_key.Rotation;
 	}
 
 	// Allocate the rotation keys
@@ -1058,9 +1058,9 @@ ParticleEmitterDefClass::Read_Frame_Keyframes (ChunkLoadClass &chunk_load)
 	}
 
 	// Read in the first key
-	W3dEmitterFrameKeyframeStruct key;
-	if (chunk_load.Read(&key,sizeof(key)) == sizeof(key)) {
-		m_FrameKeyframes.Start = key.Frame;
+	W3dEmitterFrameKeyframeStruct first_key;
+	if (chunk_load.Read(&first_key,sizeof(first_key)) == sizeof(first_key)) {
+		m_FrameKeyframes.Start = first_key.Frame;
 	}
 
 	// Allocate the keys
@@ -1101,9 +1101,9 @@ ParticleEmitterDefClass::Read_Blur_Time_Keyframes (ChunkLoadClass &chunk_load)
 	}
 
 	// Read in the first key
-	W3dEmitterBlurTimeKeyframeStruct key;
-	if (chunk_load.Read(&key,sizeof(key)) == sizeof(key)) {
-		m_BlurTimeKeyframes.Start = key.BlurTime;
+	W3dEmitterBlurTimeKeyframeStruct first_key;
+	if (chunk_load.Read(&first_key,sizeof(first_key)) == sizeof(first_key)) {
+		m_BlurTimeKeyframes.Start = first_key.BlurTime;
 	}
 
 	// Allocate the keys

--- a/Code/ww3d2/pointgr.cpp
+++ b/Code/ww3d2/pointgr.cpp
@@ -1161,8 +1161,8 @@ void PointGroupClass::Update_Arrays(
    			float y_scale = (VPYMax - VPYMin) / yres;
 
 				Vector3 scaled_locs[2][3];
-				for (int i = 0; i < 2; i++) {
-					for (int j = 0; j < 3; j++) {
+				for (i = 0; i < 2; i++) {
+					for (j = 0; j < 3; j++) {
 						scaled_locs[i][j].X = _ScreenspaceVertexLocationSizeTable[i][j].X * x_scale;
 						scaled_locs[i][j].Y = _ScreenspaceVertexLocationSizeTable[i][j].Y * y_scale;
 						scaled_locs[i][j].Z = _ScreenspaceVertexLocationSizeTable[i][j].Z;
@@ -1195,8 +1195,8 @@ void PointGroupClass::Update_Arrays(
    			float y_scale = (VPYMax - VPYMin) / yres;
 
 				Vector3 scaled_locs[2][3];
-				for (int i = 0; i < 2; i++) {
-					for (int j = 0; j < 3; j++) {
+				for (i = 0; i < 2; i++) {
+					for (j = 0; j < 3; j++) {
 						scaled_locs[i][j].X = _ScreenspaceVertexLocationSizeTable[i][j].X * x_scale;
 						scaled_locs[i][j].Y = _ScreenspaceVertexLocationSizeTable[i][j].Y * y_scale;
 						scaled_locs[i][j].Z = _ScreenspaceVertexLocationSizeTable[i][j].Z;
@@ -1232,23 +1232,23 @@ void PointGroupClass::Update_Arrays(
 		if (PointMode != QUADS) {
 			// Modes with three vertices per point:
 			Vector2 *uv_ptr = _TriVertexUVFrameTable[FrameRowColumnCountLog2];
-			int vert = 0;
-			for (int i = 0; i < active_points; i++) {
+			int fill_vert = 0;
+			for (i = 0; i < active_points; i++) {
 				int uv_idx = (point_frame[i] & frame_mask) * 3;
-				vertex_uv[vert++] = uv_ptr[uv_idx + 0];
-				vertex_uv[vert++] = uv_ptr[uv_idx + 1];
-				vertex_uv[vert++] = uv_ptr[uv_idx + 2];
+				vertex_uv[fill_vert++] = uv_ptr[uv_idx + 0];
+				vertex_uv[fill_vert++] = uv_ptr[uv_idx + 1];
+				vertex_uv[fill_vert++] = uv_ptr[uv_idx + 2];
 			}
 		} else {
 			// Modes with four vertices per point:
 			Vector2 *uv_ptr = _QuadVertexUVFrameTable[FrameRowColumnCountLog2];
-			int vert = 0;
-			for (int i = 0; i < active_points; i++) {
+			int fill_vert = 0;
+			for (i = 0; i < active_points; i++) {
 				int uv_idx = (point_frame[i] & frame_mask) * 4;
-				vertex_uv[vert++] = uv_ptr[uv_idx + 0];
-				vertex_uv[vert++] = uv_ptr[uv_idx + 1];
-				vertex_uv[vert++] = uv_ptr[uv_idx + 2];
-				vertex_uv[vert++] = uv_ptr[uv_idx + 3];
+				vertex_uv[fill_vert++] = uv_ptr[uv_idx + 0];
+				vertex_uv[fill_vert++] = uv_ptr[uv_idx + 1];
+				vertex_uv[fill_vert++] = uv_ptr[uv_idx + 2];
+				vertex_uv[fill_vert++] = uv_ptr[uv_idx + 3];
 			}
 		}
 
@@ -1259,21 +1259,21 @@ void PointGroupClass::Update_Arrays(
 		if (PointMode != QUADS) {
 			// Modes with three vertices per point:
 			Vector2 *uv_ptr = _TriVertexUVFrameTable[FrameRowColumnCountLog2] + ((DefaultPointFrame & frame_mask) * 3);
-			int vert = 0;
-			for (int i = 0; i < active_points; i++) {
-				vertex_uv[vert++] = uv_ptr[0];
-				vertex_uv[vert++] = uv_ptr[1];
-				vertex_uv[vert++] = uv_ptr[2];
+			int fill_vert = 0;
+			for (i = 0; i < active_points; i++) {
+				vertex_uv[fill_vert++] = uv_ptr[0];
+				vertex_uv[fill_vert++] = uv_ptr[1];
+				vertex_uv[fill_vert++] = uv_ptr[2];
 			}
 		} else {
 			// Modes with four vertices per point:
 			Vector2 *uv_ptr = _QuadVertexUVFrameTable[FrameRowColumnCountLog2] + ((DefaultPointFrame & frame_mask) * 4);
-			int vert = 0;
-			for (int i = 0; i < active_points; i++) {
-				vertex_uv[vert++] = uv_ptr[0];
-				vertex_uv[vert++] = uv_ptr[1];
-				vertex_uv[vert++] = uv_ptr[2];
-				vertex_uv[vert++] = uv_ptr[3];
+			int fill_vert = 0;
+			for (i = 0; i < active_points; i++) {
+				vertex_uv[fill_vert++] = uv_ptr[0];
+				vertex_uv[fill_vert++] = uv_ptr[1];
+				vertex_uv[fill_vert++] = uv_ptr[2];
+				vertex_uv[fill_vert++] = uv_ptr[3];
 			}
 		}
 

--- a/Code/ww3d2/ringobj.cpp
+++ b/Code/ww3d2/ringobj.cpp
@@ -517,7 +517,7 @@ void RingRenderObjClass::render_ring(RenderInfoClass & /*rinfo*/,const Vector3 &
 	DynamicVBAccessClass vb(BUFFER_TYPE_DYNAMIC_SORTING,dynamic_fvf_type,ring.Vertex_ct);
 	{
 		DynamicVBAccessClass::WriteLockClass Lock(&vb);
-		VertexFormatXYZNDUV2 *vb = Lock.Get_Formatted_Vertex_Array();
+		VertexFormatXYZNDUV2 *fva = Lock.Get_Formatted_Vertex_Array();
 
 		//
 		// set up the vertex color+alpha
@@ -531,21 +531,21 @@ void RingRenderObjClass::render_ring(RenderInfoClass & /*rinfo*/,const Vector3 &
 
 		for (int i=0; i<ring.Vertex_ct; i++)
 		{
-			vb->x = ring.vtx[i].X;
-			vb->y = ring.vtx[i].Y;
-			vb->z = ring.vtx[i].Z;
+			fva->x = ring.vtx[i].X;
+			fva->y = ring.vtx[i].Y;
+			fva->z = ring.vtx[i].Z;
 
-			vb->nx = ring.vtx_normal[i].X;		// may not need this!
-			vb->ny = ring.vtx_normal[i].Y;
-			vb->nz = ring.vtx_normal[i].Z;
+			fva->nx = ring.vtx_normal[i].X;		// may not need this!
+			fva->ny = ring.vtx_normal[i].Y;
+			fva->nz = ring.vtx_normal[i].Z;
 
-			vb->diffuse = color;
+			fva->diffuse = color;
 
 			if (RingTexture) {
-				vb->u1 = ring.vtx_uv[i].X;
-				vb->v1 = ring.vtx_uv[i].Y;
+				fva->u1 = ring.vtx_uv[i].X;
+				fva->v1 = ring.vtx_uv[i].Y;
 			}
-			vb++;
+			fva++;
 		}
 	}
 

--- a/Code/ww3d2/seglinerenderer.cpp
+++ b/Code/ww3d2/seglinerenderer.cpp
@@ -925,10 +925,10 @@ void SegLineRendererClass::Render
 		unsigned int residual_bottom_points = intersection[1][BOTTOM_EDGE].PointCount;
 
 		// Reduce both pointcounts by the same amount so the smaller one is 1 (skip points)
-		unsigned int delta = MIN(residual_top_points, residual_bottom_points) - 1;
-		residual_top_points -= delta;
-		residual_bottom_points -= delta;
-		pidx += delta;
+		unsigned int residual_delta = MIN(residual_top_points, residual_bottom_points) - 1;
+		residual_top_points -= residual_delta;
+		residual_bottom_points -= residual_delta;
+		pidx += residual_delta;
 
 		for (; ; ) {
 
@@ -955,10 +955,10 @@ void SegLineRendererClass::Render
 				pidx++;
 
 				// Generate two vertices for next point by picking nearest point on each direction line
-				Vector3 &top_dir = intersection[top_int_idx][TOP_EDGE].Direction;
-				top = top_dir * Vector3::Dot_Product(local_points[pidx], top_dir);
-				Vector3 &bottom_dir = intersection[bottom_int_idx][BOTTOM_EDGE].Direction;
-				bottom = bottom_dir * Vector3::Dot_Product(local_points[pidx], bottom_dir);
+				Vector3 &next_top_dir = intersection[top_int_idx][TOP_EDGE].Direction;
+				top = next_top_dir * Vector3::Dot_Product(local_points[pidx], next_top_dir);
+				Vector3 &next_bottom_dir = intersection[bottom_int_idx][BOTTOM_EDGE].Direction;
+				bottom = next_bottom_dir * Vector3::Dot_Product(local_points[pidx], next_bottom_dir);
 
 				vArray[vidx].x = top.X;
 				vArray[vidx].y = top.Y;
@@ -991,8 +991,8 @@ void SegLineRendererClass::Render
 					pidx++;
 
 					// Generate bottom vertex by picking nearest point on bottom direction line
-					Vector3 &bottom_dir = intersection[bottom_int_idx][BOTTOM_EDGE].Direction;
-					bottom = bottom_dir * Vector3::Dot_Product(local_points[pidx], bottom_dir);
+					Vector3 &next_bottom_dir = intersection[bottom_int_idx][BOTTOM_EDGE].Direction;
+					bottom = next_bottom_dir * Vector3::Dot_Product(local_points[pidx], next_bottom_dir);
 
 					vArray[vidx].x = bottom.X;
 					vArray[vidx].y = bottom.Y;
@@ -1020,8 +1020,8 @@ void SegLineRendererClass::Render
 					pidx++;
 
 					// Generate top vertex by picking nearest point on top direction line
-					Vector3 &top_dir = intersection[top_int_idx][TOP_EDGE].Direction;
-					top = top_dir * Vector3::Dot_Product(local_points[pidx], top_dir);
+					Vector3 &next_top_dir = intersection[top_int_idx][TOP_EDGE].Direction;
+					top = next_top_dir * Vector3::Dot_Product(local_points[pidx], next_top_dir);
 					vArray[vidx].x = top.X;
 					vArray[vidx].y = top.Y;
 					vArray[vidx].z = top.Z;
@@ -1032,10 +1032,10 @@ void SegLineRendererClass::Render
 			}
 
 			// Reduce both pointcounts by the same amount so the smaller one is 1 (skip points)
-			delta = MIN(residual_top_points, residual_bottom_points) - 1;
-			residual_top_points -= delta;
-			residual_bottom_points -= delta;
-			pidx += delta;
+			residual_delta = MIN(residual_top_points, residual_bottom_points) - 1;
+			residual_top_points -= residual_delta;
+			residual_bottom_points -= residual_delta;
+			pidx += residual_delta;
 
 			// Exit conditions
 			if (	(top_int_idx >= num_intersections[TOP_EDGE] && residual_top_points == 1) ||

--- a/Code/ww3d2/shattersystem.cpp
+++ b/Code/ww3d2/shattersystem.cpp
@@ -1126,7 +1126,7 @@ void ShatterSystem::Process_Clip_Pools
 				if (model->Peek_Single_Material(ipass) != NULL) {
 					matinfo->Add_Vertex_Material(model->Peek_Single_Material(ipass));
 				}
-				for (int istage=0; istage<MeshMatDescClass::MAX_TEX_STAGES; istage++) {
+				for (istage=0; istage<MeshMatDescClass::MAX_TEX_STAGES; istage++) {
 					if (model->Peek_Single_Texture(ipass,istage) != NULL) {
 						matinfo->Add_Texture(model->Peek_Single_Texture(ipass,istage));
 						has_textures = true;

--- a/Code/ww3d2/sphereobj.cpp
+++ b/Code/ww3d2/sphereobj.cpp
@@ -444,29 +444,29 @@ void SphereRenderObjClass::render_sphere()
 	DynamicVBAccessClass vb(BUFFER_TYPE_DYNAMIC_SORTING,dynamic_fvf_type,mesh.Vertex_ct);
 	{
 		DynamicVBAccessClass::WriteLockClass Lock(&vb);
-		VertexFormatXYZNDUV2 *vb = Lock.Get_Formatted_Vertex_Array();
+		VertexFormatXYZNDUV2 *fva = Lock.Get_Formatted_Vertex_Array();
 
 		for (int i=0; i<mesh.Vertex_ct; i++)
 		{
-			vb->x = mesh.vtx[i].X;
-			vb->y = mesh.vtx[i].Y;
-			vb->z = mesh.vtx[i].Z;
+			fva->x = mesh.vtx[i].X;
+			fva->y = mesh.vtx[i].Y;
+			fva->z = mesh.vtx[i].Z;
 
-			vb->nx = mesh.vtx_normal[i].X;		// may not need this!
-			vb->ny = mesh.vtx_normal[i].Y;
-			vb->nz = mesh.vtx_normal[i].Z;
+			fva->nx = mesh.vtx_normal[i].X;		// may not need this!
+			fva->ny = mesh.vtx_normal[i].Y;
+			fva->nz = mesh.vtx_normal[i].Z;
 
 			if (Flags & USE_ALPHA_VECTOR) {
-				vb->diffuse = DX8Wrapper::Convert_Color(mesh.dcg[i]);
+				fva->diffuse = DX8Wrapper::Convert_Color(mesh.dcg[i]);
 			} else {
-				vb->diffuse = 0xFFFFFFFF;		// TODO could combine the material color with this and turn off lighting
+				fva->diffuse = 0xFFFFFFFF;		// TODO could combine the material color with this and turn off lighting
 			}
 
 			if (SphereTexture) {
-				vb->u1 = mesh.vtx_uv[i].X;
-				vb->v1 = mesh.vtx_uv[i].Y;
+				fva->u1 = mesh.vtx_uv[i].X;
+				fva->v1 = mesh.vtx_uv[i].Y;
 			}
-			vb++;
+			fva++;
 		}
 	}
 

--- a/Code/ww3d2/stripoptimizer.cpp
+++ b/Code/ww3d2/stripoptimizer.cpp
@@ -923,10 +923,10 @@ int* Stripify::stripify  (const Vector3i* inTris, int N)
 			//--------------------------------------------------------------------
 
 			int		bestEdge	= -1;
-			int		bestWeight	= 0x7fffffff;
+			bestWeight	= 0x7fffffff;
 			bool	bestSwap	= false;
 
-			Vector3i nodeWeights = getTriangleNodeConnectivityWeights(queue, *next);
+			nodeWeights = getTriangleNodeConnectivityWeights(queue, *next);
 
 			for (i = 0; i < 3; i++)
 			if (next->m_neighbors[i])									// is there a neighbor?

--- a/Code/ww3d2/ww3d.cpp
+++ b/Code/ww3d2/ww3d.cpp
@@ -975,7 +975,7 @@ WW3DErrorType WW3D::Render(
 		return(WW3D_ERROR_OK);
 	}
 
-	WWPROFILE("WW3D::Render");
+	WWPROFILENAMED("WW3D::Render", top);
 	WWASSERT(IsInitted);
 	WWASSERT(IsRendering);
 
@@ -1051,7 +1051,7 @@ WW3DErrorType WW3D::End_Render(bool flip_frame)
 		return(WW3D_ERROR_OK);
 	}
 
-	WWPROFILE("WW3D::End_Render");
+	WWPROFILENAMED("WW3D::End_Render", top);
 
 	assert(IsRendering);
 	assert(IsInitted);

--- a/Code/wwdebug/wwprofile.h
+++ b/Code/wwdebug/wwprofile.h
@@ -214,9 +214,11 @@ public:
 };
 
 #ifdef ENABLE_WWPROFILE
+#define	WWPROFILENAMED(name, _var)	WWProfileSampleClass _wwprofile##_var( name, false )
 #define	WWPROFILE( name )						WWProfileSampleClass _wwprofile( name, false )
-#define	WWROOTPROFILE( name )				WWProfileSampleClass _wwprofile( name, true )
+#define	WWROOTPROFILE( name )				WWProfileSampleClass _wwrootprofile( name, true )
 #else
+#define	WWPROFILENAMED(name, _var)
 #define	WWPROFILE( name )
 #define	WWROOTPROFILE( name )
 #endif

--- a/Code/wwlib/bufffile.cpp
+++ b/Code/wwlib/bufffile.cpp
@@ -134,11 +134,11 @@ int BufferedFileClass::Read(void * buffer, int size)
 	int desired_buffer_size = _DesiredBufferSize;
 
 	// If we need more than the buffer will hold, just read it
-	int amount = BufferSize;
-	if ( amount == 0 ) {
-		amount = desired_buffer_size;
+	int buffer_size = BufferSize;
+	if ( buffer_size == 0 ) {
+		buffer_size = desired_buffer_size;
 	}
-	if ( size > amount ) {
+	if ( size > buffer_size ) {
 		return BASECLASS::Read( buffer, size ) + read;
 	}
 
@@ -158,11 +158,11 @@ int BufferedFileClass::Read(void * buffer, int size)
 
 	// If there is anything in the buffer, copy it in.
 	if ( BufferAvailable > 0 ) {
-		int amount = std::min( size, BufferAvailable );
-		::memcpy( buffer, &Buffer[BufferOffset], amount );
-		BufferAvailable -= amount;
-		BufferOffset += amount;
-		read += amount;
+		int buffered = std::min( size, BufferAvailable );
+		::memcpy( buffer, &Buffer[BufferOffset], buffered );
+		BufferAvailable -= buffered;
+		BufferOffset += buffered;
+		read += buffered;
 	}
 
 	return read;

--- a/Code/wwlib/mixfile.cpp
+++ b/Code/wwlib/mixfile.cpp
@@ -609,9 +609,9 @@ void	Add_Files( const char * dir, MixFileCreator & mix )
 		  bcontinue = ::FindNextFileA(hfile_find, &find_info)) {
 		if ( find_info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY ) {
 			if ( find_info.cFileName[0] != '.' ) {
-				StringClass	path;
-				path.Format( "%s%s/", dir, find_info.cFileName );
-				Add_Files( path, mix );
+				StringClass	sub_path;
+				sub_path.Format( "%s%s/", dir, find_info.cFileName );
+				Add_Files( sub_path, mix );
 			}
 		} else {
 			StringClass name;

--- a/Code/wwlib/wwstring.cpp
+++ b/Code/wwlib/wwstring.cpp
@@ -93,8 +93,7 @@ StringClass::Get_String (size_t length, bool is_temp)
 		//	Try to find an available temporary buffer
 		//
 		// TODO: Don't loop, there are better ways
-		unsigned mask=1;
-		for (int index = 0; index < MAX_TEMP_STRING; index ++, mask<<=1) {
+		for (int index = 0; index < MAX_TEMP_STRING; index ++) {
 			unsigned mask=1<<index;
 			if (!(ReservedMask&mask)) {
 				ReservedMask|=mask;

--- a/Code/wwphys/animcollisionmanager.cpp
+++ b/Code/wwphys/animcollisionmanager.cpp
@@ -1302,7 +1302,7 @@ bool AnimCollisionManagerClass::Check_Collision(CollideableObjClass & collisiono
 			/*
 			** Otherwise, try to push the object out of our way.
 			*/
-			int collision_bits = collisionobj.Clear_Collision_Bits();
+			collision_bits = collisionobj.Clear_Collision_Bits();
   			if (Push_Collided_Object(obj,delta_transform) == false) {
 				VERBOSE_LOG(("SAPO %s Failed to push a rider\r\n",Parent.Peek_Model()->Get_Name()));
 				revert = true;

--- a/Code/wwphys/pathsolve.cpp
+++ b/Code/wwphys/pathsolve.cpp
@@ -1638,8 +1638,8 @@ PathSolveClass::Post_Process_Path (void)
 	//	Relax the points
 	//
 	for (index = m_Path.Count () - 2; index > 1; index --) {
-		Vector3 &prev_point				= m_Path[index + 1].m_Point;
-		Vector3 &next_point				= m_Path[index - 1].m_Point;
+		Vector3 &prev_point_ref			= m_Path[index + 1].m_Point;
+		Vector3 &next_point_ref			= m_Path[index - 1].m_Point;
 		PathfindPortalClass *portal	= m_Path[index].m_Portal;
 		if (portal != NULL && portal->As_PathfindActionPortalClass () == NULL) {
 
@@ -1650,7 +1650,7 @@ PathSolveClass::Post_Process_Path (void)
 			AABoxClass portal_box;
 			portal->Get_Bounding_Box (portal_box);
 
-			m_Path[index].m_Point = Relax_Line (prev_point, next_point, portal_box);
+			m_Path[index].m_Point = Relax_Line (prev_point_ref, next_point_ref, portal_box);
 		}
 	}
 
@@ -1679,8 +1679,8 @@ PathSolveClass::Keep_Unit_Inside_Sectors (void)
 	//	Clip the starting point so that the unit will stay on the inside of its sector
 	//
 	Vector3 temp_point = m_Path[0].m_Point;
-	AABoxClass sector_box (m_Path[0].m_SectorCenter, m_Path[0].m_SectorExtent);
-	::Clip_Point (&temp_point, sector_box, m_PathObject.Get_Width () * 2);
+	AABoxClass start_sector_box (m_Path[0].m_SectorCenter, m_Path[0].m_SectorExtent);
+	::Clip_Point (&temp_point, start_sector_box, m_PathObject.Get_Width () * 2);
 	m_Path[0].m_Point = temp_point;
 
 	//

--- a/Code/wwphys/phys3.cpp
+++ b/Code/wwphys/phys3.cpp
@@ -1078,7 +1078,7 @@ bool Phys3Class::Intersection_Test(PhysMeshIntersectionTestClass & test)
  *=============================================================================================*/
 void Phys3Class::Timestep(float dt)
 {
-	WWPROFILE("Phys3::Timestep");
+	WWPROFILENAMED("Phys3::Timestep", top);
 	VERBOSE_LOG(("\r\n***** Phys3::Timestep. %s position: %f %f %f\r\n",Model->Get_Name(),State.Position.X,State.Position.Y,State.Position.Z));
 
 	/*
@@ -1705,13 +1705,13 @@ bool Phys3Class::Apply_Move
 				/*
 				** Try to move up to the obstacle
 				*/
-				float move_len = result.Fraction * move.Length();
-				if (move_len > epsilon) {
-					move_len -= epsilon;
+				float obstacle_move_len = result.Fraction * move.Length();
+				if (obstacle_move_len > epsilon) {
+					obstacle_move_len -= epsilon;
 					Vector3 direction = move;
 					direction.Normalize();
 
-					State.Position += move_len * direction;
+					State.Position += obstacle_move_len * direction;
 
 					move -= result.Fraction * move;
 					dt -= result.Fraction * dt;

--- a/Code/wwphys/projectile.cpp
+++ b/Code/wwphys/projectile.cpp
@@ -213,7 +213,7 @@ void ProjectileClass::Integrate(float dt)
 
 void ProjectileClass::Timestep(float dt)
 {
-	WWPROFILE("Projectile::Timestep");
+	WWPROFILENAMED("Projectile::Timestep", top);
 	const int MAX_BUMPS = 5;
 
 	if (Is_User_Control_Enabled()) {
@@ -229,7 +229,7 @@ void ProjectileClass::Timestep(float dt)
 
 	if ( CollidesOnMove ) {
 
-		WWPROFILE("Move and Collide");
+		WWPROFILENAMED("Move and Collide", mid);
 
 		/*
 		** Repeat until we eat all of the time
@@ -550,14 +550,14 @@ ProjectileDefClass::ProjectileDefClass(void) :
 #ifdef PARAM_EDITING_ON
 	// make our parameters editable!
 	EDITABLE_PARAM(ProjectileDefClass, ParameterClass::TYPE_BOOL, CollidesOnMove);
-
+	{
 	EnumParameterClass *param = new EnumParameterClass(&OrientationMode);
 	param->Set_Name ("OrientationMode");
 	param->Add_Value("ALIGNED",ProjectileClass::ORIENTATION_ALIGNED);
 	param->Add_Value("FIXED",ProjectileClass::ORIENTATION_FIXED);
 	param->Add_Value("TUMBLE",ProjectileClass::ORIENTATION_TUMBLING);
 	GENERIC_EDITABLE_PARAM(ProjectileDefClass,param)
-
+	}
 	FLOAT_EDITABLE_PARAM(ProjectileDefClass, TumbleAxis.X, 0.0f, 10.0f);
 	FLOAT_EDITABLE_PARAM(ProjectileDefClass, TumbleAxis.Y, 0.0f, 10.0f);
 	FLOAT_EDITABLE_PARAM(ProjectileDefClass, TumbleAxis.Z, 0.0f, 10.0f);

--- a/Code/wwphys/pscene.cpp
+++ b/Code/wwphys/pscene.cpp
@@ -329,7 +329,7 @@ PhysicsSceneClass::~PhysicsSceneClass(void)
  *=============================================================================================*/
 void PhysicsSceneClass::Update(float dt,int frameid)
 {
-	WWPROFILE("PhysicsScene::Update");
+	WWPROFILENAMED("PhysicsScene::Update", top);
 
 	Generate_Static_Shadow_Projectors();
 
@@ -1087,7 +1087,7 @@ void PhysicsSceneClass::Unregister(RenderObjClass * obj,RegType for_what)
  *=============================================================================================*/
 void PhysicsSceneClass::Pre_Render_Processing(CameraClass & camera)
 {
-	WWPROFILE("Pre_Render_Processing");
+	WWPROFILENAMED("Pre_Render_Processing", top);
 
 	LastCameraPosition = camera.Get_Position();
 
@@ -1395,7 +1395,7 @@ void PhysicsSceneClass::Render_Objects(
 	RefPhysListClass * static_list,
 	RefPhysListClass * dyn_list)
 {
-	WWPROFILE("Render_Meshes");
+	WWPROFILENAMED("Render_Meshes", top);
 
 	RefPhysListIterator it(static_ws_list);
 

--- a/Code/wwphys/rbody.cpp
+++ b/Code/wwphys/rbody.cpp
@@ -1588,7 +1588,7 @@ inline void RigidBodyClass::Dump_State(void) const
 
 void RigidBodyClass::Timestep(float dt)
 {
-	WWPROFILE("RigidBody::Timestep");
+	WWPROFILENAMED("RigidBody::Timestep", top);
 	LastTimestep = dt;
 
 // DEBUG DEBUG
@@ -1668,7 +1668,7 @@ Vector3 avel0 = AngularVelocity;
 	while ((remaining_time > 0.0f) && (collisions < MAX_COLLISIONS)) {
 
 		Assert_State_Valid();
-		WWPROFILE("RigidBodyClass integration loop");
+		WWPROFILENAMED("RigidBodyClass integration loop", mid);
 		timestep = remaining_time;
 
 		/*

--- a/Code/wwphys/trackedvehicle.cpp
+++ b/Code/wwphys/trackedvehicle.cpp
@@ -269,7 +269,7 @@ void TrackedVehicleClass::Add_Track_Mappers(MeshClass * mesh,int track_type)
 	if (has_mapper) {
 		mesh->Make_Unique();
 
-		MaterialInfoClass * matinfo = mesh->Get_Material_Info();
+		matinfo = mesh->Get_Material_Info();
 
 		if (matinfo != NULL) {
 			for (int i=0; i<matinfo->Vertex_Material_Count(); i++) {

--- a/Code/wwphys/wheel.cpp
+++ b/Code/wwphys/wheel.cpp
@@ -686,7 +686,7 @@ void WheelClass::Init
  *=============================================================================================*/
 void WheelClass::Compute_Force_And_Torque(Vector3 * force,Vector3 * torque)
 {
-	WWPROFILE("WheelClass::Compute_Force_And_Torque");
+	WWPROFILENAMED("WheelClass::Compute_Force_And_Torque", top);
 
 	if (Get_Flag(FAKE)) return;
 

--- a/Code/wwtranslatedb/translatedb.cpp
+++ b/Code/wwtranslatedb/translatedb.cpp
@@ -438,9 +438,9 @@ TranslateDBClass::Export_Table (const char *filename)
 			StringClass english_string = object->Get_English_String ();
 
 			const size_t length = english_string.Get_Length ();
-			for (size_t index = 0; index < length; index ++) {
-				if (english_string[static_cast<int>(index)] == '\n') {
-					english_string[static_cast<int>(index)] = ' ';
+			for (size_t str_index = 0; str_index < length; str_index ++) {
+				if (english_string[static_cast<int>(str_index)] == '\n') {
+					english_string[static_cast<int>(str_index)] = ' ';
 				}
 			}
 

--- a/Code/wwui/menuentryctrl.cpp
+++ b/Code/wwui/menuentryctrl.cpp
@@ -398,7 +398,7 @@ MenuEntryCtrlClass::Update_State (void)
 					//
 					uint32 start_time	= time2;
 					uint32 end_time	= time3;
-					float percent		= float(float(curr_time - start_time) / float(end_time - start_time));
+					percent		= float(float(curr_time - start_time) / float(end_time - start_time));
 
 					Vector3 color = start_color + (end_color - start_color) * percent;
 
@@ -411,7 +411,7 @@ MenuEntryCtrlClass::Update_State (void)
 
 					uint32 start_time	= time1;
 					uint32 end_time	= time2;
-					float percent		= float(float(curr_time - start_time) / float(end_time - start_time));
+					percent		= float(float(curr_time - start_time) / float(end_time - start_time));
 
 					Vector3 color = start_color + (end_color - start_color) * percent;
 					CurrColor = RGB_TO_INT32 (color.X, color.Y, color.Z);

--- a/Code/wwui/textmarqueectrl.cpp
+++ b/Code/wwui/textmarqueectrl.cpp
@@ -330,14 +330,14 @@ TextMarqueeCtrlClass::Build_Credit_Lines (void)
 			//
 			//	Copy this line of text into the control
 			//
-			WideStringClass text;
-			COPY_LINE (text, line_start, line_end);
+			WideStringClass text_str;
+			COPY_LINE (text_str, line_start, line_end);
 
 			//
 			//	Add this line to our list
 			//
 			CREDIT_LINE new_line (line);
-			new_line.Text		= text;
+			new_line.Text		= text_str;
 			new_line.Height	= TextRenderers[new_line.FontIndex].Peek_Font ()->Get_Char_Height ();
 			CreditLines.Add (new_line);
 


### PR DESCRIPTION
Cleans up instances where a variable reuses the name of a variable in a higher scope and masks it.