### PR TITLE
Silence C4244 warning for 32bit windows builds.

### DIFF
--- a/.github/workflows/openw3d.yml
+++ b/.github/workflows/openw3d.yml
@@ -23,7 +23,7 @@ jobs:
             cmake-args: -GNinja -DCMAKE_BUILD_TYPE=Release
             shell: pwsh
             arch: x86
-            options: "/W4;/WX;/wd4244"
+            options: "/W4;/WX"
           - name: MSVC x64
             os: windows-latest
             cmake-args: -GNinja -DCMAKE_BUILD_TYPE=Release

--- a/Code/BinkMovie/BinkPlayer.cpp
+++ b/Code/BinkMovie/BinkPlayer.cpp
@@ -248,7 +248,7 @@ void BINKMovieClass::Render()
 		Renderer.Set_Texture(TextureInfos[t].Texture);
 		Renderer.Set_Coordinate_Range(RectClass(0.0f, 0.0f, 1.0f, 1.0f));//Bink->Width,Bink->Height));
 
-		RectClass rect(TextureInfos[t].TextureLocX, TextureInfos[t].TextureLocY, TextureInfos[t].TextureWidth, TextureInfos[t].TextureHeight);
+		RectClass rect(float(TextureInfos[t].TextureLocX), float(TextureInfos[t].TextureLocY), float(TextureInfos[t].TextureWidth), float(TextureInfos[t].TextureHeight));
 		Renderer.Add_Quad(TextureInfos[t].Rect, TextureInfos[t].UV, 0xffffffff);
 		Renderer.Render();
 	}

--- a/Code/BinkMovie/FFMpegPlayer.cpp
+++ b/Code/BinkMovie/FFMpegPlayer.cpp
@@ -412,7 +412,7 @@ void FFMpegMovieClass::Render()
 		Renderer.Set_Texture(TextureInfos[t].Texture);
 		Renderer.Set_Coordinate_Range(RectClass(0.0f, 0.0f, 1.0f, 1.0f));//Bink->Get_Width(),Bink->Get_Height()));
 
-		RectClass rect(TextureInfos[t].TextureLocX, TextureInfos[t].TextureLocY, TextureInfos[t].TextureWidth, TextureInfos[t].TextureHeight);
+		RectClass rect(float(TextureInfos[t].TextureLocX), float(TextureInfos[t].TextureLocY), float(TextureInfos[t].TextureWidth), float(TextureInfos[t].TextureHeight));
 		Renderer.Add_Quad(TextureInfos[t].Rect, TextureInfos[t].UV, 0xffffffff);
 		Renderer.Render();
 	}

--- a/Code/BinkMovie/subtitlemanager.cpp
+++ b/Code/BinkMovie/subtitlemanager.cpp
@@ -324,7 +324,7 @@ void SubTitleManagerClass::Draw_Sub_Title(const SubTitleClass* subtitle)
 	// Assume left justification
 	int xPos = 0;
 	int yPos = subtitle->Get_Line_Position() * (h/16);
-	int xSize=extents[0];
+	int xSize=int(extents[0]);
 
 	SubTitleClass::Alignment align = subtitle->Get_Alignment();
 
@@ -335,7 +335,7 @@ void SubTitleManagerClass::Draw_Sub_Title(const SubTitleClass* subtitle)
 		xPos = (w - xSize);
 	}
 
-	Renderer.Set_Location(Vector2(xPos,yPos));
+	Renderer.Set_Location(Vector2(float(xPos),float(yPos)));
 	Renderer.Build_Sentence(string);
 
 	// Set font color

--- a/Code/Combat/WeatherMgr.cpp
+++ b/Code/Combat/WeatherMgr.cpp
@@ -177,8 +177,8 @@ void WindClass::Set (float heading, float speed, float variability)
  *=============================================================================================*/
 bool WindClass::Update()
 {
-	const double frequency [OCTAVE_COUNT] = {0.5l, 0.2l};
-	const double twopi						  = WWMATH_PI * 2.0l;
+	const double frequency [OCTAVE_COUNT] = {0.5, 0.2};
+	const double twopi						  = WWMATH_PI * 2.0;
 
 	float	h, speed;
 
@@ -189,10 +189,10 @@ bool WindClass::Update()
 
 		for (unsigned octave = 0; octave < OCTAVE_COUNT; octave++) {
 
-			Theta [octave] += WW3D::Get_Frame_Time() * 0.001l * frequency [octave];
-			d = floorf (Theta [octave] / twopi);
+			Theta [octave] += WW3D::Get_Frame_Time() * 0.001 * frequency [octave];
+			d = int(WWMath::Floor (Theta [octave] / twopi));
 			if (d >= 1) Theta [octave] -= d * twopi;
-			f += sinf (Theta [octave]);
+			f += float(WWMath::Sin (Theta [octave]));
 		}
 		speed = Speed - (Speed * ((f + 1.0f) * 0.5f) * Variability);
 	} else {
@@ -200,7 +200,7 @@ bool WindClass::Update()
 	}
 
 	h = Heading + (0.5f * WWMATH_PI);
-	Velocity.Set (cosf (h) * speed, sinf (h) * speed);
+	Velocity.Set (WWMath::Cos (h) * speed, WWMath::Sin (h) * speed);
 
 	// Update wind sound effect.
 	if (Sound != NULL) {
@@ -210,7 +210,7 @@ bool WindClass::Update()
 		float attenuation;
 
 		// Precalculate volume attenuation based on speed.
-		attenuation = (0.5f * (MIN (Speed, maxvolumespeed) + MIN (speed, maxvolumespeed))) / maxvolumespeed;
+		attenuation = (0.5f * (std::min (Speed, maxvolumespeed) + std::min (speed, maxvolumespeed))) / maxvolumespeed;
 		Sound->Set_Volume (SoundEnvironment->Get_Amplitude() * attenuation);
 	}
 
@@ -303,7 +303,7 @@ WeatherSystemClass::WeatherSystemClass	(PhysicsSceneClass *scene,
 		unsigned short *indices = lock.Get_Index_Array();
 
 		for (unsigned i = 0; i < MAX_IB_PARTICLE_COUNT * VERTICES_PER_TRIANGLE; i++) {
-			*indices++ = i;
+			*indices++ = static_cast<unsigned short>(i);
 		}
 	}
 
@@ -405,7 +405,7 @@ void WeatherSystemClass::Set_Density (float density)
 
 	// Calculate no. of rays required.
 	ParticleDensity = density;
-	raycount			 = Spawn_Count (1.0f) / (ParticlesPerUnitLength * ParticleSpeed);
+	raycount			 = int(Spawn_Count (1.0f) / (ParticlesPerUnitLength * ParticleSpeed));
 
 	// Is the ray count increasing or decreasing in size?
 	signedcount = ((int) RayCount) - ((int) raycount);
@@ -473,7 +473,7 @@ bool WeatherSystemClass::Update (WindClass *wind, const Vector3 &cameraposition)
 	const unsigned randomness		= 10000;
 	const float		oorandomness	= 1.0f / randomness;
 	const float		overlapdelta	= EmitterSize * 2.0f;
-	const unsigned rayupdatecount = MAX (RayCount * 0.018f, 1);
+	const unsigned rayupdatecount = unsigned(std::max (RayCount * 0.018f, 1.0f));
 
 	Vector3				oldemitterposition;
 	float					ooz;
@@ -667,7 +667,7 @@ bool WeatherSystemClass::Update (WindClass *wind, const Vector3 &cameraposition)
 			// Spawn some particles along the ray.
 			// NOTE: For accuracy, accumulate fractional spawncounts so that they can be used on a later ray.
 			s = ParticlesPerUnitLength * (rayptr->EndPosition - raystartposition).Quick_Length();
-			spawncount = floor (s);
+			spawncount = unsigned(WWMath::Floor (s));
 			spawncountfraction += s - spawncount;
 			if (spawncountfraction >= 1.0f) {
 				spawncountfraction -= 1.0f;
@@ -779,7 +779,7 @@ bool WeatherSystemClass::Update (WindClass *wind, const Vector3 &cameraposition)
 				// Place the particle at the collision point.
 				particleptr->Velocity.Set (0.0f, 0.0f, 0.0f);
 				particleptr->CurrentPosition = particleptr->CollisionPosition;
-				if (StaticPageExists) particleptr->Page = PageCount - 1;
+				if (StaticPageExists) particleptr->Page = static_cast<unsigned char>(PageCount - 1);
 				particleptr->RenderMode = RENDER_MODE_SURFACE_ALIGNED;
 			}
 
@@ -809,7 +809,7 @@ bool WeatherSystemClass::Update (WindClass *wind, const Vector3 &cameraposition)
 	// Spawn any new particles that need to be spawned on this update.
 	// NOTE: For accuracy, accumulate fractional spawncounts so that they can be used on a later iteration.
 	float s = Spawn_Count (time);
-	unsigned spawncount = floor (s);
+	unsigned spawncount = unsigned(WWMath::Floor (s));
 	SpawnCountFraction += s - spawncount;
 	if (SpawnCountFraction >= 1.0f) {
 		SpawnCountFraction -= 1.0f;
@@ -914,8 +914,8 @@ bool WeatherSystemClass::Spawn (RayStruct *suppliedrayptr)
 				particleptr->ElapsedTime	  = 0.0f;
 				particleptr->Velocity		  = rayptr->ParticleVelocity;
 				particleptr->CurrentPosition = Vector3 (rayptr->StartPosition.X, rayptr->StartPosition.Y, EmitterPosition.Z);
-				particleptr->Page				  = _RandomNumber (0, PageCount - (StaticPageExists ? 2 : 1));
-				particleptr->RenderMode		  = RenderMode;
+				particleptr->Page				  = static_cast<unsigned char>(_RandomNumber (0, PageCount - (StaticPageExists ? 2 : 1)));
+				particleptr->RenderMode		  = static_cast<unsigned char>(RenderMode);
 
 			} else {
 
@@ -929,17 +929,17 @@ bool WeatherSystemClass::Spawn (RayStruct *suppliedrayptr)
 					particleptr->Velocity.Set (0.0f, 0.0f, 0.0f);
 					particleptr->CurrentPosition = rayptr->EndPosition;
 					if (StaticPageExists) {
-						particleptr->Page	= PageCount - 1;
+						particleptr->Page	= static_cast<unsigned char>(PageCount - 1);
 					} else {
-						particleptr->Page	= _RandomNumber (0, PageCount - 1);
+						particleptr->Page	= static_cast<unsigned char>(_RandomNumber (0, PageCount - 1));
 					}
 					particleptr->RenderMode = RENDER_MODE_SURFACE_ALIGNED;
 
 				} else {
 					particleptr->Velocity		  = rayptr->ParticleVelocity;
 					particleptr->CurrentPosition = Vector3 (rayptr->StartPosition.X, rayptr->StartPosition.Y, EmitterPosition.Z) + (particleptr->Velocity * particleptr->ElapsedTime);
-					particleptr->Page				  = _RandomNumber (0, PageCount - (StaticPageExists ? 2 : 1));
-					particleptr->RenderMode		  = RenderMode;
+					particleptr->Page				  = static_cast<unsigned char>(_RandomNumber (0, PageCount - (StaticPageExists ? 2 : 1)));
+					particleptr->RenderMode		  = static_cast<unsigned char>(RenderMode);
 				}
 			}
 
@@ -1058,13 +1058,13 @@ void WeatherSystemClass::Render (RenderInfoClass &rinfo)
 			unsigned particlecount, submittedparticlecount;
 
 			#if WEATHER_PARTICLE_SORT
-			DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_SORTING, dynamic_fvf_type, bufferparticlecount * VERTICES_PER_TRIANGLE);
+			DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_SORTING, dynamic_fvf_type, static_cast<unsigned short>(bufferparticlecount * VERTICES_PER_TRIANGLE));
 			#else
-			DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, bufferparticlecount * VERTICES_PER_TRIANGLE);
+			DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, static_cast<unsigned short>(bufferparticlecount * VERTICES_PER_TRIANGLE));
 			#endif
 
 			// Copy the data into the sorting vertex buffer.
-			particlecount = MIN (ParticleCount - processedparticlecount, MAX_IB_PARTICLE_COUNT);
+			particlecount = std::min (ParticleCount - processedparticlecount, unsigned(MAX_IB_PARTICLE_COUNT));
 			submittedparticlecount = 0;
 			{
 				DynamicVBAccessClass::WriteLockClass lock (&dynamicvb);
@@ -1200,9 +1200,9 @@ void WeatherSystemClass::Render (RenderInfoClass &rinfo)
 				DX8Wrapper::Set_Vertex_Buffer (dynamicvb);
 
 				#if WEATHER_PARTICLE_SORT
-				SortingRendererClass::Insert_Triangles (0, submittedparticlecount, 0, submittedparticlecount * VERTICES_PER_TRIANGLE);
+				SortingRendererClass::Insert_Triangles (0, static_cast<unsigned short>(submittedparticlecount), 0, static_cast<unsigned short>(submittedparticlecount * VERTICES_PER_TRIANGLE));
 				#else
-				DX8Wrapper::Draw_Triangles (0, submittedparticlecount, 0, submittedparticlecount * VERTICES_PER_TRIANGLE);
+				DX8Wrapper::Draw_Triangles (0, static_cast<unsigned short>(submittedparticlecount), 0, static_cast<unsigned short>(submittedparticlecount * VERTICES_PER_TRIANGLE));
 				#endif
 			}
 

--- a/Code/Combat/action.cpp
+++ b/Code/Combat/action.cpp
@@ -600,7 +600,7 @@ public:
 
 		// Special case for soldier moving
 		if ( soldier && soldier->Is_On_Ladder() ) {
-			obj->Set_Analog_Control( ControlClass::ANALOG_MOVE_FORWARD, (move[2] >= 0) ? 1 : -1 );		// Could we make this move up?
+			obj->Set_Analog_Control( ControlClass::ANALOG_MOVE_FORWARD, (move[2] >= 0) ? 1.0f : -1.0f );		// Could we make this move up?
 		}
 	}
 

--- a/Code/Combat/actionparams.h
+++ b/Code/Combat/actionparams.h
@@ -79,8 +79,8 @@ class	ActionParamsStruct {
 public:
 	ActionParamsStruct( void );
 
-	void	Set_Basic( GameObjObserverClass * script, float priority, int action_id, SoldierAIState ai_state = NO_AI_STATE_CHANGE ) { ObserverID = script->Get_ID(); Priority = priority; ActionID = action_id; AIState = ai_state; }
-   void	Set_Basic( int observer_id, float priority, int action_id, SoldierAIState ai_state = NO_AI_STATE_CHANGE ) { ObserverID = observer_id; Priority = priority; ActionID = action_id; AIState = ai_state; }
+	void	Set_Basic( GameObjObserverClass * script, float priority, int action_id, SoldierAIState ai_state = NO_AI_STATE_CHANGE ) { ObserverID = script->Get_ID(); Priority = int(priority); ActionID = action_id; AIState = ai_state; }
+   void	Set_Basic( int observer_id, float priority, int action_id, SoldierAIState ai_state = NO_AI_STATE_CHANGE ) { ObserverID = observer_id; Priority = int(priority); ActionID = action_id; AIState = ai_state; }
 
 	void	Set_Look( const Vector3 & location, float duration ) { LookLocation = location; LookDuration = duration; }
 	void	Set_Look( GameObject * object, float duration ) { LookObject = object; LookDuration = duration; }
@@ -208,8 +208,8 @@ inline ActionParamsStruct::ActionParamsStruct( void ) :
 void	inline ActionParamsStruct::Set_Face_Location( const Vector3 &obj_pos, float angle, float duration )
 {
 	FaceLocation	= obj_pos;
-	FaceLocation.X	+= ::cos( angle );
-	FaceLocation.Y	+= ::sin( angle );
+	FaceLocation.X	+= WWMath::Cos( angle );
+	FaceLocation.Y	+= WWMath::Sin( angle );
 	FaceDuration	= duration;
 	return ;
 }
@@ -218,8 +218,8 @@ void	inline ActionParamsStruct::Set_Face_Location( const Vector3 &obj_pos, float
 void	inline ActionParamsStruct::Set_Look( const Vector3 &obj_pos, float angle,  float duration )
 {
 	LookLocation	= obj_pos;
-	LookLocation.X	+= ::cos( angle );
-	LookLocation.Y	+= ::sin( angle );
+	LookLocation.X	+= WWMath::Cos( angle );
+	LookLocation.Y	+= WWMath::Sin( angle );
 	LookDuration	= duration;
 	return ;
 }

--- a/Code/Combat/animcontrol.cpp
+++ b/Code/Combat/animcontrol.cpp
@@ -186,7 +186,7 @@ void AnimChannelClass::Set_Animation( const char *name )
 
 	if ( Animation ) {
 		SET_REF_OWNER( Animation );
-		NumFrames = Animation->Get_Num_Frames();
+		NumFrames = float(Animation->Get_Num_Frames());
 		Mode = ANIM_MODE_ONCE;
 		Frame = 0;
 		TargetFrame = 0;
@@ -211,7 +211,7 @@ void AnimChannelClass::Set_Animation( const HAnimClass *anim )
 
 	if ( Animation ) {
 		Animation->Add_Ref();
-		NumFrames = Animation->Get_Num_Frames();
+		NumFrames = float(Animation->Get_Num_Frames());
 		Mode = ANIM_MODE_ONCE;
 		Frame = 0;
 		TargetFrame = 0;

--- a/Code/Combat/backgroundmgr.cpp
+++ b/Code/Combat/backgroundmgr.cpp
@@ -56,6 +56,7 @@
 #include "wwmemlog.h"
 #include "seglinerenderer.h"
 #include "textureloader.h"
+#include <algorithm>
 
 
 // Singletons.
@@ -117,16 +118,16 @@ HazeClass::HazeClass (float radius)
 	for (segment = 0; segment < segmentcount; segment++) {
 		latitude = segment * twopioosegmentcount;
 		for (row = 0; row < RowCount + 1; row++) {
-			x = radius * sinf (longitude [row]) * cosf (latitude);
-			y = radius * sinf (longitude [row]) * sinf (latitude);
-			z = radius * cosf (longitude [row]);
+			x = radius * WWMath::Sin (longitude [row]) * WWMath::Cos (latitude);
+			y = radius * WWMath::Sin (longitude [row]) * WWMath::Sin (latitude);
+			z = radius * WWMath::Cos (longitude [row]);
 			VertexArray [v].Set (x, y, z);
 			v++;
 		}
 	}
 
 	// Define triangles.
-	IndexBuffer = NEW_REF (DX8IndexBufferClass, (TriangleCount * VERTICES_PER_TRIANGLE));
+	IndexBuffer = NEW_REF (DX8IndexBufferClass, (static_cast<unsigned short>(TriangleCount * VERTICES_PER_TRIANGLE)));
 	{
 		DX8IndexBufferClass::WriteLockClass lock (IndexBuffer);
 		unsigned short *indices = lock.Get_Index_Array();
@@ -138,19 +139,19 @@ HazeClass::HazeClass (float radius)
 
 				// Is this not the last segment?
 				if (segment < segmentcount - 1) {
-					indices [i + 0] = v;
-					indices [i + 1] = v + RowCount + 1;
-					indices [i + 2] = v + RowCount + 2;
-					indices [i + 3] = v + RowCount + 2;
-					indices [i + 4] = v + 1;
-					indices [i + 5] = v;
+					indices [i + 0] = static_cast<unsigned short>(v);
+					indices [i + 1] = static_cast<unsigned short>(v + RowCount + 1);
+					indices [i + 2] = static_cast<unsigned short>(v + RowCount + 2);
+					indices [i + 3] = static_cast<unsigned short>(v + RowCount + 2);
+					indices [i + 4] = static_cast<unsigned short>(v + 1);
+					indices [i + 5] = static_cast<unsigned short>(v);
 				} else {
-					indices [i + 0] = v;
-					indices [i + 1] = row;
-					indices [i + 2] = row + 1;
-					indices [i + 3] = row + 1;
-					indices [i + 4] = v + 1;
-					indices [i + 5] = v;
+					indices [i + 0] = static_cast<unsigned short>(v);
+					indices [i + 1] = static_cast<unsigned short>(row);
+					indices [i + 2] = static_cast<unsigned short>(row + 1);
+					indices [i + 3] = static_cast<unsigned short>(row + 1);
+					indices [i + 4] = static_cast<unsigned short>(v + 1);
+					indices [i + 5] = static_cast<unsigned short>(v);
 				}
 				v += RowCount + 1;
 				i += 6;
@@ -328,7 +329,7 @@ void HazeClass::Render()
 
 		// Copy the vertices into a dynamic vertex buffer.
 		// NOTE: Vertex normals and UV's are uninitialized.
-		DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, VertexCount);
+		DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, static_cast<unsigned short>(VertexCount));
 		{
 			DynamicVBAccessClass::WriteLockClass lock (&dynamicvb);
 			VertexFormatXYZNDUV2 *vertex = lock.Get_Formatted_Vertex_Array();
@@ -346,7 +347,7 @@ void HazeClass::Render()
 		DX8Wrapper::Set_Shader (Shader);
 		DX8Wrapper::Set_Index_Buffer (IndexBuffer, 0);
 		DX8Wrapper::Set_Vertex_Buffer (dynamicvb);
-		DX8Wrapper::Draw_Triangles (0, TriangleCount, 0, VertexCount);
+		DX8Wrapper::Draw_Triangles (0, static_cast<unsigned short>(TriangleCount), 0, static_cast<unsigned short>(VertexCount));
 	}
 }
 
@@ -374,7 +375,7 @@ StarfieldClass::StarfieldClass (float /* extent */, unsigned starcount)
 	WWASSERT (VertexArray != NULL);
 
 	// Define triangles.
-	IndexBuffer = NEW_REF (DX8IndexBufferClass, (VertexCount));
+	IndexBuffer = NEW_REF (DX8IndexBufferClass, (static_cast<unsigned short>(VertexCount)));
 	{
 		DX8IndexBufferClass::WriteLockClass lock (IndexBuffer);
 		unsigned short *indices = lock.Get_Index_Array();
@@ -516,7 +517,7 @@ void StarfieldClass::Configure()
 	const float		maxradius					= 0.90f;
 	const unsigned	intensityrandomness		= 16;
 	const float		oointensityrandomness	= 1.0f / intensityrandomness;
-	const float		theta							= sinf (WWMATH_PI / 36);
+	const float		theta							= WWMath::Sin (WWMATH_PI / 36);
 
 	Matrix3D		 m0;
 	unsigned		 t;
@@ -558,8 +559,8 @@ void StarfieldClass::Configure()
 
 				m1.Look_At (d * Length, d * Length * 2.0f, 0.0f);
 
-				r = pow (r, 10) * maxradius;
-				r = MAX (r, minradius);
+				r = WWMath::Pow (r, 10) * maxradius;
+				r = std::max (r, minradius);
 				VertexArray [ActiveVertexCount]		= m1 * Vector3 (-r, -r, 0.0f);
 				VertexArray [ActiveVertexCount + 1] = m1 * Vector3 (-r, +r, 0.0f);
 				VertexArray [ActiveVertexCount + 2] = m1 * Vector3 (+r, -r, 0.0f);
@@ -612,8 +613,8 @@ void StarfieldClass::Render()
 			// Emulate flickering stars by attenuating some randomly selected diffuse alphas.
 			alpha	= Alpha * flickeralpha;
 			f	   = flickercount * (((float) ActiveTriangleCount) / TriangleCount);
-			frac  = f - floorf (f);
-			activeflickercount = (frac < 0.5f) ? floorf (f) : floorf (f) + 1;
+			frac  = f - WWMath::Floor (f);
+			activeflickercount = unsigned((frac < 0.5f) ? WWMath::Floor (f) : WWMath::Floor (f) + 1);
 			for (i = 0; i < activeflickercount; i++) {
 				triangleindices [i] = _RandomNumber (0, ActiveTriangleCount - 1);
 				v = triangleindices [i] * VERTICES_PER_TRIANGLE;
@@ -628,7 +629,7 @@ void StarfieldClass::Render()
 
 		// Copy the vertices into a dynamic vertex buffer.
 		// NOTE: Vertex normals and stage 1 UV's are uninitialized.
-		DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, ActiveVertexCount);
+		DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, static_cast<unsigned short>(ActiveVertexCount));
 		{
 			const float	texcoordarray [VERTICES_PER_TRIANGLE][2] = {{0.0f, 0.0f}, {0.0f, 1.0f}, {1.0f, 0.0f}};
 
@@ -656,7 +657,7 @@ void StarfieldClass::Render()
 		DX8Wrapper::Set_Shader (Shader);
 		DX8Wrapper::Set_Index_Buffer (IndexBuffer, 0);
 		DX8Wrapper::Set_Vertex_Buffer (dynamicvb);
-		DX8Wrapper::Draw_Triangles (0, ActiveTriangleCount, 0, ActiveVertexCount);
+		DX8Wrapper::Draw_Triangles (0, static_cast<unsigned short>(ActiveTriangleCount), 0, static_cast<unsigned short>(ActiveVertexCount));
 
 		// Restore alphas for those stars that were modified prior to rendering.
 		for (i = 0; i < activeflickercount; i++) {
@@ -692,7 +693,7 @@ SkyObjectClass::SkyObjectClass (ShaderClass shader)
 
 	// Define triangles.
 	// NOTE: For simplicity, assume that there are exactly 8 vertices and 6 triangles.
-	IndexBuffer = NEW_REF (DX8IndexBufferClass, (TriangleCount * VERTICES_PER_TRIANGLE));
+	IndexBuffer = NEW_REF (DX8IndexBufferClass, (static_cast<unsigned short>(TriangleCount * VERTICES_PER_TRIANGLE)));
 	{
 		static const unsigned short _indices [] = {0, 4, 5, 5, 1, 0, 1, 5, 6, 6, 2, 1, 2, 6, 7, 7, 3, 2};
 
@@ -948,7 +949,7 @@ void SkyObjectClass::Render()
 
 		// Copy the vertices into the dynamic vertex buffer.
 		// NOTE: Vertex normals and stage 1 UV's are uninitialized.
-		DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, VertexCount);
+		DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, static_cast<unsigned short>(VertexCount));
 		{
 			DynamicVBAccessClass::WriteLockClass lock (&dynamicvb);
 			VertexFormatXYZNDUV2 *vertex = lock.Get_Formatted_Vertex_Array();
@@ -969,7 +970,7 @@ void SkyObjectClass::Render()
 		DX8Wrapper::Set_Shader (Shader);
 		DX8Wrapper::Set_Index_Buffer (IndexBuffer, 0);
 		DX8Wrapper::Set_Vertex_Buffer (dynamicvb);
-		DX8Wrapper::Draw_Triangles (0, TriangleCount, 0, VertexCount);
+		DX8Wrapper::Draw_Triangles (0, static_cast<unsigned short>(TriangleCount), 0, static_cast<unsigned short>(VertexCount));
 	}
 }
 
@@ -994,7 +995,7 @@ CloudLayerClass::CloudLayerClass (float maxdistance, const char *texturename, co
 
 	const float		radius				  = maxdistance;
 	const float		maxlongitude		  = WWMATH_PI / 15;
-	const float		oosinmaxlongitude	  = 1.0f / sinf (maxlongitude);
+	const float		oosinmaxlongitude	  = 1.0f / WWMath::Sin (maxlongitude);
 	const float		oorowcount			  = 1.0f / RowCount;
 	const unsigned	segmentcount		  = 16;
 	const float		twopioosegmentcount = (1.0f / segmentcount) * 2.0f * WWMATH_PI;
@@ -1016,17 +1017,17 @@ CloudLayerClass::CloudLayerClass (float maxdistance, const char *texturename, co
 	for (segment = 0; segment < segmentcount; segment++) {
 		latitude = segment * twopioosegmentcount;
 		for (row = 0; row < RowCount + 1; row++) {
-			longitude = (sinf (row * oorowcount * maxlongitude) * oosinmaxlongitude) * row * oorowcount * maxlongitude;
-			x = radius * sinf (longitude) * cosf (latitude);
-			y = radius * sinf (longitude) * sinf (latitude);
-			z = radius * (cosf (longitude) - cosf (maxlongitude));
+			longitude = (WWMath::Sin (row * oorowcount * maxlongitude) * oosinmaxlongitude) * row * oorowcount * maxlongitude;
+			x = radius * WWMath::Sin (longitude) * WWMath::Cos (latitude);
+			y = radius * WWMath::Sin (longitude) * WWMath::Sin (latitude);
+			z = radius * (WWMath::Cos (longitude) - WWMath::Cos (maxlongitude));
 			VertexArray [v].Set (x, y, z);
 			v++;
 		}
 	}
 
 	// Define triangles.
-	IndexBuffer = NEW_REF (DX8IndexBufferClass, (TriangleCount * VERTICES_PER_TRIANGLE));
+	IndexBuffer = NEW_REF (DX8IndexBufferClass, (static_cast<unsigned short>(TriangleCount * VERTICES_PER_TRIANGLE)));
 	{
 		DX8IndexBufferClass::WriteLockClass lock (IndexBuffer);
 		unsigned short *indices = lock.Get_Index_Array();
@@ -1038,19 +1039,19 @@ CloudLayerClass::CloudLayerClass (float maxdistance, const char *texturename, co
 
 				// Is this not the last segment?
 				if (segment < segmentcount - 1) {
-					indices [i + 0] = v;
-					indices [i + 1] = v + RowCount + 1;
-					indices [i + 2] = v + RowCount + 2;
-					indices [i + 3] = v + RowCount + 2;
-					indices [i + 4] = v + 1;
-					indices [i + 5] = v;
+					indices [i + 0] = static_cast<unsigned short>(v);
+					indices [i + 1] = static_cast<unsigned short>(v + RowCount + 1);
+					indices [i + 2] = static_cast<unsigned short>(v + RowCount + 2);
+					indices [i + 3] = static_cast<unsigned short>(v + RowCount + 2);
+					indices [i + 4] = static_cast<unsigned short>(v + 1);
+					indices [i + 5] = static_cast<unsigned short>(v);
 				} else {
-					indices [i + 0] = v;
-					indices [i + 1] = row;
-					indices [i + 2] = row + 1;
-					indices [i + 3] = row + 1;
-					indices [i + 4] = v + 1;
-					indices [i + 5] = v;
+					indices [i + 0] = static_cast<unsigned short>(v);
+					indices [i + 1] = static_cast<unsigned short>(row);
+					indices [i + 2] = static_cast<unsigned short>(row + 1);
+					indices [i + 3] = static_cast<unsigned short>(row + 1);
+					indices [i + 4] = static_cast<unsigned short>(v + 1);
+					indices [i + 5] = static_cast<unsigned short>(v);
 				}
 				v += RowCount + 1;
 				i += 6;
@@ -1076,7 +1077,7 @@ CloudLayerClass::CloudLayerClass (float maxdistance, const char *texturename, co
 	TexCoordArray = new Vector2 [VertexCount];
 	WWASSERT (TexCoordArray != NULL);
 
-	scale = tilefactor / (radius * sinf (maxlongitude));
+	scale = tilefactor / (radius * WWMath::Sin (maxlongitude));
 	for (v = 0; v < VertexCount; v++) {
 		if (rotate) {
 			TexCoordArray [v] = Vector2 (VertexArray [v].Y, VertexArray [v].X) * scale;
@@ -1302,7 +1303,7 @@ void CloudLayerClass::Render()
 
 		// Copy the vertices into the dynamic vertex buffer.
 		// NOTE: Vertex normals and stage 1 UV's are uninitialized.
-		DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, VertexCount);
+		DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, static_cast<unsigned short>(VertexCount));
 		{
 			DynamicVBAccessClass::WriteLockClass lock (&dynamicvb);
 			VertexFormatXYZNDUV2 *vertex = lock.Get_Formatted_Vertex_Array();
@@ -1323,7 +1324,7 @@ void CloudLayerClass::Render()
 		DX8Wrapper::Set_Shader (Shader);
 		DX8Wrapper::Set_Index_Buffer (IndexBuffer, 0);
 		DX8Wrapper::Set_Vertex_Buffer (dynamicvb);
-		DX8Wrapper::Draw_Triangles (0, TriangleCount, 0, VertexCount);
+		DX8Wrapper::Draw_Triangles (0, static_cast<unsigned short>(TriangleCount), 0, static_cast<unsigned short>(VertexCount));
 	}
 }
 
@@ -1359,7 +1360,7 @@ SkyGlowClass::SkyGlowClass (float radius)
 	TriangleCount = segmentcount * (RowCount * 2);
 
 	MinZ = 0.0f;
-	MaxZ = radius * cosf (longitude [0]);
+	MaxZ = radius * WWMath::Cos (longitude [0]);
 
 	// Define vertices.
 	VertexArray = new Vector3 [VertexCount];
@@ -1368,16 +1369,16 @@ SkyGlowClass::SkyGlowClass (float radius)
 	for (segment = 0; segment < segmentcount; segment++) {
 		latitude = segment * twopioosegmentcount;
 		for (row = 0; row < RowCount + 1; row++) {
-			x = radius * sinf (longitude [row]) * cosf (latitude);
-			y = radius * sinf (longitude [row]) * sinf (latitude);
-			z = radius * cosf (longitude [row]);
+			x = radius * WWMath::Sin (longitude [row]) * WWMath::Cos (latitude);
+			y = radius * WWMath::Sin (longitude [row]) * WWMath::Sin (latitude);
+			z = radius * WWMath::Cos (longitude [row]);
 			VertexArray [v].Set (x, y, z);
 			v++;
 		}
 	}
 
 	// Define triangles.
-	IndexBuffer = NEW_REF (DX8IndexBufferClass, (TriangleCount * VERTICES_PER_TRIANGLE));
+	IndexBuffer = NEW_REF (DX8IndexBufferClass, (static_cast<unsigned short>(TriangleCount * VERTICES_PER_TRIANGLE)));
 	{
 		DX8IndexBufferClass::WriteLockClass lock (IndexBuffer);
 		unsigned short *indices = lock.Get_Index_Array();
@@ -1389,19 +1390,19 @@ SkyGlowClass::SkyGlowClass (float radius)
 
 				// Is this not the last segment?
 				if (segment < segmentcount - 1) {
-					indices [i + 0] = v;
-					indices [i + 1] = v + RowCount + 1;
-					indices [i + 2] = v + RowCount + 2;
-					indices [i + 3] = v + RowCount + 2;
-					indices [i + 4] = v + 1;
-					indices [i + 5] = v;
+					indices [i + 0] = static_cast<unsigned short>(v);
+					indices [i + 1] = static_cast<unsigned short>(v + RowCount + 1);
+					indices [i + 2] = static_cast<unsigned short>(v + RowCount + 2);
+					indices [i + 3] = static_cast<unsigned short>(v + RowCount + 2);
+					indices [i + 4] = static_cast<unsigned short>(v + 1);
+					indices [i + 5] = static_cast<unsigned short>(v);
 				} else {
-					indices [i + 0] = v;
-					indices [i + 1] = row;
-					indices [i + 2] = row + 1;
-					indices [i + 3] = row + 1;
-					indices [i + 4] = v + 1;
-					indices [i + 5] = v;
+					indices [i + 0] = static_cast<unsigned short>(v);
+					indices [i + 1] = static_cast<unsigned short>(row);
+					indices [i + 2] = static_cast<unsigned short>(row + 1);
+					indices [i + 3] = static_cast<unsigned short>(row + 1);
+					indices [i + 4] = static_cast<unsigned short>(v + 1);
+					indices [i + 5] = static_cast<unsigned short>(v);
 				}
 				v += RowCount + 1;
 				i += 6;
@@ -1526,7 +1527,7 @@ void SkyGlowClass::Render()
 
 		// Copy the vertices into a dynamic vertex buffer.
 		// NOTE: Vertex normals and UV's are uninitialized.
-		DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, VertexCount);
+		DynamicVBAccessClass dynamicvb (BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, static_cast<unsigned short>(VertexCount));
 		{
 			DynamicVBAccessClass::WriteLockClass lock (&dynamicvb);
 			VertexFormatXYZNDUV2 *vertex = lock.Get_Formatted_Vertex_Array();
@@ -1544,7 +1545,7 @@ void SkyGlowClass::Render()
 		DX8Wrapper::Set_Shader (Shader);
 		DX8Wrapper::Set_Index_Buffer (IndexBuffer, 0);
 		DX8Wrapper::Set_Vertex_Buffer (dynamicvb);
-		DX8Wrapper::Draw_Triangles (0, TriangleCount, 0, VertexCount);
+		DX8Wrapper::Draw_Triangles (0, static_cast<unsigned short>(TriangleCount), 0, static_cast<unsigned short>(VertexCount));
 	}
 }
 
@@ -1566,7 +1567,7 @@ LightningBoltClass::LightningBoltClass (int branchcount, Matrix3D &m, float leng
 {
 	const int		 randomness					  = 100;
 	const float		 oorandomness				  = 1.0f / randomness;
-	const unsigned  maxvertexcount			  = MAX (2, length * 0.5f);
+	const unsigned  maxvertexcount			  = std::max (2u, unsigned(length * 0.5f));
 	const float		 oomaxvertexcountminusone = 1.0f / (maxvertexcount - 1);
 	const char		*texturename				  = "LightningBolt.tga";
 
@@ -1626,10 +1627,10 @@ LightningBoltClass::LightningBoltClass (int branchcount, Matrix3D &m, float leng
 		WWASSERT (Branches != NULL);
 		oobranchcount = 1.0f / BranchCount;
 		branchrandomness = vertexcount / (BranchCount * 2);
-		lbbranchcount = BranchCount * branchfactor;
+		lbbranchcount = int(BranchCount * branchfactor);
 		minlength = childlength * minlengthfactor;
 		maxlength = childlength * maxlengthfactor;
-		w = MAX (minwidth, width * widthfactor);
+		w = std::max (minwidth, width * widthfactor);
 		a = amplitude * amplitudefactor;
 		for (int b = 0; b < BranchCount; b++) {
 
@@ -1640,7 +1641,7 @@ LightningBoltClass::LightningBoltClass (int branchcount, Matrix3D &m, float leng
 			angle = WWMath::Lerp (minbranchangle, maxbranchangle, _RandomNumber (0, randomness) * oorandomness);
 			if ((b & 0x1) == 0) angle = -angle;
 			l = WWMath::Lerp (minlength, maxlength, _RandomNumber (0, randomness) * oorandomness);
-			v = MIN (((int) vertexcount) - 1, b * oobranchcount * (((int) vertexcount) - 1) + _RandomNumber (0, +branchrandomness));
+			v = unsigned(std::min (((int) vertexcount) - 1, int(b * oobranchcount * (((int) vertexcount) - 1) + _RandomNumber (0, +branchrandomness))));
 			m0.Translate (localvertex [v] - localvertex [0]);
 			m0.Rotate_Z (angle);
 
@@ -1843,26 +1844,26 @@ LightningClass::LightningClass (float extent, float startdistance, float enddist
 	unsigned	majorsampleindex, minorsampleindex;
 
 	Distance			  = WWMath::Lerp (startdistance, enddistance, _RandomNumber (0, randomness) * oorandomness);
-	ThunderDelayTime = WWMath::Lerp ((float) minthunderdelaytime, (float) maxthunderdelaytime, Distance);
+	ThunderDelayTime = unsigned(WWMath::Lerp ((float) minthunderdelaytime, (float) maxthunderdelaytime, Distance));
 
 	LightningGlow = new SkyGlowClass (extent);
 	WWASSERT (LightningGlow != NULL);
 
-	branchcount = WWMath::Lerp ((float) maxbranchcount, (float) minbranchcount, Distance);
+	branchcount = unsigned(WWMath::Lerp ((float) maxbranchcount, (float) minbranchcount, Distance));
 	latitude = heading + (0.5f * WWMATH_PI) + (_RandomNumber (- ((int) randomness), ((int) randomness)) * oorandomness * WWMATH_PI * distribution);
-	x = cosf (latitude);
-	y = sinf (latitude);
+	x = WWMath::Cos (latitude);
+	y = WWMath::Sin (latitude);
 	Direction.Set (x, y);
 	d.Set (x, y, 0.0f);
 	longitude = WWMath::Lerp (minlongitude, maxlongitude, Distance);
-	x = sinf (longitude) * cosf (latitude);
-	y = sinf (longitude) * sinf (latitude);
-	z = cosf (longitude);
+	x = WWMath::Sin (longitude) * WWMath::Cos (latitude);
+	y = WWMath::Sin (longitude) * WWMath::Sin (latitude);
+	z = WWMath::Cos (longitude);
 	o.Set (x, y, z);
 	m.Look_At (o * extent, (o + d) * extent, 0.0f);
 	theta   = (WWMATH_PI * 0.5f) - longitude;
-	childlength = extent * sinf (theta);
-	length = childlength + extent * cosf (theta) * tanf (bufferangle);
+	childlength = extent * WWMath::Sin (theta);
+	length = childlength + extent * WWMath::Cos (theta) * WWMath::Tan (bufferangle);
 	width	 = WWMath::Lerp (maxwidth, minwidth, Distance);
 	LightningBolt = NEW_REF (LightningBoltClass, (branchcount, m, length, childlength, width, amplitude));
 	WWASSERT (LightningBolt != NULL);
@@ -1875,7 +1876,7 @@ LightningClass::LightningClass (float extent, float startdistance, float enddist
 	LightningSource->Set_Texture (lightningsourcetexturename);
 
 	ThunderPosition	= o * (extent * Distance);
-	majorsampleindex	= MIN ((unsigned) (Distance * majorsamplecount), majorsamplecount - 1);
+	majorsampleindex	= std::min ((unsigned) (Distance * majorsamplecount), majorsamplecount - 1);
 	minorsampleindex	= _RandomNumber (0, minorsamplecount - 1);
 	ThunderSampleName = _thundersamplename [majorsampleindex][minorsampleindex];
 }
@@ -1939,10 +1940,10 @@ bool LightningClass::Update (Matrix3D &t, Vector3 &additivecolor, SoundEnvironme
   		unsigned phase;
   		Vector3	color;
 
-  		phase = (((float) Time) / lightningtime) * (phasecount + 1);
-  		phase = MIN (phase, phasecount);
+  		phase = unsigned((((float) Time) / lightningtime) * (phasecount + 1));
+  		phase = std::min (phase, phasecount);
 
-  		additivecolor = blue * _intensities [phase] * MAX (1.0f - Distance, minglowintensity);
+  		additivecolor = blue * _intensities [phase] * std::max (1.0f - Distance, minglowintensity);
 		LightningGlow->Configure (Direction, additivecolor, coldintensity);
 		additivecolor *= coldintensity;
 
@@ -2045,11 +2046,11 @@ WarBlitzClass::WarBlitzClass (float extent, float startdistance, float enddistan
 	Vector2 position;
 
 	Distance			 = WWMath::Lerp (startdistance, enddistance, _RandomNumber (0, randomness) * oorandomness);
-	SampleDelayTime = WWMath::Lerp ((float) minsampledelaytime, (float) maxsampledelaytime, Distance);
+	SampleDelayTime = unsigned(WWMath::Lerp ((float) minsampledelaytime, (float) maxsampledelaytime, Distance));
 
 	latitude = heading + (0.5f * WWMATH_PI) + (_RandomNumber (- ((int) randomness), ((int) randomness)) * oorandomness * WWMATH_PI * distribution);
-	x = cosf (latitude);
-	y = sinf (latitude);
+	x = WWMath::Cos (latitude);
+	y = WWMath::Sin (latitude);
 	Direction.Set (x, y);
 
 	position = Direction * (extent * Distance);
@@ -2108,9 +2109,9 @@ bool WarBlitzClass::Update (Matrix3D &t, Vector3 &additivecolor)
 
   		unsigned phase;
 
-  		phase = (((float) Time) / warblitztime) * (phasecount + 1);
-  		phase = MIN (phase, phasecount);
-  		additivecolor = red * _intensities [phase] * MAX (1.0f - Distance, minglowintensity);
+  		phase = unsigned((((float) Time) / warblitztime) * (phasecount + 1));
+  		phase = std::min (phase, phasecount);
+  		additivecolor = red * _intensities [phase] * std::max (1.0f - Distance, minglowintensity);
 		WarBlitzGlow->Configure (Direction, additivecolor, coldintensity);
 
   	} else {
@@ -2701,10 +2702,10 @@ Vector3 SkyClass::Interpolate_Color (const unsigned char colortable [][3], unsig
 	Vector3  color;
 
 	// Clamp the interpolant to the index range of the color table.
-	interpolant = MIN (MAX (0.0f, interpolant), colorcount);
+	interpolant = std::clamp(interpolant, 0.0f, float(colorcount));
 	if (interpolant == colorcount) interpolant = 0.0f;
 
-	lowerindex = floorf (interpolant);
+	lowerindex = unsigned(WWMath::Floor (interpolant));
 	upperindex = (lowerindex + 1) % colorcount;
 
 	lowercolor = Vector3 (colortable [lowerindex][0] * ooucharmax, colortable [lowerindex][1] * ooucharmax, colortable [lowerindex][2] * ooucharmax);
@@ -2736,10 +2737,11 @@ float SkyClass::Interpolate_Scalar (const unsigned char scalartable [], unsigned
 	float		lowervalue, uppervalue, alpha;
 
 	// Clamp the interpolant to the index range of the color table.
-	interpolant = MIN (MAX (0.0f, interpolant), scalarcount);
-	if (interpolant == scalarcount) interpolant = 0.0f;
+	interpolant = std::clamp(interpolant, 0.0f, float(scalarcount));
 
-	lowerindex = floorf (interpolant);
+	if (interpolant == float(scalarcount)) interpolant = 0.0f;
+
+	lowerindex = unsigned(WWMath::Floor (interpolant));
 	upperindex = (lowerindex + 1) % scalarcount;
 
 	lowervalue = scalartable [lowerindex] * ooucharmax;
@@ -3771,7 +3773,7 @@ void BackgroundMgrClass::Update (PhysicsSceneClass *mainscene, CameraClass *came
 	if (intensity < minlensflareintensity) {
 		lensflareintensity = 0.0f;
 	} else {
-	  	lensflareintensity = MIN (maxlensflareintensity, intensity);
+	  	lensflareintensity = std::min (maxlensflareintensity, intensity);
 	}
 	_Dazzle->Set_Dazzle_Color (dazzlecolor);
 	_Dazzle->Set_Lensflare_Intensity (lensflareintensity);

--- a/Code/Combat/basecontroller.cpp
+++ b/Code/Combat/basecontroller.cpp
@@ -777,7 +777,7 @@ BaseControllerClass::Distribute_Funds_To_Each_Teammate (int funds)
 				//
 				//	Add the money to this player's total
 				//
-				player_data->Increment_Money (funds);
+				player_data->Increment_Money (float(funds));
 			}
 		}
 	}

--- a/Code/Combat/building.cpp
+++ b/Code/Combat/building.cpp
@@ -745,7 +745,7 @@ BuildingGameObj::Update_State (bool force_update)
 
 			const GameObjObserverList & observer_list = Get_Observers();
 			for( int index = 0; index < observer_list.Count(); index++ ) {
-				observer_list[ index ]->Custom( this, event, health_percentage, NULL );
+				observer_list[ index ]->Custom( this, event, int(health_percentage), NULL );
 			}
 		}
 

--- a/Code/Combat/buildingaggregate.cpp
+++ b/Code/Combat/buildingaggregate.cpp
@@ -137,7 +137,7 @@ void BuildingAggregateClass::Init(const BuildingAggregateDefClass & def)
 {
 	StaticAnimPhysClass::Init(def);
 	AnimCollisionManagerClass & anim_mgr = Get_Animation_Manager();
-	anim_mgr.Set_Current_Frame(def.Frame0[CurrentState]);
+	anim_mgr.Set_Current_Frame(float(def.Frame0[CurrentState]));
 }
 
 
@@ -187,7 +187,7 @@ void BuildingAggregateClass::Set_Current_State(int new_state,bool force_update)
 				** Calculate the fractional position in our current loop
 				*/
 				float normalized_frame = 0.0f;
-				float cur_loop_len = def->Frame1[CurrentState] - def->Frame0[CurrentState];
+				float cur_loop_len = float(def->Frame1[CurrentState] - def->Frame0[CurrentState]);
 
 				if (cur_loop_len > 0.0f) {
 					normalized_frame = (anim_mgr.Get_Current_Frame() - def->Frame0[CurrentState]) /
@@ -197,8 +197,8 @@ void BuildingAggregateClass::Set_Current_State(int new_state,bool force_update)
 				/*
 				** Switch the loop start and end
 				*/
-				anim_mgr.Set_Loop_Start(def->Frame0[new_state]);
-				anim_mgr.Set_Loop_End(def->Frame1[new_state]);
+				anim_mgr.Set_Loop_Start(float(def->Frame0[new_state]));
+				anim_mgr.Set_Loop_End(float(def->Frame1[new_state]));
 
 				/*
 				** Jump to the same fractional position in the new loop
@@ -220,7 +220,7 @@ void BuildingAggregateClass::Set_Current_State(int new_state,bool force_update)
 				/*
 				** The new target frame is determined by the new state
 				*/
-				anim_mgr.Set_Target_Frame(def->Frame0[new_state]);
+				anim_mgr.Set_Target_Frame(float(def->Frame0[new_state]));
 				anim_mgr.Set_Animation_Mode(AnimCollisionManagerClass::ANIMATE_TARGET);
 
 				/*
@@ -229,7 +229,7 @@ void BuildingAggregateClass::Set_Current_State(int new_state,bool force_update)
 				if (	(BuildingStateClass::Is_Power_On(new_state) != BuildingStateClass::Is_Power_On(CurrentState)) ||
 						(def->AnimationEnabled[new_state] == false))
 				{
-					anim_mgr.Set_Current_Frame(def->Frame0[new_state]);
+					anim_mgr.Set_Current_Frame(float(def->Frame0[new_state]));
 				}
 				break;
 			}
@@ -241,8 +241,8 @@ void BuildingAggregateClass::Set_Current_State(int new_state,bool force_update)
 				*/
 				if ((def->Frame0[CurrentState] != def->Frame0[new_state]) || (def->Frame1[CurrentState] != def->Frame1[new_state])) {
 					anim_mgr.Set_Animation_Mode(AnimCollisionManagerClass::ANIMATE_TARGET);
-					anim_mgr.Set_Current_Frame(def->Frame0[new_state]);
-					anim_mgr.Set_Target_Frame(def->Frame1[new_state]);
+					anim_mgr.Set_Current_Frame(float(def->Frame0[new_state]));
+					anim_mgr.Set_Target_Frame(float(def->Frame1[new_state]));
 				}
 				break;
 			}

--- a/Code/Combat/c4.cpp
+++ b/Code/Combat/c4.cpp
@@ -239,7 +239,7 @@ void	C4GameObj::Init_C4( const AmmoDefinitionClass * def, SoldierGameObj *owner,
 		Timer = time;
 	}
 
-	float	sound_id = def->C4TimingSound1ID;
+	int	sound_id = def->C4TimingSound1ID;
 	if ( detonation_mode == 2 ) 		sound_id = def->C4TimingSound1ID;
 	if ( detonation_mode == 3 )		sound_id = def->C4TimingSound1ID;
 

--- a/Code/Combat/ccamera.cpp
+++ b/Code/Combat/ccamera.cpp
@@ -172,7 +172,7 @@ void	CCameraProfileClass::Set_Zoom( float amount )
 float CCameraProfileClass::Get_Zoom( void )
 {
 	// TSS - by my reckoning this is the actual zoom factor
-	return 0.8 / FOV;
+	return 0.8f / FOV;
 }
 
 #define	Get_Camera_Profile_Radians( v, e )			\
@@ -1345,14 +1345,14 @@ void	CCameraClass::Handle_Input( void )
 
 		Vector3	tweak(0,0,0);
 
-		tweak.X	 =	( Input::Get_State( INPUT_FUNCTION_CAMERA_TRANSTILT_INC ) ? 1 : 0 ) +
-						( Input::Get_State( INPUT_FUNCTION_CAMERA_TRANSTILT_DEC ) ? -1 : 0 );
+		tweak.X	 =	float(( Input::Get_State( INPUT_FUNCTION_CAMERA_TRANSTILT_INC ) ? 1 : 0 ) +
+						( Input::Get_State( INPUT_FUNCTION_CAMERA_TRANSTILT_DEC ) ? -1 : 0 ));
 
-		tweak.Y	 =	( Input::Get_State( INPUT_FUNCTION_DEBUG_FAR_CLIP_IN ) ? -1 : 0 ) +
-						( Input::Get_State( INPUT_FUNCTION_DEBUG_FAR_CLIP_OUT ) ? 1 : 0 );
+		tweak.Y	 =	float(( Input::Get_State( INPUT_FUNCTION_DEBUG_FAR_CLIP_IN ) ? -1 : 0 ) +
+						( Input::Get_State( INPUT_FUNCTION_DEBUG_FAR_CLIP_OUT ) ? 1 : 0 ));
 
-		tweak.Z	 =	( Input::Get_State( INPUT_FUNCTION_CAMERA_DIST_INC ) ? -1 : 0 ) +
-						( Input::Get_State( INPUT_FUNCTION_CAMERA_DIST_DEC ) ? 1 : 0 );
+		tweak.Z	 =	float(( Input::Get_State( INPUT_FUNCTION_CAMERA_DIST_INC ) ? -1 : 0 ) +
+						( Input::Get_State( INPUT_FUNCTION_CAMERA_DIST_DEC ) ? 1 : 0 ));
 
 		tweak *= dt * FP_TWEAK_RATE;
 		if ( tweak.Length() ) {
@@ -1368,28 +1368,28 @@ void	CCameraClass::Handle_Input( void )
 
 	} else {
 
-		float	tilt_amount =	( Input::Get_State( INPUT_FUNCTION_CAMERA_TRANSTILT_INC ) ? 1 : 0 ) +
-									( Input::Get_State( INPUT_FUNCTION_CAMERA_TRANSTILT_DEC ) ? -1 : 0 );
+		float	tilt_amount =	float(( Input::Get_State( INPUT_FUNCTION_CAMERA_TRANSTILT_INC ) ? 1 : 0 ) +
+									( Input::Get_State( INPUT_FUNCTION_CAMERA_TRANSTILT_DEC ) ? -1 : 0 ));
 		CurrentProfile->TranslationTilt += TILT_ADJUST * tilt_amount * dt;
 		CurrentProfile->TranslationTilt = WWMath::Clamp( CurrentProfile->TranslationTilt, MIN_TILT, MAX_TILT );
 
-		float	view_tilt_amount =	( Input::Get_State( INPUT_FUNCTION_CAMERA_VIEWTILT_INC ) ? 1 : 0 ) +
-									( Input::Get_State( INPUT_FUNCTION_CAMERA_VIEWTILT_DEC ) ? -1 : 0 );
+		float	view_tilt_amount =	float(( Input::Get_State( INPUT_FUNCTION_CAMERA_VIEWTILT_INC ) ? 1 : 0 ) +
+									( Input::Get_State( INPUT_FUNCTION_CAMERA_VIEWTILT_DEC ) ? -1 : 0 ));
 		CurrentProfile->ViewTilt += TILT_ADJUST * view_tilt_amount * dt;
 		CurrentProfile->ViewTilt = WWMath::Clamp( CurrentProfile->ViewTilt, MIN_TILT, MAX_TILT );
 
-		float	distance_amount =	( Input::Get_State( INPUT_FUNCTION_CAMERA_DIST_INC ) ? 1 : 0 ) +
-										( Input::Get_State( INPUT_FUNCTION_CAMERA_DIST_DEC ) ? -1 : 0 );
+		float	distance_amount =	float(( Input::Get_State( INPUT_FUNCTION_CAMERA_DIST_INC ) ? 1 : 0 ) +
+										( Input::Get_State( INPUT_FUNCTION_CAMERA_DIST_DEC ) ? -1 : 0 ));
 		CurrentProfile->Distance += DISTANCE_ADJUST * distance_amount * dt;
 		CurrentProfile->Distance = WWMath::Clamp( CurrentProfile->Distance, MIN_DISTANCE, MAX_DISTANCE );
 
-		float	fov_amount =	( Input::Get_State( INPUT_FUNCTION_CAMERA_FOV_INC ) ? 1 : 0 ) +
-									( Input::Get_State( INPUT_FUNCTION_CAMERA_FOV_DEC ) ? -1 : 0 );
+		float	fov_amount =	float(( Input::Get_State( INPUT_FUNCTION_CAMERA_FOV_INC ) ? 1 : 0 ) +
+									( Input::Get_State( INPUT_FUNCTION_CAMERA_FOV_DEC ) ? -1 : 0 ));
 		CurrentProfile->FOV += FOV_ADJUST * fov_amount * dt;
 		CurrentProfile->FOV = WWMath::Clamp( CurrentProfile->FOV, MIN_FOV, MAX_FOV );
 
-		float	height_amount =	( Input::Get_State( INPUT_FUNCTION_CAMERA_HEIGHT_INC ) ? 1 : 0 ) +
-										( Input::Get_State( INPUT_FUNCTION_CAMERA_HEIGHT_DEC ) ? -1 : 0 );
+		float	height_amount =	float(( Input::Get_State( INPUT_FUNCTION_CAMERA_HEIGHT_INC ) ? 1 : 0 ) +
+										( Input::Get_State( INPUT_FUNCTION_CAMERA_HEIGHT_DEC ) ? -1 : 0 ));
 		CurrentProfile->Height += HEIGHT_ADJUST * height_amount * dt;
 		CurrentProfile->Height = WWMath::Clamp( CurrentProfile->Height, MIN_HEIGHT, MAX_HEIGHT );
 

--- a/Code/Combat/combat.cpp
+++ b/Code/Combat/combat.cpp
@@ -538,7 +538,7 @@ void	CombatManager::Unload_Level( void )
 		Vector2 extents = backdropText.Get_Text_Extents( wide_str );
 		float x = (Render2DClass::Get_Screen_Resolution().Right - extents.X) / 2.0f;
 		float y = (Render2DClass::Get_Screen_Resolution().Bottom - extents.Y) / 2.0f;
-		backdropText.Set_Location( Vector2( (int)x, (int)y ) );
+		backdropText.Set_Location( Vector2( WWMath::Trunc(x), WWMath::Trunc(y) ) );
 		backdropText.Draw_Sentence( 0xFF00FF00 );	// Green
 		WW3D::Begin_Render( true, true, Vector3(0.0f,0.0f,0.0f), NULL);
 		backdropText.Render();

--- a/Code/Combat/cover.cpp
+++ b/Code/Combat/cover.cpp
@@ -136,7 +136,7 @@ CoverEntryClass * CoverManager::Request_Cover( const Vector3 & cur_pos, const Ve
 {
 	// Find a cover spot, not in use, within max_dist, that blocks from danger
 	int best_index = -1;
-	int best_dist = max_dist;
+	float best_dist = max_dist;
 	for ( int index = 0; index < CoverPositions.Count(); index++ ) {
 		CoverEntryClass * cover = CoverPositions[ index ];
 		if ( cover->Get_In_Use() ) {

--- a/Code/Combat/damageablestaticphys.cpp
+++ b/Code/Combat/damageablestaticphys.cpp
@@ -349,12 +349,12 @@ void DamageableStaticPhysClass::Start_Loop(void)
 
 		if (frame0 != frame1) {
 			Get_Animation_Manager().Set_Animation_Mode(AnimCollisionManagerClass::ANIMATE_LOOP);
-			Get_Animation_Manager().Set_Current_Frame(frame0);
-			Get_Animation_Manager().Set_Loop_Start(frame0);
-			Get_Animation_Manager().Set_Loop_End(frame1);
+			Get_Animation_Manager().Set_Current_Frame(float(frame0));
+			Get_Animation_Manager().Set_Loop_Start(float(frame0));
+			Get_Animation_Manager().Set_Loop_End(float(frame1));
 		} else {
 			Get_Animation_Manager().Set_Animation_Mode(AnimCollisionManagerClass::ANIMATE_MANUAL);
-			Get_Animation_Manager().Set_Current_Frame(frame0);
+			Get_Animation_Manager().Set_Current_Frame(float(frame0));
 		}
 	} else {
 		WWDEBUG_SAY(("ERROR: Missing definition for damageable object: %s\n",Model->Get_Name()));
@@ -396,8 +396,8 @@ void DamageableStaticPhysClass::Play_Twitch(void)
 
 			if (frame0 != frame1) {
 				Get_Animation_Manager().Set_Animation_Mode(AnimCollisionManagerClass::ANIMATE_TARGET);
-				Get_Animation_Manager().Set_Current_Frame(frame0);
-				Get_Animation_Manager().Set_Target_Frame(frame1);
+				Get_Animation_Manager().Set_Current_Frame(float(frame0));
+				Get_Animation_Manager().Set_Target_Frame(float(frame1));
 			}
 		}
 
@@ -415,8 +415,8 @@ void DamageableStaticPhysClass::Play_Death_Transition(void)
 		if (def->DeathTransitionStart != def->DeathTransitionEnd) {
 			CurState = STATE_DEATH_TRANSITION;
 			Get_Animation_Manager().Set_Animation_Mode(AnimCollisionManagerClass::ANIMATE_TARGET);
-			Get_Animation_Manager().Set_Current_Frame(def->DeathTransitionStart);
-			Get_Animation_Manager().Set_Target_Frame(def->DeathTransitionEnd);
+			Get_Animation_Manager().Set_Current_Frame(float(def->DeathTransitionStart));
+			Get_Animation_Manager().Set_Target_Frame(float(def->DeathTransitionEnd));
 		} else {
 			Start_Loop();
 		}

--- a/Code/Combat/doors.cpp
+++ b/Code/Combat/doors.cpp
@@ -407,7 +407,7 @@ bool DoorPhysClass::Set_State( int new_state )
 				//	Open the door
 				//
 				AnimManager.Set_Animation_Mode( AnimCollisionManagerClass::ANIMATE_TARGET );
-				AnimManager.Set_Target_Frame( AnimManager.Peek_Animation()->Get_Num_Frames() - 1	);
+				AnimManager.Set_Target_Frame( float(AnimManager.Peek_Animation()->Get_Num_Frames() - 1)	);
 			}
 			break;
 
@@ -439,7 +439,7 @@ bool DoorPhysClass::Set_State( int new_state )
 				// Clients *must* see the opening - it's a guaranteed packet. ST - 1/15/2002 12:59PM
 				//
 				AnimManager.Set_Animation_Mode( AnimCollisionManagerClass::ANIMATE_TARGET );
-				AnimManager.Set_Target_Frame( AnimManager.Peek_Animation()->Get_Num_Frames() - 1	);
+				AnimManager.Set_Target_Frame( float(AnimManager.Peek_Animation()->Get_Num_Frames() - 1)	);
 			}
 			break;
 

--- a/Code/Combat/elevator.cpp
+++ b/Code/Combat/elevator.cpp
@@ -517,7 +517,7 @@ void	ElevatorPhysClass::Set_State( int new_state )
 
 			case STATE_MOVING_DOWN:
 				AnimManager.Set_Animation_Mode( AnimCollisionManagerClass::ANIMATE_TARGET );
-				AnimManager.Set_Target_Frame( AnimManager.Peek_Animation()->Get_Num_Frames() - 1 );
+				AnimManager.Set_Target_Frame( float(AnimManager.Peek_Animation()->Get_Num_Frames() - 1) );
 				break;
 		}
 
@@ -752,7 +752,7 @@ void	ElevatorPhysClass::Update_Sound_Effects( void )
 		//
 		//	Check to see if we should play the opening or closing sounds on the door
 		//
-		if ( Has_Frame_Occured( prev_frame, curr_frame, AnimManager.Peek_Animation()->Get_Num_Frames()-1 ) ) {
+		if ( Has_Frame_Occured( prev_frame, curr_frame, float(AnimManager.Peek_Animation()->Get_Num_Frames()-1) ) ) {
 			Play_Effect( EFFECT_DOOR_CLOSING,  false );
 		} else if ( Has_Frame_Occured( prev_frame, curr_frame, def->DoorClosedTop_FrameNum ) ) {
 			Play_Effect( EFFECT_DOOR_OPENING,  true );

--- a/Code/Combat/explosion.cpp
+++ b/Code/Combat/explosion.cpp
@@ -334,7 +334,7 @@ if (!WWMath::Is_Valid_Float(dist)) {
 							float scale = 1.0f;
 							if ( explosion_def->DamageIsScaled ) {
 								WWASSERT(radius > WWMATH_EPSILON);
-								scale = 1.0 - (dist / radius);
+								scale = 1.0f - (dist / radius);
 								WWASSERT(WWMath::Is_Valid_Float(scale));
 							}
 

--- a/Code/Combat/hud.cpp
+++ b/Code/Combat/hud.cpp
@@ -359,7 +359,7 @@ static	void	Powerup_Add( const unichar_t * name, int number, const char * textur
 //	SurfaceClass::SurfaceDescription surface_desc;
 //	data->Renderer->Peek_Texture()->Get_Level_Description( surface_desc );
 //	float size = surface_desc.Width;		// Assume square
-	float size = data->Renderer->Peek_Texture()->Get_Width(); // Assume square
+	float size = float(data->Renderer->Peek_Texture()->Get_Width()); // Assume square
 	data->UV = uv;
 	if ( size > 0 ) {
 		data->UV.Scale( Vector2( 1/size, 1/size ) );
@@ -812,8 +812,8 @@ static	void	Weapon_Update( void )
 		WeaponClipCountRenderer->Set_Location( WeaponBase + Vector2( CLIP_ROUNDS_OFFSET ) );
 		WeaponClipCountRenderer->Draw_Text( tmp_text );
 
-		if ( LastClipCount != weapon->Get_Clip_Rounds() ) {
-			LastClipCount = weapon->Get_Clip_Rounds();
+		if ( LastClipCount != float(weapon->Get_Clip_Rounds()) ) {
+			LastClipCount = float(weapon->Get_Clip_Rounds());
 			CenterClipCountTimer = CENTER_CLIP_COUNT_TIME;
 		}
 
@@ -933,7 +933,7 @@ static	void	Weapon_Update( void )
 //			SurfaceClass::SurfaceDescription surface_desc;
 //			WeaponImageRenderer->Peek_Texture()->Get_Level_Description( surface_desc );
 //			float size = surface_desc.Width;		// Assume square
-			float size = WeaponImageRenderer->Peek_Texture()->Get_Width(); // Assume square
+			float size = float(WeaponImageRenderer->Peek_Texture()->Get_Width()); // Assume square
 			if ( size > 0 ) {
 				uv.Scale( Vector2( 1/size, 1/size ) );
 			}
@@ -1036,8 +1036,8 @@ static	void	Build_Weapon_Chart_Icons( void )
 		WeaponChartKeynameRenderer->Build_Sentence( name );
 		Vector2 text_size = WeaponChartKeynameRenderer->Get_Text_Extents( name );
 		Vector2 text_offset = pos - text_size/2 - Vector2( 0, WeaponChartSpacing.Y * screen_scale * 0.75f );
-		text_offset.X = (int)text_offset.X;
-		text_offset.Y = (int)text_offset.Y;
+		text_offset.X = WWMath::Trunc(text_offset.X);
+		text_offset.Y = WWMath::Trunc(text_offset.Y);
 		WeaponChartKeynameRenderer->Set_Location( text_offset );
 		WeaponChartKeynameRenderer->Draw_Sentence();
 
@@ -1079,7 +1079,7 @@ static	void	Build_Weapon_Chart_Icons( void )
 //					SurfaceClass::SurfaceDescription surface_desc;
 //					renderer->Peek_Texture()->Get_Level_Description( surface_desc );
 //					float size = surface_desc.Width;		// Assume square
-					float size = renderer->Peek_Texture()->Get_Width(); // Assume square
+					float size = float(renderer->Peek_Texture()->Get_Width()); // Assume square
 					if ( size > 0 ) {
 						uv.Scale( Vector2( 1/size, 1/size ) );
 					}
@@ -2040,16 +2040,16 @@ static	void	Objective_Update( void )
 		}
 
 		Vector2 arrow_vertex;
-		arrow_vertex.X = WWMath::Fast_Sin( angle + DEG_TO_RAD( 180 + 45 ) );
-		arrow_vertex.Y = WWMath::Fast_Cos( angle + DEG_TO_RAD( 180 + 45 ) );
+		arrow_vertex.X = WWMath::Fast_Sin( angle + DEG_TO_RADF( 180 + 45 ) );
+		arrow_vertex.Y = WWMath::Fast_Cos( angle + DEG_TO_RADF( 180 + 45 ) );
 		Vector2 verts[4];
 		verts[0] = Vector2( arrow_vertex.X, arrow_vertex.Y );
 		verts[1] = Vector2( arrow_vertex.Y, -arrow_vertex.X );
 		verts[2] = Vector2( -arrow_vertex.Y, arrow_vertex.X );
 		verts[3] = Vector2( -arrow_vertex.X, -arrow_vertex.Y );
 		Vector2 offset;
-		offset.Y = WWMath::Fast_Sin( -angle + DEG_TO_RAD( -90 ) );
-		offset.X = WWMath::Fast_Cos( -angle + DEG_TO_RAD( -90 ) );
+		offset.Y = WWMath::Fast_Sin( -angle + DEG_TO_RADF( -90 ) );
+		offset.X = WWMath::Fast_Cos( -angle + DEG_TO_RADF( -90 ) );
 		offset *= 35;
 		offset += pog_box.Center();
 
@@ -2076,7 +2076,7 @@ static	void	Objective_Update( void )
 			WideStringClass str(ObjectiveManager::Get_HUD_Objectives_Message( CurrentObjectiveIndex ),true);
 			ObjectiveTextRenderer->Build_Sentence( str );
 			Vector2 text_size = ObjectiveTextRenderer->Get_Text_Extents( str );
-			position.X = (int)(pog_box.Center().X - (text_size.X/2));
+			position.X = WWMath::Trunc(pog_box.Center().X - (text_size.X/2));
 			ObjectiveTextRenderer->Set_Location( position );
 			ObjectiveTextRenderer->Draw_Sentence();
 
@@ -2085,7 +2085,7 @@ static	void	Objective_Update( void )
 			str.Format( TRANSLATE(IDS_HUD_RANGE), irange );
 			ObjectiveTextRenderer->Build_Sentence( str );
 			text_size = ObjectiveTextRenderer->Get_Text_Extents( str );
-			position.X = (int)(pog_box.Center().X - (text_size.X/2));
+			position.X = WWMath::Trunc(pog_box.Center().X - (text_size.X/2));
 			ObjectiveTextRenderer->Set_Location( position );
 			ObjectiveTextRenderer->Draw_Sentence();
 		}
@@ -2442,7 +2442,7 @@ static	void	Info_Update_Health_Shield( void )
 			draw = uv;
 			uv.Scale( INFO_UV_SCALE );
 			draw += InfoBase + SHIELD_OFFSET - draw.Upper_Left();
-			draw += Vector2( (int)(-percent * TOTAL_SHIELD_MOVEMENT), 0 );
+			draw += Vector2( WWMath::Trunc(-percent * TOTAL_SHIELD_MOVEMENT), 0 );
 			InfoRenderer->Add_Quad( draw, uv );
 		}
 
@@ -2450,7 +2450,7 @@ static	void	Info_Update_Health_Shield( void )
 		draw = uv;
 		uv.Scale( INFO_UV_SCALE );
 		draw += InfoBase + SHIELD_OFFSET - draw.Upper_Left();
-		draw += Vector2( (int)(-shield_percent * TOTAL_SHIELD_MOVEMENT), 0 );
+		draw += Vector2( WWMath::Trunc(-shield_percent * TOTAL_SHIELD_MOVEMENT), 0 );
 		InfoRenderer->Add_Quad( draw, uv );
 
 		// Draw Shield Number
@@ -2860,10 +2860,10 @@ void 	HUDClass::Think()
 		//
 		const RectClass &screen_rect = Render2DClass::Get_Screen_Resolution();
 		RectClass status_bar_rect (0.4F, 0.95F, 0.6F, 0.98F);
-		status_bar_rect.Left		= int(status_bar_rect.Left * screen_rect.Width());
-		status_bar_rect.Right	= int(status_bar_rect.Right * screen_rect.Width());
-		status_bar_rect.Top		= int(status_bar_rect.Top * screen_rect.Height());
-		status_bar_rect.Bottom	= int(status_bar_rect.Bottom  * screen_rect.Height());
+		status_bar_rect.Left		= WWMath::Trunc(status_bar_rect.Left * screen_rect.Width());
+		status_bar_rect.Right	= WWMath::Trunc(status_bar_rect.Right * screen_rect.Width());
+		status_bar_rect.Top		= WWMath::Trunc(status_bar_rect.Top * screen_rect.Height());
+		status_bar_rect.Bottom	= WWMath::Trunc(status_bar_rect.Bottom  * screen_rect.Height());
 		RenderImages[ACTION_STATUSBAR_RENDERER]->Add_Line( status_bar_rect.Upper_Left (), status_bar_rect.Upper_Right (), 1, 0xFFFFFFFF );
 		RenderImages[ACTION_STATUSBAR_RENDERER]->Add_Line( status_bar_rect.Upper_Right (), status_bar_rect.Lower_Right (), 1, 0xFFFFFFFF );
 		RenderImages[ACTION_STATUSBAR_RENDERER]->Add_Line( status_bar_rect.Lower_Right (), status_bar_rect.Lower_Left (), 1, 0xFFFFFFFF );
@@ -3106,7 +3106,7 @@ void	HUDClass::Add_Objective( int type )
 
 void	HUDClass::Add_Data_Link( void )
 {
-	int cur = TimeManager::Get_Total_Seconds() * 2.0f;
+	int cur = int(TimeManager::Get_Total_Seconds() * 2.0f);
 	static int last = 0;
 	// Don't accept too fast;
 	if ( cur == last ) {

--- a/Code/Combat/humanstate.cpp
+++ b/Code/Combat/humanstate.cpp
@@ -532,7 +532,7 @@ void	HumanStateClass::Start_Transition_Animation( const char * anim_name, bool b
 
 	Set_State( TRANSITION );
 
-	float blend_time = blend ? 0.2 : 0;
+	float blend_time = blend ? 0.2f : 0.0f;
 	AnimControl->Set_Animation( anim_name, blend_time );
 	AnimControl->Set_Mode( ANIM_MODE_ONCE );
 	AnimControl->Update( 0 );	// update
@@ -561,7 +561,7 @@ void	HumanStateClass::Start_Scripted_Animation( const char * anim_name, bool ble
 
 	Set_State( ANIMATION );
 
-	float blend_time = blend ? 0.2 : 0;
+	float blend_time = blend ? 0.2f : 0.0f;
 	AnimControl->Set_Animation( anim_name, blend_time );
 	AnimControl->Set_Mode( looping ? ANIM_MODE_LOOP : ANIM_MODE_ONCE );
 	AnimControl->Update( 0 );	// update
@@ -586,7 +586,7 @@ void	HumanStateClass::Stop_Scripted_Animation( void )
 void	HumanStateClass::Force_Animation( const char * anim_name, bool blend )
 {
 	//Debug_Say(( "Forcing Animation to %s\n", anim_name ));
-	float blend_time = blend ? 0.2 : 0;
+	float blend_time = blend ? 0.2f : 0.0f;
 	AnimControl->Set_Animation( anim_name, blend_time );
 	AnimControl->Update( 0 );	// update
 }
@@ -1469,7 +1469,7 @@ void	HumanStateClass::Complete_Jump( void )
 //			if ( !owner->Is_Human_Controlled() ) {
 				const GameObjObserverList & observer_list = owner->Get_Observers();
 				for( int index = 0; index < observer_list.Count(); index++ ) {
-					observer_list[ index ]->Custom( owner, CUSTOM_EVENT_FALLING_DAMAGE, damage*scale, NULL );
+					observer_list[ index ]->Custom( owner, CUSTOM_EVENT_FALLING_DAMAGE, int(damage*scale), NULL );
 				}
 //			}
 

--- a/Code/Combat/input.cpp
+++ b/Code/Combat/input.cpp
@@ -1083,19 +1083,19 @@ float	Input::Get_Value( int function_index, int input, float /* clamp */ )
 
 		switch( FunctionKeyStates[ function_index ] & 0x0F ) {
 			case BUTTON_UP:
-				return (DirectInput::Get_Button_Value( input ) & BUTTON_BIT_HELD) ? 0.0 : 1.0;
+				return (DirectInput::Get_Button_Value( input ) & BUTTON_BIT_HELD) ? 0.0f : 1.0f;
 
 			case BUTTON_HIT:
-				return (DirectInput::Get_Button_Value( input ) & BUTTON_BIT_HIT) ? 1.0 : 0.0;
+				return (DirectInput::Get_Button_Value( input ) & BUTTON_BIT_HIT) ? 1.0f : 0.0f;
 
 			case BUTTON_RELEASE:
-				return (DirectInput::Get_Button_Value( input ) & BUTTON_BIT_RELEASED) ? 1.0 : 0.0;
+				return (DirectInput::Get_Button_Value( input ) & BUTTON_BIT_RELEASED) ? 1.0f : 0.0f;
 
 			case BUTTON_HELD:
-				return (DirectInput::Get_Button_Value( input ) & BUTTON_BIT_HELD) ? 1.0 : 0.0;
+				return (DirectInput::Get_Button_Value( input ) & BUTTON_BIT_HELD) ? 1.0f : 0.0f;
 
 			case BUTTON_DOUBLE:
-				return (DirectInput::Get_Button_Value( input ) & BUTTON_BIT_DOUBLE) ? 1.0 : 0.0;
+				return (DirectInput::Get_Button_Value( input ) & BUTTON_BIT_DOUBLE) ? 1.0f : 0.0f;
 		}
 	}
 
@@ -1277,14 +1277,14 @@ Input::Save_Configuration (const char *filename)
 		//	Get the name of the primary key that's mapped to this function
 		//
 		if (FunctionPrimaryKeys[index] != 0) {
-			pri_key = Get_Key_Name (FunctionPrimaryKeys[index]);
+			pri_key = Get_Key_Name (short(FunctionPrimaryKeys[index]));
 		}
 
 		//
 		//	Get the name of the secondary  key that's mapped to this function
 		//
 		if (FunctionSecondaryKeys[index] != 0) {
-			sec_key = Get_Key_Name (FunctionSecondaryKeys[index]);
+			sec_key = Get_Key_Name (short(FunctionSecondaryKeys[index]));
 		}
 
 		//

--- a/Code/Combat/mapmgr.cpp
+++ b/Code/Combat/mapmgr.cpp
@@ -132,8 +132,8 @@ MapMgrClass::Set_Map_Texture (const char *filename)
 //		texture->Get_Level_Description (surface_desc);
 //		MapSize.X = surface_desc.Width;
 //		MapSize.Y = surface_desc.Height;
-		MapSize.X = texture->Get_Width();
-		MapSize.Y = texture->Get_Height();
+		MapSize.X = float(texture->Get_Width());
+		MapSize.Y = float(texture->Get_Height());
 
 		//
 		//	Release our hold on the texture

--- a/Code/Combat/mendozabossgameobj.cpp
+++ b/Code/Combat/mendozabossgameobj.cpp
@@ -1824,7 +1824,7 @@ MendozaBossGameObjClass::STATE_IMPL_END(ATTACK_STATE_MELEE_FLYING_SIDEKICK) (voi
 	//
 	//	Now, play the animation backwards a few frams to simulate "landing"
 	//
-	int curr_frame = Get_Anim_Control()->Get_Current_Frame ();
+	float curr_frame = WWMath::Trunc(Get_Anim_Control()->Get_Current_Frame ());
 	Set_Blended_Animation ("S_A_HUMAN.H_A_FLYKICK", false);
 	Get_Anim_Control()->Set_Mode (ANIM_MODE_TARGET, curr_frame);
 	Get_Anim_Control()->Set_Target_Frame (0);

--- a/Code/Combat/physicalgameobj.cpp
+++ b/Code/Combat/physicalgameobj.cpp
@@ -791,7 +791,7 @@ void PhysicalGameObj::Post_Think( void )
 
 void PhysicalGameObj::Set_Collision_Group( int group )
 {
-	Peek_Physical_Object()->Set_Collision_Group( group );
+	Peek_Physical_Object()->Set_Collision_Group( static_cast<unsigned char>(group) );
 }
 
 void	PhysicalGameObj::Attach_To_Object_Bone( PhysicalGameObj * host, const char * bone_name )
@@ -920,7 +920,7 @@ void	PhysicalGameObj::Set_Animation_Frame ( const char *animation_name, int fram
 		AnimControl->Set_Model( Peek_Model() );
 
 		AnimControl->Set_Animation( anim_name, 0 );
-		AnimControl->Set_Mode( ANIM_MODE_STOP, frame );
+		AnimControl->Set_Mode( ANIM_MODE_STOP, float(frame) );
 
 		//
 		//	"Dirty" the object for networking
@@ -1110,8 +1110,8 @@ void	PhysicalGameObj::Export_Rare( BitStreamClass &packet )
 	AnimMode anim_mode	= ANIM_MODE_TARGET;
 	if (AnimControl != NULL) {
 		animation_name	= AnimControl->Get_Animation_Name();
-		target_frame	= AnimControl->Get_Target_Frame ();
-		curr_frame		= AnimControl->Get_Current_Frame ();
+		target_frame	= int(AnimControl->Get_Target_Frame ());
+		curr_frame		= int(AnimControl->Get_Current_Frame ());
 		anim_mode		= AnimControl->Get_Mode ();
 	}
 
@@ -1194,8 +1194,8 @@ void	PhysicalGameObj::Import_Rare( BitStreamClass &packet )
 	//	Pass the animation information onto the controller
 	//
 	if (AnimControl != NULL) {
-		AnimControl->Set_Animation( animation_name, 0, curr_frame );
-		AnimControl->Set_Target_Frame( target_frame );
+		AnimControl->Set_Animation( animation_name, 0, float(curr_frame) );
+		AnimControl->Set_Target_Frame( float(target_frame) );
 		AnimControl->Set_Mode( (AnimMode)anim_mode );
 	}
 

--- a/Code/Combat/playerdata.cpp
+++ b/Code/Combat/playerdata.cpp
@@ -274,7 +274,7 @@ void	PlayerDataClass::Increment_Money( float add )
 	Money = (float)Money + add;
 
 	if ( add > 0 ) {
-		Stats_Add_Credit_Grant( (int) add );
+		Stats_Add_Credit_Grant( WWMath::Trunc(add) );
 	}
 
 	//Set_Object_Dirty_Bit(NetworkObjectClass::BIT_OCCASIONAL, true);
@@ -322,7 +322,7 @@ bool	PlayerDataClass::Purchase_Item( int cost )
 			//
 			// Use Increment_Money so that dirty is set.
 			//
-			Increment_Money(-1 * cost);
+			Increment_Money(float(-1 * cost));
 
 			retval = true;
 		}

--- a/Code/Combat/powerup.cpp
+++ b/Code/Combat/powerup.cpp
@@ -283,7 +283,7 @@ bool	PowerUpGameObjDef::Grant( SmartGameObj * obj, PowerUpGameObj * p_powerup, b
 		};
 
 		// Round up to next int
-		add = (int)(add + 0.95f);
+		add = WWMath::Trunc(add + 0.95f);
 
 		defense->Set_Shield_Strength_Max( defense->Get_Shield_Strength_Max() + add );
 		granted = true;
@@ -327,7 +327,7 @@ bool	PowerUpGameObjDef::Grant( SmartGameObj * obj, PowerUpGameObj * p_powerup, b
 		};
 
 		// Round up to next int
-		add = (int)(add + 0.95f);
+		add = WWMath::Trunc(add + 0.95f);
 
 		defense->Set_Health_Max( defense->Get_Health_Max() + add );
 		granted = true;

--- a/Code/Combat/radar.cpp
+++ b/Code/Combat/radar.cpp
@@ -421,7 +421,7 @@ void	RadarManager::Update( const Matrix3D & player_tm, const Vector2 & center )
 }
 #endif
 
-	float	bering = WWMath::Wrap( (player_tm.Get_Z_Rotation() / DEG_TO_RAD( 360.0f )) + 0.25f, 0, 1 );
+	float	bering = WWMath::Wrap( (player_tm.Get_Z_Rotation() / DEG_TO_RADF( 360.0f )) + 0.25f, 0, 1 );
 	CurrentCompassRendererIndex = (int)((bering * 8.0f) + 0.5f);
 	CurrentCompassRendererIndex&=7;
 
@@ -438,8 +438,8 @@ void	RadarManager::Update( const Matrix3D & player_tm, const Vector2 & center )
 		Vector2 text_size=CompassRenderers[CurrentCompassRendererIndex]->Get_Text_Extents(TRANSLATE(dir[CurrentCompassRendererIndex]));
 
 		Vector2 pos = center + COMPASS_OFFSET - (text_size * 0.5f);
-		pos.X = (int)pos.X;
-		pos.Y = (int)pos.Y;
+		pos.X = WWMath::Trunc(pos.X);
+		pos.Y = WWMath::Trunc(pos.Y);
 		CompassRenderers[CurrentCompassRendererIndex]->Set_Location( pos );
 
 		CompassRenderers[CurrentCompassRendererIndex]->Draw_Sentence();
@@ -451,8 +451,8 @@ void	RadarManager::Update( const Matrix3D & player_tm, const Vector2 & center )
 			CompassRenderers[CurrentCompassRendererIndex]->Build_Sentence( TRANSLATE(dir[CurrentCompassRendererIndex]));
 			Vector2 text_size=CompassRenderers[CurrentCompassRendererIndex]->Get_Text_Extents(TRANSLATE(dir[CurrentCompassRendererIndex]));
 			Vector2 pos = center + COMPASS_OFFSET - (text_size * 0.5f);
-			pos.X = (int)pos.X;
-			pos.Y = (int)pos.Y;
+			pos.X = WWMath::Trunc(pos.X);
+			pos.Y = WWMath::Trunc(pos.Y);
 			CompassRenderers[CurrentCompassRendererIndex]->Set_Location( pos );
 			CompassRenderers[CurrentCompassRendererIndex]->Draw_Sentence();
 		}

--- a/Code/Combat/raveshawbossgameobj.cpp
+++ b/Code/Combat/raveshawbossgameobj.cpp
@@ -3601,7 +3601,7 @@ RaveshawBossGameObjClass::STATE_IMPL_THINK(LIGHTNING_ROD_STATE_ACTIVE) (void)
 		//
 		//	Randomly strike the player
 		//
-		int star_dist = (StarPos - TIBERIUM_POS).Length ();
+		int star_dist = int((StarPos - TIBERIUM_POS).Length ());
 		if (FreeRandom.Get_Int (star_dist) == 1) {
 
 			//
@@ -4184,7 +4184,7 @@ RaveshawBossGameObjClass::Determine_New_Overall_State (void)
 		//
 		//	Should he heal himself?
 		//
-		int possibility = (10.0F * health_percent) + 0.5F;
+		int possibility = int((10.0F * health_percent) + 0.5F);
 		bool go_heal = (health_percent <= 0.75F && possibility > 0) && (FreeRandom.Get_Int (possibility) == 0);
 		if (go_heal) {
 			OverallState.Set_State (OVERALL_STATE_HEALING);

--- a/Code/Combat/refinerygameobj.cpp
+++ b/Code/Combat/refinerygameobj.cpp
@@ -570,7 +570,7 @@ RefineryGameObj::Think (void)
 					// Requested to give the Total Funds to all players, no division .
 					//
 					//BaseController->Deposit_Funds (TotalFunds);
-					BaseController->Distribute_Funds_To_Each_Teammate (TotalFunds);
+					BaseController->Distribute_Funds_To_Each_Teammate (int(TotalFunds));
 					TotalFunds = 0;
 				}
 

--- a/Code/Combat/repairbaygameobj.cpp
+++ b/Code/Combat/repairbaygameobj.cpp
@@ -712,7 +712,7 @@ RepairBayGameObj::Repair_Vehicle (void)
 					//
 					if (health_restored > 0) {
 						if (CombatManager::I_Am_Server ()) {
-							vehicle->Get_Defense_Object ()->Add_Health (health_restored);
+							vehicle->Get_Defense_Object ()->Add_Health (float(health_restored));
 						}
 						is_repairing = true;
 					}
@@ -722,7 +722,7 @@ RepairBayGameObj::Repair_Vehicle (void)
 					//
 					if (shield_restored > 0) {
 						if (CombatManager::I_Am_Server ()) {
-							vehicle->Get_Defense_Object ()->Add_Shield_Strength (shield_restored);
+							vehicle->Get_Defense_Object ()->Add_Shield_Strength (float(shield_restored));
 						}
 						is_repairing = true;
 					}

--- a/Code/Combat/scriptcommands.cpp
+++ b/Code/Combat/scriptcommands.cpp
@@ -335,7 +335,7 @@ float Get_Facing( GameObject * obj )
 		return 0;
 	}
 
-	return RAD_TO_DEG( pgobj->Get_Facing() );
+	return RAD_TO_DEGF( pgobj->Get_Facing() );
 }
 
 void	Set_Facing( GameObject * obj, float degrees )
@@ -355,7 +355,7 @@ void	Set_Facing( GameObject * obj, float degrees )
 
 	Matrix3D tm(1);
 	tm.Translate(pos);
-	tm.Rotate_Z( DEG_TO_RAD( degrees ) );
+	tm.Rotate_Z( DEG_TO_RADF( degrees ) );
 
 	pgobj->Set_Transform(tm);
 }
@@ -2245,7 +2245,7 @@ void	Static_Anim_Phys_Goto_Last_Frame( int obj_id, const char * anim_name )
 				sapc->Get_Animation_Manager().Set_Animation( anim_name );
 			}
 			sapc->Get_Animation_Manager().Set_Animation_Mode( AnimCollisionManagerClass::ANIMATE_TARGET );
-			sapc->Get_Animation_Manager().Set_Target_Frame( sapc->Get_Animation_Manager().Peek_Animation()->Get_Num_Frames() - 1 );
+			sapc->Get_Animation_Manager().Set_Target_Frame( float(sapc->Get_Animation_Manager().Peek_Animation()->Get_Num_Frames() - 1) );
 		}
 	}
 }

--- a/Code/Combat/soldier.cpp
+++ b/Code/Combat/soldier.cpp
@@ -1220,7 +1220,7 @@ void	SoldierGameObj::Import_Frequent( BitStreamClass & packet )
 
 	// Bump Z up to the top of the possible values due to packing
 	// we assume the max error is half of the resolution
-	float max_error = cEncoderList::Get_Encoder_Type_Entry( BITPACK_WORLD_POSITION_Z ).Get_Resolution() / 2.0f;
+	float max_error = float(cEncoderList::Get_Encoder_Type_Entry( BITPACK_WORLD_POSITION_Z ).Get_Resolution() / 2.0);
 	sc_position.Z += max_error;
 
 	Interpret_Sc_Position_Data(sc_position);
@@ -2899,8 +2899,8 @@ void	SoldierGameObj::Handle_Head_look( void )
 			}
 		}
 
-#define	HEAD_TURN_RATE		(DEG_TO_RAD( 360 )/2)
-#define	HEAD_TILT_RATE		(DEG_TO_RAD( 180 )/2)
+		constexpr float HEAD_TURN_RATE = (DEG_TO_RADF( 360 )/2);
+		constexpr float HEAD_TILT_RATE = (DEG_TO_RADF( 180 )/2);
 		float max_turn = HEAD_TURN_RATE * TimeManager::Get_Frame_Seconds();
 		float max_tilt = HEAD_TILT_RATE * TimeManager::Get_Frame_Seconds();
 		HeadRotation.X += WWMath::Clamp( (desired_head_rotation.X - HeadRotation.X), -max_turn, max_turn );
@@ -2942,7 +2942,7 @@ void	SoldierGameObj::Set_Blended_Animation( const char *animation_name, bool loo
 		HAnimClass *anim = Get_Anim_Control()->Peek_Animation();
 		if ( anim != NULL ) {
 			int frame_count = anim->Get_Num_Frames();
-			Get_Anim_Control()->Set_Mode( ANIM_MODE_TARGET, frame_count - 1 );
+			Get_Anim_Control()->Set_Mode( ANIM_MODE_TARGET, float(frame_count - 1) );
 			Get_Anim_Control()->Set_Target_Frame( 0 );
 		}
 	}
@@ -3221,7 +3221,7 @@ bool	SoldierGameObj::Internal_Set_Targeting( const Vector3 & target_pos, bool do
 
 	if ( Is_Human_Controlled() && Get_State() != HumanStateClass::IN_VEHICLE ) {
 
-#define		TILT_DOWN_SPEED		4.0
+		constexpr float TILT_DOWN_SPEED = 4.0f;
 		float direction = -1;
 		if ( Get_Weapon() && Get_Weapon()->Is_Reloading() ) {
 			direction = 1;

--- a/Code/Combat/soldierobserver.cpp
+++ b/Code/Combat/soldierobserver.cpp
@@ -1329,14 +1329,14 @@ void	SoldierObserverClass::State_Act_Attack( SoldierGameObj * soldier )
 void SoldierObserverClass::Action_Reset( SoldierGameObj * soldier )
 {
 	WWASSERT( soldier != NULL );
-	soldier->Get_Action()->Reset( StatePriorities[ State ] );
+	soldier->Get_Action()->Reset( float(StatePriorities[ State ]) );
 }
 
 void SoldierObserverClass::Action_Face_Location( SoldierGameObj * soldier, const Vector3 & location, SoldierAIState ai_state, bool crouched )
 {
 	WWASSERT( soldier != NULL );
 	ActionParamsStruct parameters;
-	parameters.Set_Basic( Get_ID(), StatePriorities[ State ], INNATE_ACTION_ID, ai_state );
+	parameters.Set_Basic( Get_ID(), float(StatePriorities[ State ]), INNATE_ACTION_ID, ai_state );
 	parameters.Set_Face_Location( location, 2 );
 	parameters.MoveCrouched = crouched;
    soldier->Get_Action()->Face_Location( parameters );
@@ -1348,7 +1348,7 @@ void SoldierObserverClass::Action_Goto_Location( SoldierGameObj * soldier, const
 	Vector3	move_position = location;
 	Stay_Within_Home( soldier, &move_position, &distance );
 	ActionParamsStruct parameters;
-	parameters.Set_Basic( Get_ID(), StatePriorities[ State ], INNATE_ACTION_ID, ai_state );
+	parameters.Set_Basic( Get_ID(), float(StatePriorities[ State ]), INNATE_ACTION_ID, ai_state );
 	parameters.Set_Movement( move_position, speed, distance, crouched );
    soldier->Get_Action()->Goto( parameters );
 }
@@ -1359,7 +1359,7 @@ void SoldierObserverClass::Action_Goto_Location_Facing( SoldierGameObj * soldier
 	Vector3	move_position = location;
 	Stay_Within_Home( soldier, &move_position, &distance );
 	ActionParamsStruct parameters;
-	parameters.Set_Basic( Get_ID(), StatePriorities[ State ], INNATE_ACTION_ID, ai_state );
+	parameters.Set_Basic( Get_ID(), float(StatePriorities[ State ]), INNATE_ACTION_ID, ai_state );
 	parameters.Set_Movement( move_position, speed, distance, crouched );
 	parameters.ForceFacing = true;
 	parameters.FaceLocation = facing_pos;
@@ -1379,7 +1379,7 @@ void SoldierObserverClass::Action_Attack_Object( SoldierGameObj * soldier, Physi
 
 	if ( enemy != NULL && soldier->Get_Weapon() != NULL ) {
 		ActionParamsStruct parameters;
-		parameters.Set_Basic( Get_ID(), StatePriorities[ State ], INNATE_ACTION_ID, AI_STATE_COMBAT );
+		parameters.Set_Basic( Get_ID(), float(StatePriorities[ State ]), INNATE_ACTION_ID, AI_STATE_COMBAT );
 		parameters.Set_Movement( move_position, RUN_SPEED, arrived_distance, kneel );
 		parameters.Set_Attack( enemy, range, FreeRandom.Get_Float(2), true );
 		parameters.AttackCrouched = kneel;
@@ -1399,7 +1399,7 @@ void SoldierObserverClass::Action_Dive( SoldierGameObj * soldier, const Vector3 
 {
 	WWASSERT( soldier != NULL );
 	ActionParamsStruct parameters;
-	parameters.Set_Basic( Get_ID(), StatePriorities[ State ], INNATE_ACTION_ID, AI_STATE_SEARCH );
+	parameters.Set_Basic( Get_ID(), float(StatePriorities[ State ]), INNATE_ACTION_ID, AI_STATE_SEARCH );
 	parameters.MoveLocation = location;
 	soldier->Get_Action()->Dive( parameters );
 }

--- a/Code/Combat/spawn.cpp
+++ b/Code/Combat/spawn.cpp
@@ -674,7 +674,7 @@ PhysicalGameObj * SpawnerClass::Spawn( int obj_id )
 			SoldierGameObj * soldier = obj->As_SoldierGameObj();
 			if ( soldier != NULL ) {
 				ActionParamsStruct parameters;
-				parameters.Priority = Get_Definition().GotoSpawnerPosPriority;
+				parameters.Priority = int(Get_Definition().GotoSpawnerPosPriority);
 				parameters.ObserverID = 0;
 				parameters.MoveLocation = TM.Get_Translation();
 				parameters.MoveSpeed = 1;

--- a/Code/Combat/systeminfolog.cpp
+++ b/Code/Combat/systeminfolog.cpp
@@ -193,7 +193,7 @@ void SystemInfoLog::Record_Loading_Time(unsigned loading_time)
 
 void SystemInfoLog::Record_Frame()
 {
-	unsigned fps=TimeManager::Get_Average_Frame_Rate();
+	unsigned fps=unsigned(TimeManager::Get_Average_Frame_Rate());
 	CurrentTotalFPS+=fps;
 	CurrentFPSCount++;
 	if (fps<VeryMinFPS) {

--- a/Code/Combat/textwindow.cpp
+++ b/Code/Combat/textwindow.cpp
@@ -219,13 +219,13 @@ TextWindowClass::Set_Backdrop
 		//
 		//	Calculate the width and height of the sections
 		//
-		int endcap_width		= endcap_rect.Width ();
-		int fadeout_width		= fadeout_rect.Width ();
-		int textback_width	= screen_rect.Width () - ((endcap_width + fadeout_width) * 2);
+		float endcap_width		= WWMath::Trunc(endcap_rect.Width ());
+		float fadeout_width		= WWMath::Trunc(fadeout_rect.Width ());
+		float textback_width	= WWMath::Trunc(screen_rect.Width () - ((endcap_width + fadeout_width) * 2));
 
-		int endcap_height		= endcap_rect.Height ();
-		int fadeout_height	= fadeout_rect.Height ();
-		int textback_height	= textback_rect.Height ();
+		float endcap_height		= WWMath::Trunc(endcap_rect.Height ());
+		float fadeout_height	= WWMath::Trunc(fadeout_rect.Height ());
+		float textback_height	= WWMath::Trunc(textback_rect.Height ());
 
 		//
 		//	Calculate the UV coordinates for each section
@@ -277,9 +277,9 @@ TextWindowClass::Set_Backdrop
 		//
 		//	Calculate how many times we should vertically tile the text backdrop
 		//
-		int largest_height	= std::min (endcap_height, fadeout_height);
-		largest_height			= std::min (largest_height, textback_height);
-		int section_count		= (screen_rect.Height () / largest_height);
+		float largest_height	= std::min (endcap_height, fadeout_height);
+		largest_height			= WWMath::Trunc(std::min (largest_height, textback_height));
+		int section_count		= int(screen_rect.Height () / largest_height);
 
 		//
 		//	Tile the text backdrop sections
@@ -324,7 +324,7 @@ TextWindowClass::Set_Backdrop
 		//
 		//	Tile the endcaps appropriately
 		//
-		section_count = screen_rect.Height () / endcap_height;
+		section_count = int(screen_rect.Height () / endcap_height);
 		for (index = 0; index < section_count; index ++) {
 
 			//
@@ -765,7 +765,7 @@ TextWindowClass::Update_Row
 	float *	row_height
 )
 {
-	float x_pos	= int (TextRect.Left);
+	float x_pos	= WWMath::Trunc(TextRect.Left);
 
 	//
 	//	Loop over all the columns
@@ -798,7 +798,7 @@ TextWindowClass::Update_Row
 		//	Update the text and color of this renderer
 		//
 		TextRenderers[1]->Build_Sentence (text);
-		TextRenderers[1]->Set_Location (Vector2 (int(x_pos), int(y_pos)));
+		TextRenderers[1]->Set_Location (Vector2 (x_pos, WWMath::Trunc(y_pos)));
 		TextRenderers[1]->Draw_Sentence (VRGB_TO_INT32(color));
 
 		//
@@ -810,7 +810,7 @@ TextWindowClass::Update_Row
 		//
 		//	Move to the next column
 		//
-		x_pos += int (column->Get_Width () * (TextRect.Right - TextRect.Left));
+		x_pos += WWMath::Trunc(column->Get_Width () * (TextRect.Right - TextRect.Left));
 	}
 
 	return ;

--- a/Code/Combat/timemgr.cpp
+++ b/Code/Combat/timemgr.cpp
@@ -95,7 +95,7 @@ void FrameTimeHistogramClass::Get_Packed_Report(unsigned char* bytes)
 	if (total==0) total=1;
 
 	for (i=0;i<SlotCount;++i) {
-		unsigned char value=255*Counts[i]/total;
+		unsigned char value=static_cast<unsigned char>(255*Counts[i]/total);
 		if (value==0 && Counts[i]!=0) value=1;
 		bytes[i]=value;
 	}
@@ -176,7 +176,7 @@ void	TimeManager::Update_Frame_Time()
 	FrameTicks = MIN( FrameTicks, (TICKS_PER_SECOND / SLOWEST_FPS) );
 
 	if ( WW3D::Get_Movie_Capture_Frame_Rate() != 0.0f ) {
-		FrameTicks = TICKS_PER_SECOND / WW3D::Get_Movie_Capture_Frame_Rate();
+		FrameTicks = int(TICKS_PER_SECOND / WW3D::Get_Movie_Capture_Frame_Rate());
 	}
 
 #if	TIME_STABILIZING_TECHNOLOGY_ENABLED
@@ -220,7 +220,7 @@ void	TimeManager::Update_Frame_Time()
 		FrameTicks = 0;
 	}
 
-	FrameTicks *= TimeScale;
+	FrameTicks = int(FrameTicks * TimeScale);
 	FrameSeconds=(float)FrameTicks / TICKS_PER_SECOND;
 	RealFrameSeconds=(float)RealFrameTicks / TICKS_PER_SECOND;
 

--- a/Code/Combat/vehicle.cpp
+++ b/Code/Combat/vehicle.cpp
@@ -1406,7 +1406,7 @@ void VehicleGameObj::Apply_Control( void )
 			target_direction += TARGET_STRAFE_ANGLE * Control.Get_Analog( ControlClass::ANALOG_TURN_LEFT );
 
 			// Set the final steering angle
-			float turn_amount = target_direction / DEG_TO_RAD( 60 ) * Control.Get_Analog( ControlClass::ANALOG_MOVE_FORWARD );
+			float turn_amount = target_direction / DEG_TO_RADF( 60 ) * Control.Get_Analog( ControlClass::ANALOG_MOVE_FORWARD );
 			Control.Set_Analog( ControlClass::ANALOG_TURN_LEFT, turn_amount );
 
 		} else {

--- a/Code/Commando/ConsoleMode.cpp
+++ b/Code/Commando/ConsoleMode.cpp
@@ -673,7 +673,7 @@ void ConsoleModeClass::Think(void)
 						Handle_Profile_Key(key);
 					} else {
 						if (key == 32 || isgraph(key)) {
-							string[Pos++] = key;
+							string[Pos++] = char(key);
 							last_suggestion[0] = 0;
 						}
 					}

--- a/Code/Commando/DlgDownload.cpp
+++ b/Code/Commando/DlgDownload.cpp
@@ -475,15 +475,15 @@ void PrintableSize(unsigned int size, WideStringClass& printable)
 	{
 	float value = ((float)size / (float)(1024 * 1024));
 
-	if (value >= 1.0)
+	if (value >= 1.0f)
 		{
 		printable.Format(TRANSLATE(IDS_MENU_TRANSFER_MB_FORMAT), value);
 		return;
 		}
 
-	value = ((float)size / 1024.0);
+	value = ((float)size / 1024.0f);
 
-	if (value >= 1.0)
+	if (value >= 1.0f)
 		{
 		printable.Format(TRANSLATE(IDS_MENU_TRANSFER_KB_FORMAT), value);
 		return;

--- a/Code/Commando/DlgMPTeamSelect.cpp
+++ b/Code/Commando/DlgMPTeamSelect.cpp
@@ -73,7 +73,7 @@ enum
 typedef void (*GameOptionsDispatchFunc)(DlgMPTeamSelect&, const char*);
 
 #define PARSE_INT(s, d, v) {char* ptr = strtok(s, d); if (ptr) {v = atoi(ptr);}}
-#define PARSE_FLOAT(s, d, v) {char* ptr = strtok(s, d); if (ptr) {v = atof(ptr);}}
+#define PARSE_FLOAT(s, d, v) {char* ptr = strtok(s, d); if (ptr) {v = strtof(ptr, NULL);}}
 #define PARSE_HEXDWORD(s, d, v) {char* ptr = strtok(s, d); if (ptr) {sscanf(ptr, "%08X", &v);}}
 #define PARSE_HEXBYTE(s, d, v) {char* ptr = strtok(s, d); if (ptr) {sscanf(ptr, "%02X", &v);}}
 #define PARSE_STRING(s, d, v) {v = strtok(s, d);}
@@ -1112,7 +1112,7 @@ void DlgMPTeamSelect::AddLANPlayerInfo(cPlayer* player)
 		{
 		list->Set_Entry_Text(itemIndex, COL_NAME, player->Get_Name());
 		list->Set_Entry_Int(itemIndex, COL_RANK, player->Get_Rung());
-		list->Set_Entry_Int(itemIndex, COL_SCORE, player->Get_Score());
+		list->Set_Entry_Int(itemIndex, COL_SCORE, int(player->Get_Score()));
 
 		WideStringClass text(0, true);
 		text.Format(U_CHAR("%d/%d"), player->Get_Kills(), player->Get_Deaths());

--- a/Code/Commando/GameResSend.cpp
+++ b/Code/Commando/GameResSend.cpp
@@ -377,7 +377,7 @@ void AddPlayerStats(GameResPacket& stats, cPlayer* player, WOL::Locale locale,
 		stats.Add_Field("TEAM", team);
 
 		// Score and other information
-		unsigned int score = (unsigned int)std::max<int>(player->Get_Score(), 0);
+		unsigned int score = unsigned(std::max(player->Get_Score(), 0.0f));
 		stats.Add_Field("PSCR", score);
 
 		stats.Add_Field("PPTS",	(int)player->Get_Ladder_Points());

--- a/Code/Commando/GameSpy_QnR.cpp
+++ b/Code/Commando/GameSpy_QnR.cpp
@@ -642,7 +642,7 @@ BOOL CGameSpyQnR::Parse_HeartBeat_List(const char *list, bool log_on_error) {
 			// Parse off the port value
 			*s++ = 0;
 			char *p = s;
-			if (atoi(p)) port = atoi(p);
+			if (atoi(p)) port = WORD(atoi(p));
 		}
 		// skip white space
 		while (*t == ' ' || *t == '\t') t++;

--- a/Code/Commando/GameSpy_QnR.h
+++ b/Code/Commando/GameSpy_QnR.h
@@ -49,7 +49,7 @@ protected:
 	static const int prodid;
 	static const int cdkey_id;
 	static const char *default_heartbeat_list;
-	int StartTime;
+	time_t StartTime;
 
 public:
 	void Init(void);

--- a/Code/Commando/NAT.cpp
+++ b/Code/Commando/NAT.cpp
@@ -238,7 +238,7 @@ void FirewallHelperClass::Set_Firewall_Info(unsigned int last_behavior, int last
  *=============================================================================================*/
 void FirewallHelperClass::Get_Firewall_Info(unsigned int &last_behavior, int &last_delta, unsigned short &port_pool, bool &send_delay, int &confidence) const
 {
-	port_pool = SourcePortPool;
+	port_pool = static_cast<unsigned short>(SourcePortPool);
 	last_behavior = (unsigned int) LastBehavior;
 	last_delta = LastSourcePortAllocationDelta;
 	send_delay = SendDelay;
@@ -634,7 +634,7 @@ bool FirewallHelperClass::Send_To_Mangler(IPAddressClass *address, SocketHandler
 	** Build the packet to send out.
 	*/
 	unsigned char packet_buf[512];
-	int packet_size = Build_Mangler_Packet(packet_buf, socket_handler->Get_Incoming_Port(), packet_id, blitzme);
+	int packet_size = Build_Mangler_Packet(packet_buf, static_cast<unsigned short>(socket_handler->Get_Incoming_Port()), packet_id, blitzme);
 
 	WWDEBUG_SAY(("FirewallHelper: Sending from port %d to %s\n", (unsigned int)(socket_handler->Get_Incoming_Port()), address->As_String()));
 
@@ -835,7 +835,7 @@ FirewallHelperClass::FirewallBehaviorType FirewallHelperClass::Detect_Firewall_B
 	if (SlaveMaster.Am_I_Slave()) {
 		behavior = LastBehavior;
 		SourcePortAllocationDelta = LastSourcePortAllocationDelta;
-		ExternalAddress.Set_Address(WOLNATInterface.Get_Reg_External_IP(), WOLNATInterface.Get_Reg_External_Port());
+		ExternalAddress.Set_Address(WOLNATInterface.Get_Reg_External_IP(), static_cast<unsigned short>(WOLNATInterface.Get_Reg_External_Port()));
 		return(behavior);
 	}
 
@@ -1360,10 +1360,10 @@ int FirewallHelperClass::Get_NAT_Port_Allocation_Scheme(int num_ports, unsigned 
 			if (mangled_ports[y] > mangled_ports[y+1]) {
 				int temp = mangled_ports[y];
 				mangled_ports[y] = mangled_ports[y+1];
-				mangled_ports[y+1] = temp;
+				mangled_ports[y+1] = static_cast<unsigned short>(temp);
 				temp = original_ports[y];
 				original_ports[y] = original_ports[y+1];
-				original_ports[y+1] = temp;
+				original_ports[y+1] = static_cast<unsigned short>(temp);
 			}
 		}
 	}
@@ -2434,7 +2434,7 @@ void FirewallHelperClass::Send_Connection_Result(int result, unsigned short port
 	WOLNATInterfaceClass::PrivateGameOptionsStruct options;
 	strcpy(options.NATOptionsPrefix, "NAT:");
 	options.Option = WOLNATInterfaceClass::OPTION_CONNECTION_RESULT;
-	options.OptionData.ConnectionResult.Result[0] = 'a' + result;
+	options.OptionData.ConnectionResult.Result[0] = static_cast<char>('a' + result);
 	options.OptionData.ConnectionResult.Result[1] = ',';
 	sprintf(options.OptionData.ConnectionResult.Port, "%04x,", (unsigned int) port);
 
@@ -3550,7 +3550,7 @@ bool FirewallHelperClass::Get_Local_Chat_Connection_Address(void)
 			*/
 			case tcpConnLocalPort:
 				fw_assert(index < connection_list.Count());
-				connection_list[index]->LocalPort = bind_ptr->value.asnValue.number;
+				connection_list[index]->LocalPort = static_cast<unsigned short>(bind_ptr->value.asnValue.number);
 				index++;
 				break;
 
@@ -3568,7 +3568,7 @@ bool FirewallHelperClass::Get_Local_Chat_Connection_Address(void)
 			*/
 			case tcpConnRemPort:
 				fw_assert(index < connection_list.Count());
-				connection_list[index]->RemotePort = bind_ptr->value.asnValue.number;
+				connection_list[index]->RemotePort = static_cast<unsigned short>(bind_ptr->value.asnValue.number);
 				index++;
 				break;
 		}

--- a/Code/Commando/ServerSettings.cpp
+++ b/Code/Commando/ServerSettings.cpp
@@ -713,7 +713,7 @@ void ServerSettingsClass::Encrypt_Serial(StringClass serial_in, StringClass &ser
 		t += (sign * stringbuffer[i]);
 		t += 1000;
 		t %= 10;
-		c  = t + '0';
+		c  = char(t + '0');
 		s[p] = c;
 		p++;
 		if (p == numberlength) {

--- a/Code/Commando/WOLGameInfo.cpp
+++ b/Code/Commando/WOLGameInfo.cpp
@@ -503,7 +503,7 @@ void WOLGameInfo::ExportToChannel(const RefPtr<ChannelData>& channel)
 			{
 			ModPackageClass& package = ModPackageMgrClass::Get_Current_Package();
 			fileCRC = package.Get_CRC();
-			modMapIndex = package.Get_Map_Index(mMapName);
+			modMapIndex = static_cast<unsigned char>(package.Get_Map_Index(mMapName));
 			}
 		else
 			{

--- a/Code/Commando/apppacketstats.cpp
+++ b/Code/Commando/apppacketstats.cpp
@@ -371,7 +371,7 @@ cAppPacketStats::Get_Description
 	DWORD t3 = 0;
 	if (BitsSent[type] > 0)
 	{
-		float bits = BitsSent[type];
+		float bits = float(BitsSent[type]);
 
 		t0 = cMathUtil::Round(100 * (BitsSentTier[type][0] / bits));
 		t1 = cMathUtil::Round(100 * (BitsSentTier[type][1] / bits));

--- a/Code/Commando/cnetwork.cpp
+++ b/Code/Commando/cnetwork.cpp
@@ -204,7 +204,7 @@ void cNetwork::Init_Client([[maybe_unused]] unsigned short my_port)
 
 	WWASSERT(PTheGameData != NULL);
    PClientConnection->Init_As_Client(
-		The_Game()->Get_Ip_Address(), The_Game()->Get_Port(), my_port);
+		The_Game()->Get_Ip_Address(), static_cast<unsigned short>(The_Game()->Get_Port()), my_port);
 
 	//
 	// This packet resurfaces on the server in Application_Acceptance_Handler
@@ -696,7 +696,7 @@ void cNetwork::Init_Server(void)
 
 	WWASSERT(PTheGameData != NULL);
 	PServerConnection->Init_As_Server(
-		The_Game()->Get_Port(),
+		static_cast<unsigned short>(The_Game()->Get_Port()),
 		The_Game()->Get_Max_Players(),
 		The_Game()->IsDedicated.Get(),
 		ntohl(The_Game()->Get_Ip_Address()));
@@ -997,7 +997,7 @@ void cNetwork::Client_Send_Packet([[maybe_unused]] cPacket & packet, [[maybe_unu
 
 	if (cNetwork::PClientConnection->Is_Established()) {
 
-		PClientConnection->Send_Packet_To_Individual(packet, 0, mode);
+		PClientConnection->Send_Packet_To_Individual(packet, 0, static_cast<unsigned char>(mode));
 
 		/*
 		BYTE message_type = packet.Peek_Message_Type();
@@ -1044,7 +1044,7 @@ void cNetwork::Server_Send_Packet(cPacket & packet, int mode, int recipient)
 				int client_id = p_player->Get_Id();
 
 				PServerConnection->Send_Packet_To_Individual(
-					packet, client_id, mode);
+					packet, client_id, static_cast<unsigned char>(mode));
 
 				/*
 				BYTE message_type = packet.Peek_Message_Type();
@@ -1055,7 +1055,7 @@ void cNetwork::Server_Send_Packet(cPacket & packet, int mode, int recipient)
 		}
 
 	} else {
-		PServerConnection->Send_Packet_To_Individual(packet, recipient, mode);
+		PServerConnection->Send_Packet_To_Individual(packet, recipient, static_cast<unsigned char>(mode));
 
 		/*
 		BYTE message_type = packet.Peek_Message_Type();
@@ -1084,7 +1084,7 @@ void cNetwork::Server_Send_Packet_To_All_Connected(cPacket & packet, int mode)
 
    for (int rhost_id = PServerConnection->Get_Min_RHost(); rhost_id <= PServerConnection->Get_Max_RHost(); rhost_id++) {
 		if (Get_Server_Rhost(rhost_id) != NULL) {
-         PServerConnection->Send_Packet_To_Individual(packet, rhost_id, mode);
+         PServerConnection->Send_Packet_To_Individual(packet, rhost_id, static_cast<unsigned char>(mode));
 
 			/*
 			PServerStatListGroup->Increment_Num_Msg_Sent(rhost_id - 1, message_type);
@@ -1138,7 +1138,7 @@ float cNetwork::Get_Server_Rhost_Threshold_Priority(int client_id)
 {
    WWASSERT(I_Am_Server());
    WWASSERT(Get_Server_Rhost(client_id) != NULL);
-   return Get_Server_Rhost(client_id)->Get_Threshold_Priority();
+   return float(Get_Server_Rhost(client_id)->Get_Threshold_Priority());
 }
 
 //-----------------------------------------------------------------------------
@@ -1146,7 +1146,7 @@ float cNetwork::Get_Client_Rhost_Threshold_Priority(void)
 {
    WWASSERT(I_Am_Client());
    WWASSERT(Get_Client_Rhost() != NULL);
-   return Get_Client_Rhost()->Get_Threshold_Priority();
+   return float(Get_Client_Rhost()->Get_Threshold_Priority());
 }
 
 //-----------------------------------------------------------------------------

--- a/Code/Commando/combatgmode.cpp
+++ b/Code/Commando/combatgmode.cpp
@@ -448,7 +448,7 @@ public:
 						// Scale
 						x *= Render2DClass::Get_Screen_Resolution().Right / 640.0f;
 						y *= Render2DClass::Get_Screen_Resolution().Bottom / 480.0f;
-						backdropText2.Set_Location( Vector2( (int)x, (int)y ) );
+						backdropText2.Set_Location( Vector2( WWMath::Trunc(x), WWMath::Trunc(y) ) );
 						backdropText2.Draw_Sentence( color );
 						color=0xFFFFFFFF;
 						backdropText2.Set_Wrapping_Width( 0 );
@@ -471,7 +471,7 @@ public:
 						// Scale
 						x *= Render2DClass::Get_Screen_Resolution().Right / 640.0f;
 						y *= Render2DClass::Get_Screen_Resolution().Bottom / 480.0f;
-						backdropText.Set_Location( Vector2( (int)x, (int)y ) );
+						backdropText.Set_Location( Vector2( WWMath::Trunc(x), WWMath::Trunc(y) ) );
 						backdropText.Draw_Sentence( color );
 						color=0xFFFFFFFF;
 						backdropText.Set_Wrapping_Width( 0 );
@@ -517,7 +517,7 @@ public:
 						// Scale
 						x *= Render2DClass::Get_Screen_Resolution().Right / 640.0f;
 						y *= Render2DClass::Get_Screen_Resolution().Bottom / 480.0f;
-						backdropText.Set_Location( Vector2( (int)x, (int)y ) );
+						backdropText.Set_Location( Vector2( WWMath::Trunc(x), WWMath::Trunc(y) ) );
 						backdropText.Draw_Sentence( color );
 						color=0xFFFFFFFF;
 						backdropText.Set_Wrapping_Width( 0 );
@@ -599,7 +599,7 @@ public:
 		LoadPercentageDrawn += ( LoadPercentage - LoadPercentageDrawn ) * 0.1f;
 		backdrop.Set_Animation_Percentage( LoadPercentageDrawn );
 		if (ConsoleBox.Is_Exclusive() && _last_percent_drawn != LoadPercentageDrawn) {
-			_last_percent_drawn = LoadPercentageDrawn;
+			_last_percent_drawn = int(LoadPercentageDrawn);
 			ConsoleBox.Print("Load %d%% complete\r", (int)(LoadPercentageDrawn * 100.0f));
 		}
 

--- a/Code/Commando/console.cpp
+++ b/Code/Commando/console.cpp
@@ -288,7 +288,7 @@ WWPROFILE( "Input Active" );
 
 				default:
 					if ( len + 1 < static_cast<size_t>(MAX_INPUT_LINE_LENGTH)) {
-						InputLine[ len++ ] = key;
+						InputLine[ len++ ] = char(key);
 						InputLine[ len ] = 0;
 
 						if (ConsoleInputType == INPUT_FUNCTION_BEGIN_CONSOLE) {

--- a/Code/Commando/consolefunction.cpp
+++ b/Code/Commando/consolefunction.cpp
@@ -549,7 +549,7 @@ public:
 
 		char mode = 0;
 		if (sscanf(input, "%c", &mode) == 1) {
-			mode = toupper(mode);
+			mode = (char)toupper(mode);
 
 			if (mode == 'P') {
 				if (COMBAT_SCENE->Vis_Grid_Debug_Enter_Parent()) {
@@ -723,7 +723,7 @@ class ShadowIntensityConsoleFunctionClass : public ConsoleFunctionClass
 	virtual	void Activate( const char * input ) override
 	{
 		PhysicsSceneClass * scene = PhysicsSceneClass::Get_Instance();
-		scene->Set_Shadow_Normal_Intensity(atof(input));
+		scene->Set_Shadow_Normal_Intensity(strtof(input, NULL));
 		Print("shadow intensity set to: %f\n",scene->Get_Shadow_Normal_Intensity());
 	}
 };
@@ -750,7 +750,7 @@ class ShadowResolutionConsoleFunctionClass : public ConsoleFunctionClass
 	virtual	void Activate( const char * input ) override
 	{
 		PhysicsSceneClass * scene = PhysicsSceneClass::Get_Instance();
-		scene->Set_Shadow_Resolution(atof(input));
+		scene->Set_Shadow_Resolution(int(strtof(input, NULL)));
 		Print("shadow resolution set to: %f\n",scene->Get_Shadow_Resolution());
 	}
 };
@@ -762,7 +762,7 @@ class ShadowCountConsoleFunctionClass : public ConsoleFunctionClass
 	virtual	void Activate( const char * input ) override
 	{
 		PhysicsSceneClass * scene = PhysicsSceneClass::Get_Instance();
-		scene->Set_Max_Simultaneous_Shadows(atof(input));
+		scene->Set_Max_Simultaneous_Shadows(int(strtof(input, NULL)));
 		Print("simultaneous shadow count set to: %f\n",scene->Get_Max_Simultaneous_Shadows());
 	}
 };
@@ -1763,7 +1763,7 @@ public:
 	virtual	void Activate( const char * input ) override {
       WWASSERT(input != NULL);
 		if (cNetwork::I_Am_Server()) {
-			float f = ::atof(input);
+			float f = ::strtof(input, NULL);
 			cUserOptions::MaxFacingPenalty.Set(f);
          Print( "MaxFacingPenalty set to %5.2f.", f);
 		} else {
@@ -1781,7 +1781,7 @@ public:
 	virtual	void Activate( const char * input ) override {
       WWASSERT(input != NULL);
 		if (cNetwork::I_Am_Server()) {
-			float f = ::atof(input);
+			float f = ::strtof(input, NULL);
 			cUserOptions::IrrelevancePenalty.Set(f);
          Print( "IrrelevancePenalty set to %5.2f.", f);
 		} else {
@@ -2169,7 +2169,7 @@ public:
 	virtual	void Activate( const char * input ) override {
       WWASSERT(input != NULL);
 		if (cNetwork::I_Am_Only_Client()) {
-			float chf = ::atof(input);
+			float chf = ::strtof(input, NULL);
 			cUserOptions::ClientHintFactor.Set(chf);
          Print( "ClientHintFactor set to %5.2f.", chf);
 		} else {
@@ -2827,7 +2827,7 @@ public:
 	virtual	const char * Get_Help( void ) override	{ return "SET_STAR_HEALTH <strength> - sets the strength of the star."; }
 	virtual	void Activate( const char * input ) override {
 		if ( COMBAT_STAR ) {
-			float health = atof( input );
+			float health = strtof( input, NULL );
 			DefenseObjectClass * defense = COMBAT_STAR->Get_Defense_Object();
 			WWASSERT(defense != NULL);
 			if (health > defense->Get_Health_Max()) {
@@ -2859,7 +2859,7 @@ public:
 	virtual	void Activate( const char * input ) override {
 		if ( COMBAT_STAR ) {
 			DefenseObjectClass * defense = COMBAT_STAR->Get_Defense_Object();
-			defense->Set_Shield_Strength( atof( input ) );
+			defense->Set_Shield_Strength( strtof( input, NULL ) );
 			Print( "Star Shield Strength set to %1.1f\n", defense->Get_Shield_Strength() );
 		}
 	}
@@ -2888,7 +2888,7 @@ public:
 		if ( COMBAT_STAR ) {
 			COMBAT_STAR->Get_Position( &star_pos );
 		}
-		float min_dist = atof( input );
+		float min_dist = strtof( input, NULL );
 
 		int count = 0;
 		SLNode<SmartGameObj> *objnode;
@@ -3218,7 +3218,7 @@ public:
 	virtual	const char * Get_Help( void ) override	{ return "SCALE_TIME < factor > - scale time (SP only)."; }
 	virtual	void Activate( const char * input ) override {
 		if (IS_SOLOPLAY) {
-			float scale = atof( input );
+			float scale = strtof( input, NULL );
 			if ( scale <= 0 ) {
 				scale = 1;
 			}
@@ -3606,8 +3606,8 @@ public:
 				RectClass rect;
 				rect.Left = 0;
 				rect.Top = 0;
-				rect.Right = resos[i].Width;
-				rect.Bottom = resos[i].Height;
+				rect.Right = float(resos[i].Width);
+				rect.Bottom = float(resos[i].Height);
 
 				Render2DClass::Set_Screen_Resolution(rect);
 				Print( "Resolution changed to %d * %d, %d bits\n", resos[i].Width,resos[i].Height,resos[i].BitDepth);
@@ -3911,7 +3911,7 @@ public:
 
 				if (active && The_Game()) {
 
-					unsigned int time = The_Game()->Get_Time_Remaining_Seconds();
+					unsigned int time = unsigned(The_Game()->Get_Time_Remaining_Seconds());
 					unsigned int seconds = time % 60;
 					unsigned int minutes = (time / 60) % 60;
 					unsigned int hours = (time / (60*60));

--- a/Code/Commando/datasafe.h
+++ b/Code/Commando/datasafe.h
@@ -1474,9 +1474,9 @@ DataSafeHandleClass DataSafeClass<T>::Add_Entry(T &value, bool is_slop)
 			int index = Get_Handle_ID(list);
 			ds_assert(index >= 0 && index < MAX_ENTRIES_PER_LIST);
 			DataSafeHandleClass handle;
-			handle.Handle.Part.List = list;
-			handle.Handle.Part.ID = index;
-			handle.Handle.Part.Type = Type;
+			handle.Handle.Part.List = static_cast<unsigned short>(list);
+			handle.Handle.Part.ID = static_cast<unsigned char>(index);
+			handle.Handle.Part.Type = static_cast<unsigned char>(Type);
 
 			/*
 			** We have a handle. Better encrypt it.
@@ -1520,9 +1520,9 @@ DataSafeHandleClass DataSafeClass<T>::Add_Entry(T &value, bool is_slop)
 						** keeps the ID usage list neat. Fill in the rest of the handle to make it valid.
 						*/
 						DataSafeHandleClass slop_handle;
-						slop_handle.Handle.Part.ID = Get_Handle_ID(list);
-						slop_handle.Handle.Part.List = list;
-						slop_handle.Handle.Part.Type = Type;
+						slop_handle.Handle.Part.ID = static_cast<unsigned char>(Get_Handle_ID(list));
+						slop_handle.Handle.Part.List = static_cast<unsigned short>(list);
+						slop_handle.Handle.Part.Type = static_cast<unsigned char>(Type);
 						DataSafeHandleClass encrypted_slop_handle = slop_handle ^ SimpleKey;
 						Checksum = Checksum ^ encrypted_slop_handle;
 						entry_ptr->Handle = encrypted_slop_handle;

--- a/Code/Commando/dlgcncbattleinfo.cpp
+++ b/Code/Commando/dlgcncbattleinfo.cpp
@@ -367,7 +367,7 @@ CNCBattleInfoDialogClass::Populate_Player_List (ListCtrlClass *list_ctrl, int te
 				list_ctrl->Set_Entry_Text(item_index, COL_NAME, (const unichar_t*)displayName);
 
 				list_ctrl->Set_Entry_Int (item_index, COL_RANK,			player->Get_Rung ());
-				list_ctrl->Set_Entry_Int (item_index, COL_SCORE,		player->Get_Score ());
+				list_ctrl->Set_Entry_Int (item_index, COL_SCORE,		int(player->Get_Score ()));
 
 				//
 				//	Put a star by the player's name if this is the local player

--- a/Code/Commando/dlgcncpurchasemainmenu.cpp
+++ b/Code/Commando/dlgcncpurchasemainmenu.cpp
@@ -692,7 +692,7 @@ CNCPurchaseMainMenuClass::Refresh_Beacon_State (void)
 	//
 	//	Get the beacon cost and the player's current cash supply
 	//
-	float cost	= definition->Get_Beacon_Cost ();
+	float cost	= float(definition->Get_Beacon_Cost ());
 	int funds	= 0;
 	if (COMBAT_STAR->Get_Player_Data() != NULL) {
 		funds	= (int) COMBAT_STAR->Get_Player_Data ()->Get_Money ();

--- a/Code/Commando/dlgcncpurchasemenu.cpp
+++ b/Code/Commando/dlgcncpurchasemenu.cpp
@@ -154,7 +154,7 @@ CNCPurchaseMenuClass::On_Init_Dialog (void)
 				//
 				//	Configure the merchandise settings
 				//
-				int cost = Definition->Get_Cost (index) * CostScalingFactor;
+				int cost = int(Definition->Get_Cost (index) * CostScalingFactor);
 				ctrl->Set_Text (Definition->Get_Name (index));
 				ctrl->Set_Cost (cost);
 				ctrl->Set_Texture (Definition->Get_Texture (index));
@@ -326,7 +326,7 @@ CNCPurchaseMenuClass::Add_Item_To_Shopping_Cart (int ctrl_id)
 	WWASSERT(COMBAT_STAR->Get_Player_Data() != NULL);
 
 	int funds	= (int) COMBAT_STAR->Get_Player_Data ()->Get_Money ();
-	int cost		= Definition->Get_Cost (item_index) * CostScalingFactor;
+	int cost		= int(Definition->Get_Cost (item_index) * CostScalingFactor);
 	if ((TotalCost + cost) <= funds) {
 
 		//
@@ -848,7 +848,7 @@ CNCPurchaseMenuClass::Update_Enabled_Status (void)
 				//
 				//	Configure the merchandise settings
 				//
-				int cost = Definition->Get_Cost (index) * CostScalingFactor;
+				int cost = int(Definition->Get_Cost (index) * CostScalingFactor);
 
 				//
 				//	Disable any options that cost money if production is disabled

--- a/Code/Commando/dlgcncwinscreen.cpp
+++ b/Code/Commando/dlgcncwinscreen.cpp
@@ -577,7 +577,7 @@ CNCWinScreenMenuClass::Populate_Player_Lists (int team_id, int list_ctrl1_id)
 			//	Fill in information about the player
 			//
 			list_ctrl->Set_Entry_Int (item_index, COL_RANK,			player->Get_Rung ());
-			list_ctrl->Set_Entry_Int (item_index, COL_SCORE,		player->Get_Score ());
+			list_ctrl->Set_Entry_Int (item_index, COL_SCORE,		int(player->Get_Score ()));
 			list_ctrl->Set_Entry_Int (item_index, COL_KILLS,		player->Get_Kills ());
 			if (ShowLadderPoints) {
 				list_ctrl->Set_Entry_Int (item_index, COL_LADDER,		player->Get_Ladder_Points ());

--- a/Code/Commando/dlgcontroltabs.cpp
+++ b/Code/Commando/dlgcontroltabs.cpp
@@ -276,7 +276,7 @@ ControlsLookTabClass::Load_Controls (void)
 	//
 	SliderCtrlClass *slider_ctrl = (SliderCtrlClass *)Get_Dlg_Item (IDC_MOUSE_SENSITIVITY_SLIDER);
 	if (slider_ctrl != NULL) {
-		slider_ctrl->Set_Pos (Input::Get_Mouse_Sensitivity () * 100);
+		slider_ctrl->Set_Pos (int(Input::Get_Mouse_Sensitivity () * 100));
 	}
 
 	//

--- a/Code/Commando/dlgloadspgame.cpp
+++ b/Code/Commando/dlgloadspgame.cpp
@@ -369,7 +369,7 @@ LoadSPGameMenuClass::On_ListCtrl_Column_Click
 		if (col_index == CurrSortCol) {
 			IsSortAscending = !IsSortAscending;
 		} else {
-			CurrSortCol = col_index;
+			CurrSortCol = uint16(col_index);
 			IsSortAscending = true;
 		}
 

--- a/Code/Commando/dlgmpingamechat.cpp
+++ b/Code/Commando/dlgmpingamechat.cpp
@@ -768,8 +768,8 @@ MPIngameChatPopupClass::On_Init_Dialog (void)
 	const RectClass &screen_rect = Render2DClass::Get_Screen_Resolution ();
 	RectClass window_rect	= Get_Rect ();
 	float height				= window_rect.Height ();
-	window_rect.Bottom		= int(screen_rect.Bottom - 40.0F);
-	window_rect.Top			= int(window_rect.Bottom - height);
+	window_rect.Bottom		= WWMath::Trunc(screen_rect.Bottom - 40.0F);
+	window_rect.Top			= WWMath::Trunc(window_rect.Bottom - height);
 	Set_Rect (window_rect);
 
 	//

--- a/Code/Commando/dlgsavegame.cpp
+++ b/Code/Commando/dlgsavegame.cpp
@@ -129,7 +129,7 @@ SaveGameMenuClass::On_ListCtrl_Column_Click
 		if (col_index == CurrSortCol) {
 			IsSortAscending = !IsSortAscending;
 		} else {
-			CurrSortCol = col_index;
+			CurrSortCol = uint16(col_index);
 			IsSortAscending = true;
 		}
 

--- a/Code/Commando/donateevent.cpp
+++ b/Code/Commando/donateevent.cpp
@@ -102,8 +102,8 @@ cDonateEvent::Act(void)
 		 (p_donor->Get_Player_Type() == p_recipient->Get_Player_Type()) &&
 		 p_donor->Get_Money() >= Amount) {
 
-		p_donor->Increment_Money(-Amount);
-		p_recipient->Increment_Money(Amount);
+		p_donor->Increment_Money(float(-Amount));
+		p_recipient->Increment_Money(float(Amount));
 
 		//
 		// Notify recipient

--- a/Code/Commando/gamedata.cpp
+++ b/Code/Commando/gamedata.cpp
@@ -1243,7 +1243,7 @@ void cGameData::Begin_Intermission(void)
 	}
 
 	IsIntermission.Set(true);
-   IntermissionTimeRemaining = Get_Intermission_Time_Seconds();
+   IntermissionTimeRemaining = float(Get_Intermission_Time_Seconds());
 
 	//
 	//	Display a dialog with the win information on it
@@ -1302,7 +1302,7 @@ void cGameData::Set_Time_Remaining_Seconds(float time_remaining_seconds)
 //-----------------------------------------------------------------------------
 void cGameData::Reset_Time_Remaining_Seconds(void)
 {
-	TimeRemainingSeconds = 60 * TimeLimitMinutes;
+	TimeRemainingSeconds = float(60 * TimeLimitMinutes);
 }
 
 //-----------------------------------------------------------------------------
@@ -1844,12 +1844,12 @@ void cGameData::Show_Game_Settings_Limits(void)
 
 
 	// Render if needed  -------------------------------------------------------
-	float charHeight = PTextRenderer->Peek_Font()->Get_Char_Height();
+	float charHeight = float(PTextRenderer->Peek_Font()->Get_Char_Height());
 
 	if (!changed) {
 		// Proceed the multihud by one line (as we are caching the time render which would usually do this)
 		float y = MultiHUDClass::Get_Bottom_Text_Y_Pos();
-		y -= 1.2 * charHeight;
+		y -= 1.2f * charHeight;
 		MultiHUDClass::Set_Bottom_Text_Y_Pos(y);
 		BottomText.Reset_Active();
 		return;
@@ -1876,15 +1876,15 @@ void cGameData::Show_Game_Settings_Limits(void)
 	MultiHUDClass::Set_Bottom_Text_Y_Pos( Render2DClass::Get_Screen_Resolution().Bottom - 15 );
 
 	y = MultiHUDClass::Get_Bottom_Text_Y_Pos();
-	y -= 1.2 * charHeight;
-	Vector2 loc(cMathUtil::Round(x), cMathUtil::Round(y));
+	y -= 1.2f * charHeight;
+	Vector2 loc(WWMath::Round(x), WWMath::Round(y));
 	PTextRenderer->Set_Location(loc);
 	PTextRenderer->Build_Sentence(renderer_time_text);
 	PTextRenderer->Draw_Sentence();
 
 	for (j=0;j<OldBottomText.Count();++j) {
-		y -= 1.2 * charHeight;
-		loc[1]=cMathUtil::Round(y);
+		y -= 1.2f * charHeight;
+		loc[1]=WWMath::Round(y);
 		PTextRenderer->Set_Location(loc);
 		PTextRenderer->Build_Sentence(OldBottomText[j]);
 		PTextRenderer->Draw_Sentence();
@@ -1899,7 +1899,7 @@ void cGameData::Show_Game_Settings_Limits(void)
 		x = Render2DClass::Get_Screen_Resolution().Center().X - extent.X / 2.0f;
 
 		y = Render2DClass::Get_Screen_Resolution().Center().Y;
-		PTextRenderer->Set_Location(Vector2(cMathUtil::Round(x), cMathUtil::Round(y)));
+		PTextRenderer->Set_Location(Vector2(WWMath::Round(x), WWMath::Round(y)));
 		PTextRenderer->Build_Sentence(renderer_dedicated_server_label);
 		PTextRenderer->Draw_Sentence(renderer_dedicated_server_color);
 	}
@@ -1908,8 +1908,8 @@ void cGameData::Show_Game_Settings_Limits(void)
 	if (show_gameplay_label) {
 		Vector2 extent = PTextRenderer->Get_Text_Extents(renderer_gameplay_label);
 		x = Render2DClass::Get_Screen_Resolution().Center().X -  extent.X / 2.0f;
-		y = Render2DClass::Get_Screen_Resolution().Center().Y + 1.2 * charHeight;
-		PTextRenderer->Set_Location(Vector2(cMathUtil::Round(x), cMathUtil::Round(y)));
+		y = Render2DClass::Get_Screen_Resolution().Center().Y + 1.2f * charHeight;
+		PTextRenderer->Set_Location(Vector2(WWMath::Round(x), WWMath::Round(y)));
 		PTextRenderer->Build_Sentence(renderer_gameplay_label);
 		PTextRenderer->Draw_Sentence(color);
 	}
@@ -1987,7 +1987,7 @@ void cGameData::Think(void)
 		//
 		// Update CurrentPlayers
 		//
-		int max = (int) WWMath::Max(
+		int max = std::max(
 			cPlayerManager::Count(),
 			cNetwork::PServerConnection->Get_Num_RHosts());
 		Set_Current_Players(max);

--- a/Code/Commando/gamedataupdateevent.cpp
+++ b/Code/Commando/gamedataupdateevent.cpp
@@ -85,7 +85,7 @@ cGameDataUpdateEvent::Act(void)
 
 	if (The_Game() != NULL && TimeRemainingSeconds > 0)
 	{
-		The_Game()->Set_Time_Remaining_Seconds(TimeRemainingSeconds);
+		The_Game()->Set_Time_Remaining_Seconds(float(TimeRemainingSeconds));
 		//The_Game()->Set_Server_Is_Gameplay_Permitted(ServerIsGameplayPermitted);
 	}
 	The_Game()->Set_Hosted_Game_Number(HostedGameNumber);

--- a/Code/Commando/gamesideservercontrol.cpp
+++ b/Code/Commando/gamesideservercontrol.cpp
@@ -111,7 +111,7 @@ void GameSideServerControlClass::Init(void)
 				/*
 				** Start listening.
 				*/
-				ServerControl.Start_Listening(port, password, &App_Request_Callback, NULL, loopback ? true : false, ip);
+				ServerControl.Start_Listening(static_cast<unsigned short>(port), password, &App_Request_Callback, NULL, loopback ? true : false, ip);
 				Listening = true;
 
 				/*

--- a/Code/Commando/gdcnc.cpp
+++ b/Code/Commando/gdcnc.cpp
@@ -164,7 +164,7 @@ cGameDataCnc::Soldier_Added (SoldierGameObj *soldier)
 			soldier->Get_Player_Data() != NULL &&
 			soldier->Get_Player_Data()->Get_Game_Time () == 0)
 	{
-		soldier->Get_Player_Data ()->Set_Money (StartingCredits);
+		soldier->Get_Player_Data ()->Set_Money (float(StartingCredits));
 	}
 
 	return ;

--- a/Code/Commando/gdskirmish.cpp
+++ b/Code/Commando/gdskirmish.cpp
@@ -170,7 +170,7 @@ cGameDataSkirmish::Soldier_Added (SoldierGameObj *soldier)
 			soldier->Get_Player_Data() != NULL &&
 			soldier->Get_Player_Data()->Get_Game_Time () == 0)
 	{
-		soldier->Get_Player_Data ()->Set_Money (StartingCredits);
+		soldier->Get_Player_Data ()->Set_Money (float(StartingCredits));
 	}
 
 	return ;

--- a/Code/Commando/messages.cpp
+++ b/Code/Commando/messages.cpp
@@ -225,7 +225,7 @@ if (cDevOptions::UseNewTCADO.Is_False()) {
 								** Add the packet header.
 								*/
 								packet_size += cPacket::Get_Packet_Header_Size();
-								p_object->Set_Frequent_Update_Export_Size(packet_size);
+								p_object->Set_Frequent_Update_Export_Size(static_cast<unsigned char>(packet_size));
 							} else {
 								/*
 								** For some reason, some objects have a frequent bit set but there is no frequent update export.
@@ -372,7 +372,7 @@ if (cDevOptions::UseNewTCADO.Is_False()) {
 				}
 				temp_obj->Set_Update_Rate(client_id, (unsigned short) update_rate);
 				if (update_rate != infinity_update_rate) {
-					int bps = (1000.0f / update_rate) * temp_obj->Get_Frequent_Update_Export_Size();
+					int bps = int((1000.0f / update_rate) * temp_obj->Get_Frequent_Update_Export_Size());
 					total_bps += bps;
 				}
 			}
@@ -387,7 +387,8 @@ if (cDevOptions::UseNewTCADO.Is_False()) {
 			*/
 			float factor = 1.0;
 			if (total_bps) {
-				factor = avail_bytes_per_update / total_bps;
+				// TODO OmniBlade: This looks bugged, intended that division be floating point rather than integer?
+				factor = float(avail_bytes_per_update / total_bps);
 				if (factor < 0.00001f) {
 					factor = 0.00001f;
 				}
@@ -623,7 +624,7 @@ if (cDevOptions::UseNewTCADO.Is_False()) {
 										hidden = true;
 									}
 									if (hidden) {
-										int distance = cPriority::Get_Object_Distance_2(dest_pos, p_object);
+										int distance = int(cPriority::Get_Object_Distance_2(dest_pos, p_object));
 										if (distance > min_vis_distance) {
 											/*
 											** Allow some very infrequent updates for distant, hidden objects on broadband connections.
@@ -677,7 +678,7 @@ if (cDevOptions::UseNewTCADO.Is_False()) {
 									** Add the packet header.
 									*/
 									packet_size += cPacket::Get_Packet_Header_Size();
-									p_object->Set_Frequent_Update_Export_Size(packet_size);
+									p_object->Set_Frequent_Update_Export_Size(static_cast<unsigned char>(packet_size));
 								} else {
 									/*
 									** For some reason, some objects have a frequent bit set but there is no frequent update export.
@@ -770,12 +771,12 @@ if (cDevOptions::UseNewTCADO.Is_False()) {
 					update_rate = (unsigned int)(((1.0f - pri) * spread) + ms_low);
 				} else {
 					if (pri > 0.009f) {
-						update_rate = min_update_rate;
+						update_rate = int(min_update_rate);
 					}
 				}
 				temp_obj->Set_Update_Rate(client_id, (unsigned short) update_rate);
 				if (update_rate != infinity_update_rate) {
-					int bps = (1000.0f / update_rate) * temp_obj->Get_Frequent_Update_Export_Size();
+					int bps = int((1000.0f / update_rate) * temp_obj->Get_Frequent_Update_Export_Size());
 					total_bps += bps;
 				}
 			}
@@ -790,7 +791,8 @@ if (cDevOptions::UseNewTCADO.Is_False()) {
 			*/
 			float factor = 1.0;
 			if (total_bps) {
-				factor = avail_bytes_per_update / total_bps;
+				// TODO OmniBlade: Looks bugged, should use floating point division rather than integer?
+				factor = float(avail_bytes_per_update / total_bps);
 				if (factor < 0.00001f) {
 					factor = 0.00001f;
 				}

--- a/Code/Commando/moneyevent.cpp
+++ b/Code/Commando/moneyevent.cpp
@@ -86,7 +86,7 @@ cMoneyEvent::Act(void)
 
 	if (p_player != NULL && p_player->Invulnerable.Is_True()) {
 
-		p_player->Set_Money(Amount);
+		p_player->Set_Money(float(Amount));
 
 	   WWDEBUG_SAY(("Client %d setting money to %d.\n", SenderId, Amount));
 	}

--- a/Code/Commando/multihud.cpp
+++ b/Code/Commando/multihud.cpp
@@ -158,8 +158,8 @@ void MultiHUDClass::Render_Text(WideStringClass & text, float x, float y, unsign
 		// is non-integral.
 		//
 
-		x = cMathUtil::Round(x);
-		y = cMathUtil::Round(y);
+		x = WWMath::Round(x);
+		y = WWMath::Round(y);
 
 		NameRenderer->Set_Location(Vector2(x, y));
 		NameRenderer->Build_Sentence(text);
@@ -449,8 +449,8 @@ void MultiHUDClass::Render_Debug_Text(const char *text, float x, float y, unsign
 
 	WWASSERT(text != NULL);
 
-	x = cMathUtil::Round(x);
-	y = cMathUtil::Round(y);
+	x = WWMath::Round(x);
+	y = WWMath::Round(y);
 
 	if (PTextRenderer != NULL) {
 		WWASSERT(PTextRenderer != NULL);
@@ -660,7 +660,7 @@ void MultiHUDClass::Show_Player_Rhost_Data(SmartGameObj * smart_obj)
 
 			cRemoteHost * p_rhost = cNetwork::Get_Server_Rhost(controlling_client);
 			float x = 20;
-			float y = 60 + controlling_client * 10;
+			float y = float(60 + controlling_client * 10);
 
 			WideStringClass name(p_player->Get_Name(), true);
 			StringClass short_name;

--- a/Code/Commando/nat.h
+++ b/Code/Commando/nat.h
@@ -158,7 +158,7 @@ class FirewallHelperClass {
 		*/
 		void Detect_Firewall(HANDLE event = INVALID_HANDLE_VALUE);
 		unsigned short Get_Raw_Firewall_Behavior(void);	// {return((unsigned short)Behavior);};
-		short Get_Source_Port_Allocation_Delta(void) {return(SourcePortAllocationDelta);}
+		short Get_Source_Port_Allocation_Delta(void) {return short(SourcePortAllocationDelta);}
 
 		/*
 		** Query class for behavior.

--- a/Code/Commando/natter.cpp
+++ b/Code/Commando/natter.cpp
@@ -181,7 +181,7 @@ void WOLNATInterfaceClass::Init(void)
 		/*
 		** Read the local class values from the registry.
 		*/
-		PortBase = reg.Get_Int("PortBase", PortBase);
+		PortBase = (unsigned short) reg.Get_Int("PortBase", PortBase);
 		//ForcePort = reg.Get_Int("ForcePort", ForcePort);
 	}
 
@@ -189,7 +189,7 @@ void WOLNATInterfaceClass::Init(void)
 	** Make sure the base port is reasonable.
 	*/
 	if (PortBase < 1024) {
-		PortBase = FreeRandom.Get_Int(PORT_BASE_MIN, PORT_BASE_MAX - 32);
+		PortBase = (unsigned short) FreeRandom.Get_Int(PORT_BASE_MIN, PORT_BASE_MAX - 32);
 	}
 
 	fw_assert(PortBase >= PORT_BASE_MIN && PortBase < PORT_BASE_MAX);
@@ -610,7 +610,7 @@ void WOLNATInterfaceClass::Get_Config(RegistryClass *reg, int &port_number, bool
 	port_number = local_reg->Get_Int("ForcePort", ForcePort);
 
 	FirewallHelper.Set_Send_Delay(send_delay);
-	ForcePort = port_number;
+	ForcePort = (unsigned short) port_number;
 
 	if (!reg) {
 		delete local_reg;
@@ -646,7 +646,7 @@ void WOLNATInterfaceClass::Set_Config(RegistryClass *reg, int port_number, bool 
 	}
 
 	FirewallHelper.Set_Send_Delay(send_delay);
-	ForcePort = port_number;
+	ForcePort = (unsigned short) port_number;
 
 	local_reg->Set_Bool("SendDelay", send_delay);
 	local_reg->Set_Int("ForcePort", ForcePort);
@@ -1313,7 +1313,7 @@ void WOLNATInterfaceClass::Intercept_Game_Packet(cPacket &packet)
 	*/
 	char payload[512];
 	payload[0] = 0;
-	int payload_size = 512;
+	uint16_t payload_size = 512;
 
 	packet.Get_Terminated_String(payload, payload_size, true);
 	fw_assert(strlen(payload) > 0);

--- a/Code/Commando/netgraphs.cpp
+++ b/Code/Commando/netgraphs.cpp
@@ -72,14 +72,14 @@ void cNetwork::Packet_Graph(Render2DTextClass * renderer, cMsgStatList * p_stat_
 	WWASSERT(p_stat_list	!= NULL);
 	WWASSERT(label	!= NULL);
 
-	GraphingY = cMathUtil::Round(GraphingY);
+	GraphingY = WWMath::Round(GraphingY);
 
 	//
 	// Draw scaling bar
 	//
 	const float bar_length			= 200.0f;
-	const float bar_height			= cMathUtil::Round(renderer->Peek_Font()->Char_Height());
-	const float y_increment			= cMathUtil::Round(bar_height * 1.25f);
+	const float bar_height			= WWMath::Round(float(renderer->Peek_Font()->Char_Height()));
+	const float y_increment			= WWMath::Round(bar_height * 1.25f);
 
 	renderer->Draw_Block(RectClass(0, GraphingY, bar_length, GraphingY + bar_height), COLOR_BLACK);
 
@@ -318,13 +318,13 @@ void cNetwork::Bandwidth_Graph(Render2DTextClass * renderer,
 	WWASSERT(renderer != NULL);
 	WWASSERT(label != NULL);
 
-	const int screen_width	= Render2DClass::Get_Screen_Resolution().Width();
-	const int screen_height = Render2DClass::Get_Screen_Resolution().Height();
+	const float screen_width	= WWMath::Trunc(Render2DClass::Get_Screen_Resolution().Width());
+	const float screen_height = WWMath::Trunc(Render2DClass::Get_Screen_Resolution().Height());
 
 	WWASSERT(packetloss_pc > -MISCUTIL_EPSILON && packetloss_pc < 100 + MISCUTIL_EPSILON);
 
-	const float bar_height		= cMathUtil::Round(renderer->Peek_Font()->Char_Height());
-	const float y_increment		= cMathUtil::Round(bar_height * 1.25f);
+	const float bar_height		= WWMath::Round(float(renderer->Peek_Font()->Char_Height()));
+	const float y_increment		= WWMath::Round(bar_height * 1.25f);
 
 	float end_x;
 	float full_x;
@@ -427,10 +427,10 @@ void cNetwork::Bandwidth_Graph(Render2DTextClass * renderer,
 	// Render object prioritys so can compare against threshold priority
 	//
 	if (cNetwork::I_Am_Server())	{
-		int top = (int)(0.2 * screen_height);
+		float top = WWMath::Trunc(0.2f * screen_height);
 		int obj_count = NetworkObjectMgrClass::Get_Object_Count();
 
-		int x_pos = screen_width - 75;
+		float x_pos = screen_width - 75;
 
 		renderer->Set_Location(Vector2(x_pos, 300));
 		renderer->Draw_Text("UNKNOWN", COLOR_BLACK);
@@ -465,7 +465,7 @@ void cNetwork::Bandwidth_Graph(Render2DTextClass * renderer,
 			if (priority > 0) {
 
 				RectClass rect;
-				rect.Left	= (int)(priority * screen_width) - 3;
+				rect.Left	= WWMath::Trunc((priority * screen_width) - 3);
 				rect.Right	= rect.Left + 6;
 				rect.Top		= top;
 				rect.Bottom	= rect.Top + 1;
@@ -499,7 +499,7 @@ void cNetwork::Bandwidth_Graph(Render2DTextClass * renderer,
 
 				renderer->Draw_Block(rect, color);
 
-				top += 3;
+				top += 3.0f;
 			}
 		}
 	}
@@ -525,9 +525,9 @@ void cNetwork::Watch_Bandwidth(Render2DTextClass * renderer)
 	//
 	// Draw the scale at the top
 	//
-	const int	screen_width	= Render2DClass::Get_Screen_Resolution().Width();
-	const float	bar_height		= cMathUtil::Round(renderer->Peek_Font()->Char_Height());
-	const float y_increment		= cMathUtil::Round(bar_height * 1.25f);
+	const float	screen_width	= WWMath::Trunc(Render2DClass::Get_Screen_Resolution().Width());
+	const float	bar_height		= WWMath::Round(float(renderer->Peek_Font()->Char_Height()));
+	const float y_increment		= WWMath::Round(bar_height * 1.25f);
 
 	//BandwidthBarLength = screen_width / 8.0f;
 	BandwidthBarLength = screen_width / 10.0f;
@@ -565,10 +565,10 @@ void cNetwork::Watch_Bandwidth(Render2DTextClass * renderer)
 			//XXX Get_Client_Rhost()->Get_Stats().StatSnapshot[STAT_BitsSent],
 			Get_Client_Rhost()->Get_Stats().StatMacroSnapshot[STAT_BitsSent],
 			Get_Client_Rhost()->Get_Target_Bps(),
-         Get_Client_Rhost()->Get_Stats().Get_Pc_Packetloss_Sent(),
+         float(Get_Client_Rhost()->Get_Stats().Get_Pc_Packetloss_Sent()),
 			COLOR_RED,
          true,
-			Get_Client_Rhost()->Get_Threshold_Priority());
+			float(Get_Client_Rhost()->Get_Threshold_Priority()));
 
 		sprintf(text, "c%d<-s", Get_My_Id());
 		Bandwidth_Graph(
@@ -577,7 +577,7 @@ void cNetwork::Watch_Bandwidth(Render2DTextClass * renderer)
 			//XXX Get_Client_Rhost()->Get_Stats().StatSnapshot[STAT_BitsRcv],
 			Get_Client_Rhost()->Get_Stats().StatMacroSnapshot[STAT_BitsRcv],
 			-1,
-         Get_Client_Rhost()->Get_Stats().Get_Pc_Packetloss_Received(),
+         float(Get_Client_Rhost()->Get_Stats().Get_Pc_Packetloss_Received()),
          COLOR_RED,
          false,
 			-1);
@@ -631,10 +631,10 @@ void cNetwork::Watch_Bandwidth(Render2DTextClass * renderer)
 					//XXX p_rhost->Get_Stats().StatSnapshot[STAT_BitsSent],
 					p_rhost->Get_Stats().StatMacroSnapshot[STAT_BitsSent],
 					p_rhost->Get_Target_Bps(),
-               p_rhost->Get_Stats().Get_Pc_Packetloss_Sent(),
+               float(p_rhost->Get_Stats().Get_Pc_Packetloss_Sent()),
 					COLOR_RED,
                true,
-					p_rhost->Get_Threshold_Priority());
+					float(p_rhost->Get_Threshold_Priority()));
 
 				sprintf(text, "s<-c%d", i);
 				Bandwidth_Graph(
@@ -643,7 +643,7 @@ void cNetwork::Watch_Bandwidth(Render2DTextClass * renderer)
 					//XXX p_rhost->Get_Stats().StatSnapshot[STAT_BitsRcv],
 					p_rhost->Get_Stats().StatMacroSnapshot[STAT_BitsRcv],
                -1,
-					p_rhost->Get_Stats().Get_Pc_Packetloss_Received(),
+					float(p_rhost->Get_Stats().Get_Pc_Packetloss_Received()),
 					COLOR_RED,
                false,
 					-1);

--- a/Code/Commando/playermanager.cpp
+++ b/Code/Commando/playermanager.cpp
@@ -552,7 +552,7 @@ void cPlayerManager::Compute_Ladder_Points(int winning_team)
 	// Additional step. Let's now post-multiply ladder points by the fraction of
 	// gametime that each player was present.
 	//
-	float game_duration_s = The_Game()->Get_Game_Duration_S();
+	float game_duration_s = float(The_Game()->Get_Game_Duration_S());
 	//WWASSERT(game_duration_s > 0);
 	if (game_duration_s == 0)
 	{
@@ -565,7 +565,7 @@ void cPlayerManager::Compute_Ladder_Points(int winning_team)
 			continue;
 		}
 
-		float player_duration_s = Player_Array[i]->Get_Total_Time() / 1000.0;
+		float player_duration_s = Player_Array[i]->Get_Total_Time() / 1000.0f;
 		float ratio_present = player_duration_s / game_duration_s;
 		float ladder_points = ratio_present * Player_Array[i]->Get_Ladder_Points();
 		/*
@@ -965,7 +965,7 @@ int cPlayerManager::Fast_Player_Compare(const void * elem1, const void * elem2)
 int cPlayerManager::Compute_Fast_Sort_Key(cPlayer * player)
 {
 	int key = 0;
-	key = player->Get_Score();
+	key = int(player->Get_Score());
 	return key;
 }
 
@@ -1111,14 +1111,14 @@ void cPlayerManager::List_Print(WideStringClass & text, Vector3 color)
 
 	WWASSERT(PTextRenderer != NULL);
 
-	PTextRenderer->Set_Location(Vector2(cMathUtil::Round(XPos), cMathUtil::Round(YPos)));
+	PTextRenderer->Set_Location(Vector2(float(XPos), float(YPos)));
 
 	int c = ((int)(color[0]*255)&0xFF) << 16 | ((int)(color[1]*255)&0xFF) << 8 | ((int)(color[2]*255)&0xFF) << 0 | 0xFF000000;
 
 	PTextRenderer->Draw_Text(text, c);
 
    WWASSERT(PFont != NULL);
-   YPos += PFont->Char_Height() * Y_INCREMENT_FACTOR;
+   YPos += int(PFont->Char_Height() * Y_INCREMENT_FACTOR);
 }
 
 //-----------------------------------------------------------------------------
@@ -1308,9 +1308,9 @@ void cPlayerManager::Render_Player_List(void)
 	XPos = 0;
 	float text_len = PFont->String_Width(heading);
 	if (The_Game()->IsIntermission.Is_True()) {
-		XPos = Render2DClass::Get_Screen_Resolution().Center().X - text_len / 2.0f;
+		XPos = int(Render2DClass::Get_Screen_Resolution().Center().X - text_len / 2.0f);
 	} else {
-		XPos = Render2DClass::Get_Screen_Resolution().Right - 20 - text_len;
+		XPos = int(Render2DClass::Get_Screen_Resolution().Right - 20 - text_len);
 	}
 
 	//
@@ -1319,12 +1319,12 @@ void cPlayerManager::Render_Player_List(void)
 	if (The_Game()->IsIntermission.Is_True()) {
 		//YPos = 70;
 
-		int combined_height =
+		float combined_height = WWMath::Trunc(
 			cTeamManager::Compute_Team_List_Height() +
 			cPlayerManager::Compute_Full_Player_List_Height() +
-			2 * PFont->Char_Height() * Y_INCREMENT_FACTOR;
+			2 * PFont->Char_Height() * Y_INCREMENT_FACTOR);
 
-		YPos = (int)(Render2DClass::Get_Screen_Resolution().Height() / 2.0 - combined_height / 2.0);
+		YPos = (int)(Render2DClass::Get_Screen_Resolution().Height() / 2.0f - combined_height / 2.0f);
 		if (YPos < 10) {
 			YPos = 10;
 		}
@@ -1349,7 +1349,7 @@ void cPlayerManager::Render_Player_List(void)
 		}
 		*/
 
-		YPos += 2 * PFont->Char_Height() * Y_INCREMENT_FACTOR;
+		YPos += int(2 * PFont->Char_Height() * Y_INCREMENT_FACTOR);
 		YPos += cTeamManager::Compute_Team_List_Height();
 
 	} else {
@@ -1384,8 +1384,8 @@ void cPlayerManager::Render_Player_List(void)
 		if ((MultiHUDClass::Get_Playerlist_Format() != PLAYERLIST_FORMAT_TINY) &&
 			 (renderer_star_index == j)) {
 			float x = XPos - 2 * PFont->String_Width(star_text);
-			float y = YPos;
-			PTextRenderer->Set_Location(Vector2(cMathUtil::Round(x), cMathUtil::Round(y)));
+			float y = float(YPos);
+			PTextRenderer->Set_Location(Vector2(WWMath::Round(x), WWMath::Round(y)));
 			PTextRenderer->Draw_Text(star_text);
 		}
 

--- a/Code/Commando/priority.cpp
+++ b/Code/Commando/priority.cpp
@@ -111,7 +111,7 @@ cPriority::Compute_Object_Priority
 			//float bendy = WWMath::Fast_Sin(priority * DEG_TO_RAD(90.0f));
 			//priority = (priority + bendy) / 2.0f;
 			float bendy = WWMath::Fast_Asin(priority);
-			bendy = (RAD_TO_DEG(bendy)) / 90.0f;
+			bendy = (RAD_TO_DEGF(bendy)) / 90.0f;
 			priority = (priority + bendy) / 2.0f;
 		}
 	}
@@ -376,7 +376,7 @@ cPriority::Compute_Object_Priority_2
 			//float bendy = WWMath::Fast_Sin(priority * DEG_TO_RAD(90.0f));
 			//priority = (priority + bendy) / 2.0f;
 			float bendy = WWMath::Fast_Asin(priority);
-			bendy = (RAD_TO_DEG(bendy)) / 90.0f;
+			bendy = (RAD_TO_DEGF(bendy)) / 90.0f;
 			priority = (priority + bendy) / 2.0f;
 		}
 	}

--- a/Code/Commando/sbbomanager.cpp
+++ b/Code/Commando/sbbomanager.cpp
@@ -109,7 +109,7 @@ cSbboManager::Think
 			ULONG sbbo = cNetwork::PServerConnection->Get_Bandwidth_Budget_Out();
 			if (sbbo >= 64000)
 			{
-				sbbo *= 0.90;
+				sbbo = ULONG(sbbo * 0.90);
 				cNetwork::PServerConnection->Set_Bandwidth_Budget_Out(sbbo);
 				Debug_Say(("cSbboManager::Think: reducing sbbo to %d\n", sbbo));
 				SlowSamples = 0;

--- a/Code/Commando/scoreevent.cpp
+++ b/Code/Commando/scoreevent.cpp
@@ -89,7 +89,7 @@ cScoreEvent::Act(void)
 		//
 		// We use increment rather than set so that it propagates to teams if appropriate
 		//
-		p_player->Increment_Score(Amount);
+		p_player->Increment_Score(float(Amount));
 
 	   WWDEBUG_SAY(("Client %d incrementing score by %d.\n", SenderId, Amount));
 	}

--- a/Code/Commando/scorescreen.cpp
+++ b/Code/Commando/scorescreen.cpp
@@ -402,7 +402,7 @@ int	ScoreScreenDialogClass::Get_Time_To_Finish_Stars( void )
 		stars = 5;
 	}
 
-	int minutes = time;
+	int minutes = int(time);
 	WideStringClass wtime;
 	wtime.Format( TRANSLATE( IDS_SS_HOURS_MINUTES ), minutes / 60, minutes % 60 );
 	Set_Dlg_Item_Text( IDC_SCORE_SCREEN_PLAYTIME, wtime );

--- a/Code/Commando/slavemaster.cpp
+++ b/Code/Commando/slavemaster.cpp
@@ -434,7 +434,7 @@ void SlaveMasterClass::Load(void)
 		SlaveServers[i].Enable = reg.Get_Bool(entry, false);
 
 		sprintf(entry, "%s%d", KEY_SLAVE_PORT, i);
-		SlaveServers[i].Port = reg.Get_Int(entry, false);
+		SlaveServers[i].Port = static_cast<unsigned short>(reg.Get_Int(entry, false));
 
 		sprintf(entry, "%s%d", KEY_SLAVE_BANDWIDTH, i);
 		SlaveServers[i].Bandwidth = reg.Get_Int(entry, false);
@@ -883,7 +883,7 @@ void SlaveMasterClass::Create_Registry_Copies(void)
 				}
 				slave_port += i;
 				slave_port++;
-				SlaveServers[i].ControlPort = slave_port;
+				SlaveServers[i].ControlPort = static_cast<unsigned short>(slave_port);
 				reg.Set_Int(SERVER_CONTROL_PORT_KEY, slave_port);
 
 				/*

--- a/Code/Commando/teammanager.cpp
+++ b/Code/Commando/teammanager.cpp
@@ -410,14 +410,14 @@ void cTeamManager::List_Print(WideStringClass & text, Vector3 color)
 
 	WWASSERT(PTextRenderer != NULL);
 
-	PTextRenderer->Set_Location(Vector2(cMathUtil::Round(XPos), cMathUtil::Round(YPos)));
+	PTextRenderer->Set_Location(Vector2(float(XPos), float(YPos)));
 
 	int c = ((int)(color[0]*255)&0xFF) << 16 | ((int)(color[1]*255)&0xFF) << 8 | ((int)(color[2]*255)&0xFF) << 0 | 0xFF000000;
 
 	PTextRenderer->Draw_Text(text, c);
 
 	WWASSERT(PFont != NULL);
-   YPos += PFont->Char_Height() * Y_INCREMENT_FACTOR;
+   YPos += int(PFont->Char_Height() * Y_INCREMENT_FACTOR);
 }
 
 //-----------------------------------------------------------------------------
@@ -599,9 +599,9 @@ void cTeamManager::Render_Team_List(void)
 	XPos = 0;
 	float text_len = PFont->String_Width(heading);
 	if (The_Game()->IsIntermission.Is_True()) {
-		XPos = Render2DClass::Get_Screen_Resolution().Center().X - text_len / 2.0f;
+		XPos = int(Render2DClass::Get_Screen_Resolution().Center().X - text_len / 2.0f);
 	} else {
-		XPos = Render2DClass::Get_Screen_Resolution().Right - 20 - text_len;
+		XPos = int(Render2DClass::Get_Screen_Resolution().Right - 20 - text_len);
 	}
 
 	YPos = 10;
@@ -612,12 +612,12 @@ void cTeamManager::Render_Team_List(void)
 	WWASSERT(PTheGameData != NULL);
 	if (The_Game()->IsIntermission.Is_True()) {
 
-		int combined_height =
+		float combined_height = WWMath::Trunc(
 			Compute_Team_List_Height() +
 			cPlayerManager::Compute_Full_Player_List_Height() +
-			2 * PFont->Char_Height() * Y_INCREMENT_FACTOR;
+			2 * PFont->Char_Height() * Y_INCREMENT_FACTOR);
 
-		YPos = (int)(Render2DClass::Get_Screen_Resolution().Height() / 2.0 - combined_height / 2.0);
+		YPos = (int)(Render2DClass::Get_Screen_Resolution().Height() / 2.0f - combined_height / 2.0f);
 		if (YPos < 10) {
 			YPos = 10;
 		}
@@ -626,11 +626,11 @@ void cTeamManager::Render_Team_List(void)
 
 		float x = Render2DClass::Get_Screen_Resolution().Center().X -
 			PFont->String_Width(text) / 2.0f;
-		float y = YPos;
-		PTextRenderer->Set_Location(Vector2(cMathUtil::Round(x), cMathUtil::Round(y)));
+		float y = float(YPos);
+		PTextRenderer->Set_Location(Vector2(WWMath::Round(x), WWMath::Round(y)));
 		PTextRenderer->Draw_Text(text);
 
-		YPos += 2 * PFont->Char_Height() * Y_INCREMENT_FACTOR;
+		YPos += int(2 * PFont->Char_Height() * Y_INCREMENT_FACTOR);
 	}
 
    //

--- a/Code/Commando/useroptions.cpp
+++ b/Code/Commando/useroptions.cpp
@@ -238,7 +238,7 @@ cUserOptions::ParseResult cUserOptions::Parse_Command_Line(int argc, char *argv[
                     return FAILURE;
                 }
                 if (arg_port != 0 || arg_port > 0) {
-                    port = arg_port;
+                    port = USHORT(arg_port);
                 }
                 saddr = saddr_mem = new char[tport - argval + 1];
                 memcpy(saddr_mem, argval, tport - argval);

--- a/Code/Commando/wolgmode.cpp
+++ b/Code/Commando/wolgmode.cpp
@@ -930,7 +930,7 @@ void WolGameModeClass::Update_Channel_Settings(cGameData* theGame, const RefPtr<
 			//---------------------------------------------------------------------------
 			// Get average FPS of game (Capped at 255 fps)
 			//---------------------------------------------------------------------------
-			unsigned int fps = TimeManager::Get_Average_Frame_Rate();
+			unsigned int fps = unsigned(TimeManager::Get_Average_Frame_Rate());
 			fps = std::min<unsigned int>(fps, 255);
 
 			int numPlayers = theGame->Get_Current_Players();
@@ -980,7 +980,7 @@ void WolGameModeClass::Init_WOL_Player(cPlayer* player)
 			RefPtr<LadderData> ladder = user->GetTeamLadder();
 
 			if (ladder.IsValid()) {
-				player->Set_WOL_Points(ladder->GetPoints());
+				player->Set_WOL_Points(static_cast<unsigned short>(ladder->GetPoints()));
 				player->Set_Wol_Rank(ladder->GetRung());
 				player->Set_Num_Wol_Games(ladder->GetReserved2());
 				return;
@@ -1677,7 +1677,7 @@ void WolGameModeClass::HandleNotification(GameOptionsMessage& message)
 				WWASSERT(team != NULL);
 
 				int teamID = team->Get_Id();
-				int teamScore = team->Get_Score();
+				int teamScore = int(team->Get_Score());
 
 				info.Format("TINFO:%d %d", teamID, teamScore);
 
@@ -1702,7 +1702,7 @@ void WolGameModeClass::HandleNotification(GameOptionsMessage& message)
 					int rung = player->Get_Rung();
 					int kills = player->Get_Kills();
 					int deaths = player->Get_Deaths();
-					int score = player->Get_Score();
+					int score = int(player->Get_Score());
 
 					// PINFO string format: Name fps,type,rank,kills,deaths
 					info.Format("PINFO:%S %d %d %d %d %d", (const unichar_t*)name, type, rung, kills, deaths, score);

--- a/Code/Scripts/Mission00.cpp
+++ b/Code/Scripts/Mission00.cpp
@@ -140,7 +140,7 @@ DECLARE_SCRIPT (MTU_Tutorial_Controller, "")
 		// Start a slight delay timer, then tell Logan Sheppard to begin.
 
 		Commands->Start_Timer (obj, this, 2.0f, MTU_TIMER_MISSION_START);
-		Commands->Start_Timer (obj, this, (10 + Get_Int_Random (0, 20)), MTU_TIMER_FLYOVERS);
+		Commands->Start_Timer (obj, this, float(10 + Get_Int_Random (0, 20)), MTU_TIMER_FLYOVERS);
 
 		// Set the gates to be closed at first.
 
@@ -304,7 +304,7 @@ DECLARE_SCRIPT (MTU_Tutorial_Controller, "")
 						Commands->Attach_Script (flyover, "MTU_Flyover", "1");
 					}
 				}
-				Commands->Start_Timer (obj, this, (10 + Get_Int_Random (0, 20)), MTU_TIMER_FLYOVERS);
+				Commands->Start_Timer (obj, this, float(10 + Get_Int_Random (0, 20)), MTU_TIMER_FLYOVERS);
 				break;
 			}
 		}
@@ -2207,7 +2207,7 @@ DECLARE_SCRIPT (MTU_Tutorial_Instructor, "")
 			Commands->Force_Camera_Look (target_loc);
 		}
 
-		int conversation = Commands->Create_Conversation (conv_name, 100.0f, 300.0f, false);
+		int conversation = Commands->Create_Conversation (conv_name, 100, 300.0f, false);
 		Commands->Join_Conversation(obj, conversation, false, true, true);
 		Commands->Join_Conversation(STAR, conversation, false, false, false);
 		Commands->Start_Conversation (conversation, speech_id);
@@ -3272,7 +3272,7 @@ DECLARE_SCRIPT (MTU_GDI_Soldier, "")
 		{
 			Commands->Select_Weapon (STAR, NULL);
 			gate_guard_opened = true;
-			int conversation = Commands->Create_Conversation ("MTU_GDI_POKE", 100.0f, 300.0f, true);
+			int conversation = Commands->Create_Conversation ("MTU_GDI_POKE", 100, 300.0f, true);
 			Commands->Join_Conversation(obj, conversation, false, true, true);
 			Commands->Join_Conversation(STAR, conversation, false, true, true);
 			Commands->Start_Conversation (conversation, MTU_SPEECH_GATEGUARD_POKE);
@@ -3870,7 +3870,7 @@ DECLARE_SCRIPT (MSK_Controller, "")
 {
 	void Created (GameObject * obj) override
 	{
-		int conversation = Commands->Create_Conversation ("MSK_MP_STARTUP_DESC", 100.0f, 300.0f, false);
+		int conversation = Commands->Create_Conversation ("MSK_MP_STARTUP_DESC", 100, 300.0f, false);
 		Commands->Join_Conversation(obj, conversation, false, false, false);
 		Commands->Start_Conversation (conversation, 1);
 
@@ -4819,7 +4819,7 @@ DECLARE_SCRIPT (MSK_Info_Zone, "")
 					break;
 				}
 			}
-			int conversation = Commands->Create_Conversation (conv_name, 100.0f, 300.0f, false);
+			int conversation = Commands->Create_Conversation (conv_name, 100, 300.0f, false);
 			Commands->Join_Conversation(obj, conversation, false, false, false);
 			Commands->Start_Conversation (conversation, 1);
 		}

--- a/Code/Scripts/Mission01.cpp
+++ b/Code/Scripts/Mission01.cpp
@@ -1659,7 +1659,7 @@ DECLARE_SCRIPT(M01_Mission_Controller_JDG, "")//this guys ID number is 100376
 								}
 							}
 
-							Commands->Send_Custom_Event( obj, Commands->Find_Object ( M01_MISSION_CONTROLLER_JDG ), 0, M01_HON_SPAWNS_MINIGUNNER_JDG, m01_HON_SpawnRate );
+							Commands->Send_Custom_Event( obj, Commands->Find_Object ( M01_MISSION_CONTROLLER_JDG ), 0, M01_HON_SPAWNS_MINIGUNNER_JDG, float(m01_HON_SpawnRate) );
 						}
 					}
 					break;
@@ -4637,7 +4637,7 @@ DECLARE_SCRIPT(M01_Flamethrower_Point_Guard_JDG, "")
 			float delayTimer = Commands->Get_Random ( 5, 10 );
 
 			params.Set_Basic( this, 45, 20 );
-			params.Set_Face_Location(  myPosition, DEG_TO_RAD(atarashiLookSpot), delayTimer );
+			params.Set_Face_Location(  myPosition, DEG_TO_RADF(atarashiLookSpot), delayTimer );
 			Commands->Action_Face_Location ( obj, params );
 			Commands->Send_Custom_Event( obj, obj, 0, M01_PICK_A_NEW_LOCATION_JDG, delayTimer );
 		}
@@ -5263,14 +5263,14 @@ DECLARE_SCRIPT(M01_Whack_A_Mole_Minigunner_JDG, "")
 				attacked = true;
 				Commands->Set_Health ( obj, base_health );
 				points_given = 2 * points_given;
-				speed = speed + .1;
+				speed = speed + .1f;
 
 				if (speed > 1)
 				{
 					speed = 1;
 				}
 
-				Commands->Give_Points( damager, points_given, false );
+				Commands->Give_Points( damager, float(points_given), false );
 
 				Commands->Send_Custom_Event( obj, obj, 0, M01_DOING_ANIMATION_01_JDG, 0 );
 			}
@@ -6446,7 +6446,7 @@ DECLARE_SCRIPT(M01_GDI_Base_Spawner_Controller_JDG, "")//this guys ID is M01_GDI
 					{
 						if (active_unit_count < 2)
 						{
-							int random = Commands->Get_Random(0.5f, 2.5f);
+							float random = Commands->Get_Random(0.5f, 2.5f);
 
 							if ((random >= 0.5f) && (random < 1.5f))
 							{
@@ -6468,7 +6468,7 @@ DECLARE_SCRIPT(M01_GDI_Base_Spawner_Controller_JDG, "")//this guys ID is M01_GDI
 					{
 						if (active_unit_count < 3)
 						{
-							int random = Commands->Get_Random(0.5f, 3.5f);
+							float random = Commands->Get_Random(0.5f, 3.5f);
 
 							if ((random >= 0.5f) && (random < 1.5f))
 							{
@@ -6608,7 +6608,7 @@ DECLARE_SCRIPT(M01_Tailgun_Run_Spawner_Controller_JDG, "")//this guys ID is M01_
 						{
 							if (active_unit_count < 2)
 							{
-								int random = Commands->Get_Random(0.5f, 2.5f);
+								float random = Commands->Get_Random(0.5f, 2.5f);
 
 								if ((random >= 0.5f) && (random < 1.5f))
 								{
@@ -6628,7 +6628,7 @@ DECLARE_SCRIPT(M01_Tailgun_Run_Spawner_Controller_JDG, "")//this guys ID is M01_
 						{
 							if (active_unit_count < 3)
 							{
-								int random = Commands->Get_Random(0.5f, 3.5f);
+								float random = Commands->Get_Random(0.5f, 3.5f);
 
 								if ((random >= 0.5f) && (random < 1.5f))
 								{
@@ -6765,7 +6765,7 @@ DECLARE_SCRIPT(M01_ChurchArea_Spawner_Controller_JDG, "")//this guys ID is M01_C
 						{
 							if (active_unit_count < 2)
 							{
-								int random = Commands->Get_Random(0.5f, 2.5f);
+								float random = Commands->Get_Random(0.5f, 2.5f);
 
 								if ((random >= 0.5f) && (random < 1.5f))
 								{
@@ -6785,7 +6785,7 @@ DECLARE_SCRIPT(M01_ChurchArea_Spawner_Controller_JDG, "")//this guys ID is M01_C
 						{
 							if (active_unit_count < 3)
 							{
-								int random = Commands->Get_Random(0.5f, 3.5f);
+								float random = Commands->Get_Random(0.5f, 3.5f);
 
 								if ((random >= 0.5f) && (random < 1.5f))
 								{

--- a/Code/Scripts/Mission02.cpp
+++ b/Code/Scripts/Mission02.cpp
@@ -2367,7 +2367,7 @@ DECLARE_SCRIPT (M02_Respawn_Controller, "")
 				counter++;
 			}
 			int players_difficulty = Commands->Get_Difficulty_Level();
-			float timer_length = 25 - (10 * (players_difficulty));
+			float timer_length = float(25 - (10 * (players_difficulty)));
 			Commands->Start_Timer(obj, this, timer_length, 2);
 		}
 	}
@@ -3675,7 +3675,11 @@ DECLARE_SCRIPT (M02_Nod_Soldier, "Area_Number:int,Area_Officer:int,Pre_Placed:in
 				// Time to move the chem-warrior. Pick a new location.
 
 				Vector3 newloc;
-				int rndnum = (Get_Int_Random(0.0f,1.0f) * 5);
+				// TODO OmniBlade: So I've silenced the C4244 warning here, but the logic looks screwed.
+				// Intention seems to have been to generate a random float and then round to int. As it stands
+				// it appears to have a 1/2 chance of hitting either case 0 or default.
+				//int rndnum = (Get_Int_Random(0.0f,1.0f) * 5);
+				int rndnum = (Get_Int_Random(0,1) * 5);
 				switch (rndnum)
 				{
 				case (0):
@@ -4641,7 +4645,7 @@ DECLARE_SCRIPT (M02_Nod_Apache, "Area_ID:int")
 			{
 				ActionParamsStruct params;
 				params.Set_Basic(this, 90, 0);
-				params.Set_Movement(Vector3(0,0,0), 0.2 + (0.1 * DIFFICULTY), 5.0f);
+				params.Set_Movement(Vector3(0,0,0), 0.2f + (0.1f * DIFFICULTY), 5.0f);
 				params.WaypathID = waypath_id;
 				params.WaypathSplined = true;
 				params.MovePathfind = false;

--- a/Code/Scripts/Mission03.cpp
+++ b/Code/Scripts/Mission03.cpp
@@ -1924,7 +1924,7 @@ DECLARE_SCRIPT(M03_Announce_PowerPlant_Controller_JDG, "")
 		{
 
 
-			float lineNumber = Commands->Get_Random ( 0.5f, total_number_of_sounds+0.5);
+			float lineNumber = Commands->Get_Random ( 0.5f, total_number_of_sounds+0.5f);
 
 			if ((lineNumber >= 0.5) && (lineNumber < 1.5))
 			{
@@ -2371,7 +2371,7 @@ DECLARE_SCRIPT(M03_Announce_Refinery_Controller_JDG, "")
 		else if (param == pick_sound)
 		{
 
-			float lineNumber = Commands->Get_Random ( 0.5f, total_number_of_sounds+0.5);
+			float lineNumber = Commands->Get_Random ( 0.5f, total_number_of_sounds+0.5f);
 
 			if ((lineNumber >= 0.5) && (lineNumber < 1.5))
 			{
@@ -2825,7 +2825,7 @@ DECLARE_SCRIPT(M03_Announce_CommCenter_Controller_JDG, "")
 		else if (param == pick_sound)
 		{
 
-			float lineNumber = Commands->Get_Random ( 0.5f, total_number_of_sounds+0.5);
+			float lineNumber = Commands->Get_Random ( 0.5f, total_number_of_sounds+0.5f);
 
 			if ((lineNumber >= 0.5) && (lineNumber < 1.5))
 			{
@@ -3490,8 +3490,8 @@ DECLARE_SCRIPT(M03_Chinook_Spawned_Soldier_GDI, "Area:int, Send_Type_When_Killed
 			//distance *= 3;
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * distance;
-			float b = sin(DEG_TO_RADF(facing)) * distance;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * distance;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * distance;
 			Vector3 goto_loc = pos + Vector3(a, b, 0.0f);
 
 			ActionParamsStruct params;
@@ -5135,8 +5135,8 @@ DECLARE_SCRIPT(M03_Structure_Powerup_Drop, "Powerup:string")
 		Vector3 pos = Commands->Get_Position(obj);
 		float facing = Commands->Get_Facing(obj);
 		facing = facing + 180.0f;
-		pos.X += cos(DEG_TO_RADF(facing)) * 2.5f;
-		pos.Y += sin(DEG_TO_RADF(facing)) * 2.5f;
+		pos.X += WWMath::Cos(DEG_TO_RADF(facing)) * 2.5f;
+		pos.Y += WWMath::Sin(DEG_TO_RADF(facing)) * 2.5f;
 		pos.Z += 0.5f;
 
 		const char *powerup = Get_Parameter("Powerup");
@@ -5413,7 +5413,7 @@ DECLARE_SCRIPT(DLS_Volcano_Active, "Receive_Type=0:int, Receive_Param=0:int, Vol
 		receive_type = Get_Int_Parameter("Receive_Type");
 		receive_param = Get_Int_Parameter("Receive_Param");
 		volcano_timer_id = Get_Int_Parameter("Volcano_Timer_Id");
-		volcano_delay = Get_Int_Parameter("Volcano_Delay");
+		volcano_delay = float(Get_Int_Parameter("Volcano_Delay"));
 		explosion_delay_min = Get_Float_Parameter("Explosion_Delay_Min");
 		explosion_delay_max = Get_Float_Parameter("Explosion_Delay_Max");
 		rumble_delay_min = Get_Float_Parameter("Rumble_Delay_Min");
@@ -6769,7 +6769,7 @@ DECLARE_SCRIPT(M03_Engineer_Repair, "Repair_Priority=96:int")
 
 				ActionParamsStruct params;
 
-				params.Set_Basic( this, repair_priority, MOVE_TO_HEAL );
+				params.Set_Basic( this, float(repair_priority), MOVE_TO_HEAL );
 				params.Set_Movement( Commands->Get_Position (sound.Creator), RUN, 5.0f );
 
 				Commands->Action_Goto (obj, params);
@@ -6793,7 +6793,7 @@ DECLARE_SCRIPT(M03_Engineer_Repair, "Repair_Priority=96:int")
 		{
 			ActionParamsStruct params;
 
-			params.Set_Basic( this, repair_priority, REPAIRING );
+			params.Set_Basic( this, float(repair_priority), REPAIRING );
 			params.Set_Attack (Commands->Find_Object (target_id), 50.0f, 0.0f, 0);
 			params.AttackCheckBlocked = false;
 			Commands->Action_Attack( obj, params );
@@ -7037,8 +7037,8 @@ DECLARE_SCRIPT(M03_Paratrooper_Run, "")
 			//distance *= 3;
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * distance;
-			float b = sin(DEG_TO_RADF(facing)) * distance;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * distance;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * distance;
 			Vector3 goto_loc = pos + Vector3(a, b, 0.0f);
 
 			ActionParamsStruct params;

--- a/Code/Scripts/Mission04.cpp
+++ b/Code/Scripts/Mission04.cpp
@@ -3105,7 +3105,7 @@ DECLARE_SCRIPT(M04_EngineRoom_Prisoner_01_JDG, "")//this guys ID number is M04_P
 		{
 			if (damager == STAR )
 			{
-				int myMaxHealth = Commands->Get_Max_Health ( obj );
+				float myMaxHealth = Commands->Get_Max_Health ( obj );
 				Commands->Set_Health ( obj, myMaxHealth );
 
 				if (firstTimeDamaged == true)
@@ -3270,7 +3270,7 @@ DECLARE_SCRIPT(M04_EngineRoom_Prisoner_02_JDG, "")//this guys ID number is M04_P
 	{
 		if (obj && damager == STAR)
 		{
-			int myMaxHealth = Commands->Get_Max_Health ( obj );
+			float myMaxHealth = Commands->Get_Max_Health ( obj );
 			Commands->Set_Health ( obj, myMaxHealth );
 
 			if (firstTimeDamaged == true)
@@ -3378,7 +3378,7 @@ DECLARE_SCRIPT(M04_EngineRoom_Prisoner_03_JDG, "")//this guys ID number is M04_P
 		ActionParamsStruct params;
 		if (obj && damager == STAR)
 		{
-			int myMaxHealth = Commands->Get_Max_Health ( obj );
+			float myMaxHealth = Commands->Get_Max_Health ( obj );
 			Commands->Set_Health ( obj, myMaxHealth );
 
 			if (firstTimeDamaged == true)

--- a/Code/Scripts/Mission05.cpp
+++ b/Code/Scripts/Mission05.cpp
@@ -360,7 +360,7 @@ DECLARE_SCRIPT(M05_Objective_Controller, "")  // 100001
 		{
 			// Hotwire here, I can't rendezvous at your position, I've got tons of armor pounding my location in the southwest quarter.\n
 			const char *conv_name = ("M05_CON001");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300503);
@@ -432,7 +432,7 @@ DECLARE_SCRIPT(M05_Activate_Objective_501, "")
 
 			// This is Gunner, I'm pinned down under heavy fire on the south side of the village, requesting backup!\n
 			const char *conv_name = ("M05_CON003");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300501);
@@ -478,7 +478,7 @@ DECLARE_SCRIPT(M05_Activate_Objective_502, "")
 
 			// This is Deadeye - I'm held up in the Fancy Inn on the east side with some local resistance fighters. Need further assistance.\n
 			const char *conv_name = ("M05_CON004");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(Commands->Get_A_Star(Vector3(0.0f,0.0f,0.0f)), conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300502);
@@ -535,7 +535,7 @@ DECLARE_SCRIPT(M05_Activate_Objective_504, "")
 
 			// Havoc, this is Patch.  I'm at the Cathedral. Nod's gathering for major bloodletting. Get up here.\n
 			const char *conv_name = ("M05_CON005");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300504);
@@ -593,7 +593,7 @@ DECLARE_SCRIPT(M05_Activate_Objective_507, "")
 
 			// Attention GDI forces, this is Resistance Radio. Nod is assaulting the Town Square, on the south side of village. Requesting assistance.\n
 			const char *conv_name = ("M05_CON006");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300507);
@@ -656,7 +656,7 @@ DECLARE_SCRIPT(M05_Activate_Objective_508, "")
 
 			// This is Nod supply helo Delta-12, possible rooftop sighting of terrorists in quadrant 4.  Are those rocket launchers? Evasive- <explosion and static>\n
 			const char *conv_name = ("M05_CON007");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300501);
@@ -735,7 +735,7 @@ DECLARE_SCRIPT(M05_Activate_Objective_509, "")
 
 			// GDI forces, this is Resistance Radio. Communications indicate an escapee from the Chateau is in our custody on the northern side of the village. He has valuable information, make contact if needed.\n
 			const char *conv_name = ("M05_CON038");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300509);
@@ -797,7 +797,7 @@ DECLARE_SCRIPT(M05_Activate_Objective_510, "")
 
 			// How's this work? Okay... Attention, this is Resistance Radio. Rumours are true, our leader Babushka is kidnapped. Is anybody around to help? Hello? Is this on?
 			const char *conv_name = ("M05_CON008");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(Commands->Get_A_Star(Vector3(0.0f,0.0f,0.0f)), conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300510);
@@ -874,7 +874,7 @@ DECLARE_SCRIPT(M05_DEAD6_Engineer, "") // first hotwire
 				{
 					// Work your way to the Cathedral and secure comm link to Locke.\n
 					const char *conv_name = ("M05_CON009");
-					int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+					int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 					Commands->Join_Conversation(obj, conv_id, false, true, true);
 					Commands->Join_Conversation(Commands->Get_A_Star(Vector3(0.0f,0.0f,0.0f)), conv_id, false, true, true);
 					Commands->Start_Conversation (conv_id, 300551);
@@ -1107,7 +1107,7 @@ DECLARE_SCRIPT(M05_DEAD6_Rocket_Soldier, "") // first gunner
 				{
 					// I'm going to take this town if I have to vaporize every Nod reject in existence. I assume you're assisting?\n
 					const char *conv_name = ("M05_CON010");
-					int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+					int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 					Commands->Join_Conversation(obj, conv_id, false, true, true);
 					Commands->Join_Conversation(STAR, conv_id, false, true, true);
 					Commands->Start_Conversation (conv_id, 300001);
@@ -1121,7 +1121,7 @@ DECLARE_SCRIPT(M05_DEAD6_Rocket_Soldier, "") // first gunner
 				{
 					// We won't make it out of here if we don't clear the area.\n
 					const char *conv_name = ("M05_CON011");
-					int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+					int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 					Commands->Join_Conversation(obj, conv_id, false, true, true);
 					Commands->Start_Conversation (conv_id, 300002);
 					Commands->Monitor_Conversation (obj, conv_id);
@@ -1356,7 +1356,7 @@ DECLARE_SCRIPT(M05_DEAD6_MiniGunner, "") // deadeye
 				{
 					// Nod is about to roll over this place, time to move out Deadeye.\n
 					const char *conv_name = ("M05_CON013");
-					int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+					int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 					Commands->Join_Conversation(STAR, conv_id, false, true, true);
 					Commands->Join_Conversation(obj, conv_id, false, true, true);
 					Commands->Start_Conversation (conv_id, 300004);
@@ -1446,7 +1446,7 @@ DECLARE_SCRIPT(M05_DEAD6_Grenadier, "")
 				{
 					// Havoc! Black Hand squads are arriving from the Chateau! Support fire needed!\n
 					const char *conv_name = ("M05_CON014");
-					int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+					int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 					Commands->Join_Conversation(obj, conv_id, false, true, true);
 					Commands->Join_Conversation(STAR, conv_id, false, true, true);
 					Commands->Start_Conversation (conv_id, 300004);
@@ -1587,16 +1587,16 @@ DECLARE_SCRIPT(M05_Mendoza, "")
 	{
 		ActionParamsStruct params;
 
-		if(health > (.5 * Commands->Get_Max_Health(obj)))
+		if(health > (.5f * Commands->Get_Max_Health(obj)))
 		{
 			float damage = health - Commands->Get_Health(obj);
 			damage *= 0.25f;
 			health -= damage;
 			Commands->Set_Health(obj, health);
 		}
-		if((Commands->Get_Health(obj)) < (Commands->Get_Max_Health(obj) * .23))
+		if((Commands->Get_Health(obj)) < (Commands->Get_Max_Health(obj) * .23f))
 		{
-			Commands->Set_Health( obj, (Commands->Get_Max_Health(obj) * .23) );
+			Commands->Set_Health( obj, (Commands->Get_Max_Health(obj) * .23f) );
 
 			if(!exiting)
 			{
@@ -2105,7 +2105,7 @@ DECLARE_SCRIPT(M05_Cache_Escort, "")
 				{
 					// Thank you GDI, these weapons will help.\n
 					const char *conv_name = ("M05_CON020");
-					int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+					int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 					Commands->Join_Conversation(obj, conv_id, false, true, true);
 					Commands->Join_Conversation(STAR, conv_id, false, true, true);
 					Commands->Start_Conversation (conv_id, 1);
@@ -2116,7 +2116,7 @@ DECLARE_SCRIPT(M05_Cache_Escort, "")
 			{
 				// Thank you GDI, these weapons will help.\n
 				const char *conv_name = ("M05_CON020");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Join_Conversation(STAR, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, 1);
@@ -2343,7 +2343,7 @@ DECLARE_SCRIPT(M05_Escapee_Brother, "")
 				{
 					// Got one back from the dead huh? What you got for me?\n
 					const char *conv_name = ("M05_CON022");
-					int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+					int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 					Commands->Join_Conversation(STAR, conv_id, false, true, true);
 					Commands->Join_Conversation(obj, conv_id, false, true, true);
 					Commands->Start_Conversation (conv_id, 300509);
@@ -2376,8 +2376,8 @@ DECLARE_SCRIPT(M05_Escapee_Brother, "")
 
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * 1.5;
-			float b = sin(DEG_TO_RADF(facing)) * 1.5;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * 1.5f;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * 1.5f;
 			Vector3 powerup_loc = pos + Vector3(a, b, 0.5f);
 			Commands->Create_Object("POW_PersonalIonCannon_Player", powerup_loc);
 
@@ -3531,9 +3531,9 @@ DECLARE_SCRIPT(M05_Mendoza3, "")
 			health -= damage;
 			Commands->Set_Health(obj, health);
 		}
-		if((Commands->Get_Health(obj)) < (Commands->Get_Max_Health(obj) * .13))
+		if((Commands->Get_Health(obj)) < (Commands->Get_Max_Health(obj) * .13f))
 		{
-			Commands->Set_Health( obj, (Commands->Get_Max_Health(obj) * .13) );
+			Commands->Set_Health( obj, (Commands->Get_Max_Health(obj) * .13f) );
 
 			if(!exiting)
 			{
@@ -3802,16 +3802,16 @@ DECLARE_SCRIPT(M05_Mendoza4, "")
 	{
 		ActionParamsStruct params;
 
-		if(health > (.2 * Commands->Get_Max_Health(obj)))
+		if(health > (.2f * Commands->Get_Max_Health(obj)))
 		{
 			float damage = health - Commands->Get_Health(obj);
 			damage *= 0.5f;
 			health -= damage;
 			Commands->Set_Health(obj, health);
 		}
-		if((Commands->Get_Health(obj)) < (Commands->Get_Max_Health(obj) * .13))
+		if((Commands->Get_Health(obj)) < (Commands->Get_Max_Health(obj) * .13f))
 		{
-			Commands->Set_Health( obj, (Commands->Get_Max_Health(obj) * .13) );
+			Commands->Set_Health( obj, (Commands->Get_Max_Health(obj) * .13f) );
 
 			if(!exiting)
 			{
@@ -3870,7 +3870,7 @@ DECLARE_SCRIPT(M05_Civ_Warn, "")
 		{
 			// Don't shoot, I am a friend! There are enemies shooting from the balcony. Can you help?\n
 			const char *conv_name = ("M05_CON002");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(obj, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 1000971);
@@ -5735,8 +5735,8 @@ DECLARE_SCRIPT(M05_Execution_Civilian, "")
 
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * 1.5;
-			float b = sin(DEG_TO_RADF(facing)) * 1.5;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * 1.5f;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * 1.5f;
 			Vector3 powerup_loc = pos + Vector3(a, b, 0.5f);
 			Commands->Create_Object("tw_POW00_Health", powerup_loc);
 
@@ -5897,9 +5897,9 @@ DECLARE_SCRIPT(M05_Entrapment_Mendoza, "")
 			health -= damage;
 			Commands->Set_Health(obj, health);
 		}
-		if((Commands->Get_Health(obj)) < (Commands->Get_Max_Health(obj) * .23))
+		if((Commands->Get_Health(obj)) < (Commands->Get_Max_Health(obj) * .23f))
 		{
-			Commands->Set_Health( obj, (Commands->Get_Max_Health(obj) * .23) );
+			Commands->Set_Health( obj, (Commands->Get_Max_Health(obj) * .23f) );
 
 			if(!exiting)
 			{
@@ -6561,7 +6561,7 @@ DECLARE_SCRIPT(M05_Activate_Roadblock_Tank, "")
 
 DECLARE_SCRIPT(M05_Building_Debris, "")
 {
-	int health;
+	int health; // TODO OmniBlade: This should really be changed to float to silence C4244, but will break savegames.
 	bool already_entered;
 
 	// Register variables to be Auto-Saved
@@ -6575,7 +6575,7 @@ DECLARE_SCRIPT(M05_Building_Debris, "")
 
 	void Created (GameObject * obj) override
 	{
-		health = Commands->Get_Max_Health(obj);
+		health = int(Commands->Get_Max_Health(obj));
 		//Commands->Set_Shield_Type ( obj, "ShieldKevlar" );
 	}
 
@@ -6583,11 +6583,11 @@ DECLARE_SCRIPT(M05_Building_Debris, "")
 	{
 		if(Commands->Get_Player_Type(damager) == SCRIPT_PLAYERTYPE_NOD)
 		{
-			Commands->Set_Health(obj, health);
+			Commands->Set_Health(obj, float(health));
 		}
 		else
 		{
-			health = Commands->Get_Health(obj);
+			health = int(Commands->Get_Health(obj));
 		}
 	}
 
@@ -6719,7 +6719,7 @@ DECLARE_SCRIPT(M05_Dead6_Help, "Message_ID=0:int")
 					{
 						// I need help!  Where's the second insertion team?! Backup needed at the Town Square!\n
 						const char *conv_name = ("M05_CON039");
-						int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+						int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 						Commands->Join_Conversation(NULL, conv_id, false, true, true);
 						Commands->Start_Conversation (conv_id, 100003);
 
@@ -6733,7 +6733,7 @@ DECLARE_SCRIPT(M05_Dead6_Help, "Message_ID=0:int")
 					{
 						// Hotwire here - I'm losing ground.  I need support or my own body bag!\n
 						const char *conv_name = ("M05_CON040");
-						int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+						int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 						Commands->Join_Conversation(NULL, conv_id, false, true, true);
 						Commands->Start_Conversation (conv_id, 100002);
 
@@ -6747,7 +6747,7 @@ DECLARE_SCRIPT(M05_Dead6_Help, "Message_ID=0:int")
 					{
 						// Havoc, this is Deadeye. Nod pressure increasing.  Need backup immediately!\n
 						const char *conv_name = ("M05_CON041");
-						int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+						int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 						Commands->Join_Conversation(NULL, conv_id, false, true, true);
 						Commands->Start_Conversation (conv_id, 100650);
 
@@ -6763,7 +6763,7 @@ DECLARE_SCRIPT(M05_Dead6_Help, "Message_ID=0:int")
 						mission_failed_text = 1;
 						// This is Hotwire, I can't hold this position! Requesting - oh great! <gunfire and static>\n
 						const char *conv_name = ("M05_CON043");
-						int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+						int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 						Commands->Join_Conversation(NULL, conv_id, false, true, true);
 						Commands->Start_Conversation (conv_id, 100002);
 						Commands->Monitor_Conversation (obj, conv_id);
@@ -6774,7 +6774,7 @@ DECLARE_SCRIPT(M05_Dead6_Help, "Message_ID=0:int")
 						mission_failed_text = 2;
 						// This is Gunner, too many Nod reinforcements... <gunfire> <static>\n
 						const char *conv_name = ("M05_CON042");
-						int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+						int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 						Commands->Join_Conversation(NULL, conv_id, false, true, true);
 						Commands->Start_Conversation (conv_id, 100003);
 						Commands->Monitor_Conversation (obj, conv_id);
@@ -6785,7 +6785,7 @@ DECLARE_SCRIPT(M05_Dead6_Help, "Message_ID=0:int")
 						mission_failed_text = 3;
 						// This is Deadeye, I'm being overrun - <exchanges of gunfire - static>\n
 						const char *conv_name = ("M05_CON044");
-						int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+						int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 						Commands->Join_Conversation(NULL, conv_id, false, true, true);
 						Commands->Start_Conversation (conv_id, 100652);
 						Commands->Monitor_Conversation (obj, conv_id);
@@ -6869,7 +6869,7 @@ DECLARE_SCRIPT(M05_Hotwire_Conversation, "")
 
 			// Havoc? Bust me outta here?\n
 			const char *conv_name = ("M05_CON036");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300503);
@@ -7535,8 +7535,8 @@ DECLARE_SCRIPT(M05_APC_Deploy_Soldier, "APC_ID=0:int")
 
 			Vector3 pos = Commands->Get_Position(apc);
 			float facing = Commands->Get_Facing(apc);
-			float a = cos(DEG_TO_RADF(facing)) * Commands->Get_Random(-8.0f, -10.0f);
-			float b = sin(DEG_TO_RADF(facing)) * Commands->Get_Random(-8.0f, -10.0f);
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * Commands->Get_Random(-8.0f, -10.0f);
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * Commands->Get_Random(-8.0f, -10.0f);
 			Vector3 soldier_loc = pos + Vector3(a, b, 0.0f);
 
 			ActionParamsStruct params;
@@ -7751,7 +7751,7 @@ DECLARE_SCRIPT(M05_Resistance_Poke_Conversation, "")
 	void Play_Conversation(GameObject * obj, int Min, int Max)
 	{
 		const char *conv_name = Resistance_Conv_Table[Index(Min, Max)];
-		int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+		int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 		Commands->Join_Conversation(obj, conv_id, false, true, true);
 		Commands->Start_Conversation (conv_id, 0);
 	}

--- a/Code/Scripts/Mission06.cpp
+++ b/Code/Scripts/Mission06.cpp
@@ -74,7 +74,7 @@ DECLARE_SCRIPT(M06_Objective_Controller, "") // 100018
 
 		// EVA - Give me a position on the scientists.\n
 		const char *conv_name = ("M06_CON059");
-		int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+		int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 		Commands->Join_Conversation(STAR, conv_id, false, true, true);
 		Commands->Join_Conversation(NULL, conv_id, false, true, true);
 		Commands->Start_Conversation (conv_id, 300601);
@@ -331,7 +331,7 @@ DECLARE_SCRIPT(M06_WarRoom_Computer, "")
 		{
 			// Data decryption complete. Internal computer systems indicate Dr. Ignatio Mobius is located beneath the Chateau. Access is gained through the dining hall.\n
 			const char *conv_name = ("M06_CON001");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, true, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300603);
@@ -581,7 +581,7 @@ DECLARE_SCRIPT(M06_Sydney_Mobius, "")
 			{
 				// Don't leave me here!\n
 				const char *conv_name = ("M06_CON005");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, 1);
 				Commands->Monitor_Conversation (obj, conv_id);
@@ -597,7 +597,7 @@ DECLARE_SCRIPT(M06_Sydney_Mobius, "")
 			{
 				// Wait for me!\n
 				const char *conv_name = ("M06_CON006");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, 1);
 				Commands->Monitor_Conversation (obj, conv_id);
@@ -808,8 +808,8 @@ DECLARE_SCRIPT(M06_Destruction_Stub, "")
 			distance *= 3;
 			Vector3 pos = Commands->Get_Position(STAR);
 			float facing = Commands->Get_Facing(STAR);
-			float a = cos(DEG_TO_RADF(facing)) * distance;
-			float b = sin(DEG_TO_RADF(facing)) * distance;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * distance;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * distance;
 			Vector3 explode_loc = pos + Vector3(a, b, 0.0f);
 
 			Commands->Create_Explosion("Chateau_Explosions_Twiddler", explode_loc, obj);
@@ -868,7 +868,7 @@ DECLARE_SCRIPT(M06_GDI_Prisoner, "")
 		{
 			// Thank for the release. I've got a Nod officer I've got to hunt down.\n
 			const char *conv_name = ("M06_CON008");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(obj, conv_id, false, true, true);
 			Commands->Join_Conversation(poker, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300607);
@@ -1022,8 +1022,8 @@ DECLARE_SCRIPT(M06_Civ_Prisoner, "")
 
 				Vector3 pos = Commands->Get_Position(obj);
 				float facing = Commands->Get_Facing(obj);
-				float a = cos(DEG_TO_RADF(facing)) * 1.5;
-				float b = sin(DEG_TO_RADF(facing)) * 1.5;
+				float a = WWMath::Cos(DEG_TO_RADF(facing)) * 1.5f;
+				float b = WWMath::Sin(DEG_TO_RADF(facing)) * 1.5f;
 				Vector3 powerup_loc = pos + Vector3(a, b, 0.5f);
 				Commands->Create_Object("POW_Health_100", powerup_loc);
 				Commands->Enable_HUD_Pokable_Indicator( obj, false );
@@ -2391,8 +2391,8 @@ DECLARE_SCRIPT(M06_Barracks_Patrol, "")
 		{
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * 1.5;
-			float b = sin(DEG_TO_RADF(facing)) * 1.5;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * 1.5f;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * 1.5f;
 			Vector3 powerup_loc = pos + Vector3(a, b, 0.5f);
 			Commands->Create_Object("M06_Barracks_Powerups_Twiddler", powerup_loc);
 
@@ -3470,7 +3470,7 @@ DECLARE_SCRIPT(M06_Resistance_Raider_DLS, "")
 			talking = true;
 			// Looks like you're bleedin'.\n
 			const char *conv_name = ("M06_CON045");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Join_Conversation(obj, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 100823);
@@ -3488,8 +3488,8 @@ DECLARE_SCRIPT(M06_Resistance_Raider_DLS, "")
 
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * 1.5;
-			float b = sin(DEG_TO_RADF(facing)) * 1.5;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * 1.5f;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * 1.5f;
 			Vector3 powerup_loc = pos + Vector3(a, b, 0.5f);
 			Commands->Create_Object("POW_GrenadeLauncher_Player", powerup_loc);
 
@@ -3545,8 +3545,8 @@ DECLARE_SCRIPT(M06_Assistance_Farmer_DLS, "")
 		{
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * 1.5;
-			float b = sin(DEG_TO_RADF(facing)) * 1.5;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * 1.5f;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * 1.5f;
 			Vector3 powerup_loc = pos + Vector3(a, b, 0.5f);
 			Commands->Create_Object("POW_GrenadeLauncher_Player", powerup_loc);
 
@@ -3585,8 +3585,8 @@ DECLARE_SCRIPT(M06_Assistance_Farmer_DLS, "")
 
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * 1.5;
-			float b = sin(DEG_TO_RADF(facing)) * 1.5;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * 1.5f;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * 1.5f;
 			Vector3 powerup_loc = pos + Vector3(a, b, 0.5f);
 			Commands->Create_Object("tw_POW00_Health", powerup_loc);
 
@@ -5049,7 +5049,7 @@ DECLARE_SCRIPT(M06_Drop_Thunder_Squad, "")
 
 			// This is Nod Helo Delta 14.  We are hot dropping a squad of Black Hand at your doorstep, be advised they are on the ground only long enough to re-equip, skip the standard check in.  Raveshaw's orders.\n
 			const char *conv_name = ("M06_CON057");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, true, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300603);
@@ -5646,7 +5646,7 @@ DECLARE_SCRIPT(M06_Enable_Alarm_Objective, "")
 
 			// Warning: Nod Security Measures Detected.
 			const char *conv_name = ("M06_CON060");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300609);
 			Commands->Monitor_Conversation (obj, conv_id);

--- a/Code/Scripts/Mission07.cpp
+++ b/Code/Scripts/Mission07.cpp
@@ -376,7 +376,7 @@ DECLARE_SCRIPT(M07_Havoc_DLS, "")
 		{
 			// You've got to be kidding.\n
 			const char *conv_name = ("M07_CON015");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300707);
 			Commands->Monitor_Conversation (obj, conv_id);
@@ -1392,7 +1392,7 @@ DECLARE_SCRIPT(M07_Cathedral_Controller, "")  // 100663
 		{
 			// Impact: 2 Minutes.\n
 			const char *conv_name = ("M07_CON003");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 10);
 
@@ -1406,7 +1406,7 @@ DECLARE_SCRIPT(M07_Cathedral_Controller, "")  // 100663
 		{
 			// Impact: 1 Minute.\n
 			const char *conv_name = ("M07_CON004");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 10);
 
@@ -1416,7 +1416,7 @@ DECLARE_SCRIPT(M07_Cathedral_Controller, "")  // 100663
 		{
 			// Impact: 30 seconds.\n
 			const char *conv_name = ("M07_CON005");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 10);
 
@@ -1426,7 +1426,7 @@ DECLARE_SCRIPT(M07_Cathedral_Controller, "")  // 100663
 		{
 			// Impact: 20 seconds.\n
 			const char *conv_name = ("M07_CON006");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 10);
 
@@ -1436,7 +1436,7 @@ DECLARE_SCRIPT(M07_Cathedral_Controller, "")  // 100663
 		{
 			// Impact: 10 seconds.\n
 			const char *conv_name = ("M07_CON007");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 10);
 
@@ -1446,7 +1446,7 @@ DECLARE_SCRIPT(M07_Cathedral_Controller, "")  // 100663
 		{
 			// Impact: 5 seconds.\n
 			const char *conv_name = ("M07_CON008");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 10);
 
@@ -1459,7 +1459,7 @@ DECLARE_SCRIPT(M07_Cathedral_Controller, "")  // 100663
 
 			// 4 seconds.\n
 			const char *conv_name = ("M07_CON009");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 10);
 
@@ -1469,7 +1469,7 @@ DECLARE_SCRIPT(M07_Cathedral_Controller, "")  // 100663
 		{
 			// 3 seconds.\n
 			const char *conv_name = ("M07_CON010");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 10);
 
@@ -1479,7 +1479,7 @@ DECLARE_SCRIPT(M07_Cathedral_Controller, "")  // 100663
 		{
 			// 2 seconds.\n
 			const char *conv_name = ("M07_CON011");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 10);
 
@@ -1491,7 +1491,7 @@ DECLARE_SCRIPT(M07_Cathedral_Controller, "")  // 100663
 		{
 			// 1 seconds.\n
 			const char *conv_name = ("M07_CON012");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 10);
 
@@ -1586,7 +1586,7 @@ DECLARE_SCRIPT(M07_In_Nuke_Blast, "")
 
 			// Warning - Your are within the Nuclear Strike blast radius. Evacuate immediately.\n
 			const char *conv_name = ("M07_CON013");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 10);
 		}
@@ -1644,7 +1644,7 @@ DECLARE_SCRIPT(M07_Out_Nuke_Blast, "")
 
 			// Minimum safe distance achieved.\n
 			const char *conv_name = ("M07_CON014");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 10);
 
@@ -1904,7 +1904,7 @@ DECLARE_SCRIPT(M07_Activate_Hotwire, "")
 
 			// Keep those Nod forces off my back, Havoc.  I'll crack these SAM's in no time.\n
 			const char *conv_name = ("M07_CON016");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(HOTWIRE, conv_id, true, true, true);
 			Commands->Start_Conversation (conv_id, HOTWIRE_CAPTURE_SAMS);
 			Commands->Monitor_Conversation(obj, conv_id);
@@ -2207,7 +2207,7 @@ DECLARE_SCRIPT(M07_Activate_Objective_704, "")
 
 			// Attention GDI, this is Resistance Radio. Nod's aerial reinforcements are coordinated from mobile radar stations in the Town Square.  We need those radar dishes destroyed.\n
 			const char *conv_name = ("M07_CON018");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300704);
@@ -2257,7 +2257,7 @@ DECLARE_SCRIPT(M07_Activate_Objective_705, "")
 
 			// This is Resistance Radio, I have reports of captured resistance fighters west of your position.  Can anyone assist?\n
 			const char *conv_name = ("M07_CON019");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300705);
@@ -2303,7 +2303,7 @@ DECLARE_SCRIPT(M07_Activate_Objective_706, "")
 
 			// Havoc, we've spotted an SSM napalm stockpile to your west.\n
 			const char *conv_name = ("M07_CON020");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300706);
@@ -2349,7 +2349,7 @@ DECLARE_SCRIPT(M07_Activate_Objective_707, "")
 
 			// Those must be the SSMs. Time to get to work.\n
 			const char *conv_name = ("M07_CON021");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300707);
 			Commands->Monitor_Conversation (obj, conv_id);
@@ -2394,7 +2394,7 @@ DECLARE_SCRIPT(M07_Activate_Objective_708, "")
 
 			// \\Warning - Nod Obelisk detected.\n
 			const char *conv_name = ("M07_CON022");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300708);
@@ -2922,7 +2922,7 @@ DECLARE_SCRIPT(M07_Activate_Present, "")
 
 			// Havoc, got a present for ya.\n
 			const char *conv_name = ("M07_CON023");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300700);
@@ -3016,7 +3016,7 @@ DECLARE_SCRIPT(M07_Vehicle_Drop_Controller, "")
 			{
 				// Havoc!  Taking missile fire over the park.  Launcher is unseen.  Repeat, launcher is unseen.\n
 				const char *conv_name = ("M07_CON024");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(NULL, conv_id, false, true, true);
 				Commands->Join_Conversation(STAR, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, 300700);
@@ -3036,7 +3036,7 @@ DECLARE_SCRIPT(M07_Vehicle_Drop_Controller, "")
 				{
 					// Got you another ride, inbound now!\n
 					const char *conv_name = ("M07_CON025");
-					int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+					int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 					Commands->Join_Conversation(NULL, conv_id, false, true, true);
 					Commands->Start_Conversation (conv_id, 300700);
 
@@ -3051,7 +3051,7 @@ DECLARE_SCRIPT(M07_Vehicle_Drop_Controller, "")
 				{
 					// Complements of the local resistance.\n
 					const char *conv_name = ("M07_CON026");
-					int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+					int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 					Commands->Join_Conversation(NULL, conv_id, false, true, true);
 					Commands->Join_Conversation(STAR, conv_id, false, true, true);
 					Commands->Start_Conversation (conv_id, 300700);
@@ -3070,7 +3070,7 @@ DECLARE_SCRIPT(M07_Vehicle_Drop_Controller, "")
 			{
 				// Last one, Captain.  Recon show Nod's pulling back to the park.\n
 				const char *conv_name = ("M07_CON027");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(NULL, conv_id, false, true, true);
 				Commands->Join_Conversation(STAR, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, 300700);
@@ -3656,13 +3656,13 @@ DECLARE_SCRIPT(M07_Encounter_Unit, "Waypath_ID=0:int, Priority=0:int, Suicide=0:
 		}
 		else if(waypath_id == 1)
 		{
-			params.Set_Basic( this, priority, GO_STAR );
+			params.Set_Basic( this, float(priority), GO_STAR );
 			params.Set_Movement( STAR, RUN, 2.0f );
 			Commands->Action_Goto (  obj, params );
 		}
 		else
 		{
-			params.Set_Basic( this, priority, WAYPATH );
+			params.Set_Basic( this, float(priority), WAYPATH );
 			params.Set_Movement( Vector3(0,0,0), RUN, 1.5f );
 			params.WaypathID = waypath_id;
 			Commands->Action_Goto( obj, params );
@@ -4087,8 +4087,8 @@ DECLARE_SCRIPT(M07_Inn_APC, "")
 
 				Vector3 pos = Commands->Get_Position(obj);
 				float facing = Commands->Get_Facing(obj);
-				float a = cos(DEG_TO_RADF(facing)) * -4.0;
-				float b = sin(DEG_TO_RADF(facing)) * -4.0;
+				float a = WWMath::Cos(DEG_TO_RADF(facing)) * -4.0f;
+				float b = WWMath::Sin(DEG_TO_RADF(facing)) * -4.0f;
 
 				Vector3 soldier_loc1 = pos + Vector3(a, b + .5f, 0.5f);
 				GameObject * soldier1 = Commands->Create_Object("M07_Nod_APC", soldier_loc1);
@@ -4912,8 +4912,8 @@ DECLARE_SCRIPT(M07_Hostage, "")
 
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * 1.5;
-			float b = sin(DEG_TO_RADF(facing)) * 1.5;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * 1.5f;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * 1.5f;
 			Vector3 powerup_loc = pos + Vector3(a, b, 0.5f);
 			Commands->Create_Object("Ramjet_Weapon_Powerup", powerup_loc);
 
@@ -5034,8 +5034,8 @@ DECLARE_SCRIPT(M07_APC_Dec, "")
 
 				Vector3 pos = Commands->Get_Position(obj);
 				float facing = Commands->Get_Facing(obj);
-				float a = cos(DEG_TO_RADF(facing)) * -4.0;
-				float b = sin(DEG_TO_RADF(facing)) * -4.0;
+				float a = WWMath::Cos(DEG_TO_RADF(facing)) * -4.0f;
+				float b = WWMath::Sin(DEG_TO_RADF(facing)) * -4.0f;
 
 				Vector3 soldier_loc1 = pos + Vector3(a, b + .5f, 0.5f);
 				GameObject * soldier1 = Commands->Create_Object("M07_Nod_APC", soldier_loc1);
@@ -5811,7 +5811,7 @@ DECLARE_SCRIPT(M07_Inn_Evac, "")//104496
 			{
 				// This is Resistance Radio.  Nod SSM deployment confirmed.  All available personnel to the park.\n
 				const char *conv_name = ("M07_CON017");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(NULL, conv_id, false, true, true);
 				Commands->Join_Conversation(STAR, conv_id, false, true, true);
 				Commands->Join_Conversation(NULL, conv_id, false, true, true);
@@ -6162,7 +6162,7 @@ DECLARE_SCRIPT(M07_Alley_Vehicle, "Waypath_ID=0:int")
 		if(!active)
 		{
 			active = true;
-			Commands->Send_Custom_Event (obj, obj, M07_CUSTOM_ACTIVATE, 0.0f, 0.0f);
+			Commands->Send_Custom_Event (obj, obj, M07_CUSTOM_ACTIVATE, 0, 0.0f);
 		}
 		if(!attacking)
 		{
@@ -6185,7 +6185,7 @@ DECLARE_SCRIPT(M07_Alley_Vehicle, "Waypath_ID=0:int")
 		if(!active)
 		{
 			active = true;
-			Commands->Send_Custom_Event (obj, obj, M07_CUSTOM_ACTIVATE, 0.0f, 0.0f);
+			Commands->Send_Custom_Event (obj, obj, M07_CUSTOM_ACTIVATE, 0, 0.0f);
 		}
 
 		if(!attacking && (Commands->Get_Player_Type(damager) != SCRIPT_PLAYERTYPE_NOD))
@@ -6516,7 +6516,7 @@ DECLARE_SCRIPT(M07_Hotwire_Help, "")
 			{
 				// Hotwire here, I need help!  Now!  Anyone!?
 				const char *conv_name = ("M07_CON028");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(NULL, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, 100658);
 
@@ -6556,7 +6556,7 @@ DECLARE_SCRIPT(M07_Hotwire_Dead, "")
 			{
 				// This is Hotwire, I can't hold this position! Requesting - oh great! <gunfire and static>
 				const char *conv_name = ("M07_CON029");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(NULL, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, 100658);
 				Commands->Monitor_Conversation (obj, conv_id);

--- a/Code/Scripts/Mission09.cpp
+++ b/Code/Scripts/Mission09.cpp
@@ -1551,7 +1551,7 @@ DECLARE_SCRIPT (M09_Mutant_Damage_Mod_10, "")
 		{
 			current_health = Commands->Get_Health (obj);
 			float damage = ((last_health - current_health) + damage_tally);
-			float mod_damage = (damage * .10);
+			float mod_damage = (damage * .10f);
 			damage_tally += mod_damage;
 
 			Commands->Set_Health (obj, (last_health - mod_damage));
@@ -1585,7 +1585,7 @@ DECLARE_SCRIPT (M09_Mutant_Damage_Mod_50, "")
 		{
 			current_health = Commands->Get_Health (obj);
 			float damage = ((last_health - current_health) + damage_tally);
-			float mod_damage = (damage * .25);
+			float mod_damage = (damage * .25f);
 			damage_tally += mod_damage;
 
 			Commands->Set_Health (obj, (last_health - mod_damage));
@@ -1619,7 +1619,7 @@ DECLARE_SCRIPT (M09_Nod_Damage_Mod_10, "")
 		{
 			current_health = Commands->Get_Health (obj);
 			float damage = ((last_health - current_health) + damage_tally);
-			float mod_damage = (damage * .08);
+			float mod_damage = (damage * .08f);
 			damage_tally += mod_damage;
 
 			Commands->Set_Health (obj, (last_health - mod_damage));

--- a/Code/Scripts/Mission10.cpp
+++ b/Code/Scripts/Mission10.cpp
@@ -1462,8 +1462,8 @@ DECLARE_SCRIPT(M10_Apache, "Area:int")
 			{
 				Vector3 pos = Commands->Get_Position(STAR);
 				float facing = Commands->Get_Facing(STAR);
-				pos.X -= cos(DEG_TO_RADF(facing)) * 6.0f;
-				pos.Y -= sin(DEG_TO_RADF(facing)) * 6.0f;
+				pos.X -= WWMath::Cos(DEG_TO_RADF(facing)) * 6.0f;
+				pos.Y -= WWMath::Sin(DEG_TO_RADF(facing)) * 6.0f;
 
 				pos.Z = WWMath::Max(pos.Z + 12.0f, Commands->Get_Safe_Flight_Height(pos.X, pos.Y) + 6.0f);
 

--- a/Code/Scripts/MissionDemo.cpp
+++ b/Code/Scripts/MissionDemo.cpp
@@ -224,7 +224,7 @@ DECLARE_SCRIPT (MDD_Respawn_Controller, "")
 			}
 Commands->Debug_Message (">>>>>>>>>>>>>>>> UNIT COUNT = %i, UNIT MAX = %i.\n",area_unit_count[25],area_unit_max[25]);
 			int players_difficulty = Commands->Get_Difficulty_Level();
-			float timer_length = 25 - (10 * (players_difficulty));
+			float timer_length = float(25 - (10 * (players_difficulty)));
 			Commands->Start_Timer(obj, this, timer_length, 2);
 		}
 		//DEMO
@@ -1007,7 +1007,11 @@ DECLARE_SCRIPT (MDD_Nod_Soldier, "Area_Number:int,Area_Officer:int,Pre_Placed:in
 				// Time to move the chem-warrior. Pick a new location.
 
 				Vector3 newloc;
-				int rndnum = (Get_Int_Random(0.0f,1.0f) * 5);
+				// TODO OmniBlade: So I've silenced the C4244 warning here, but the logic looks screwed.
+				// Intention seems to have been to generate a random float and then round to int. As it stands
+				// it appears to have a 1/2 chance of hitting either case 0 or default.
+				//int rndnum = (Get_Int_Random(0.0f,1.0f) * 5);
+				int rndnum = (Get_Int_Random(0,1) * 5);
 				switch (rndnum)
 				{
 				case (0):
@@ -1538,7 +1542,7 @@ DECLARE_SCRIPT (MDD_Nod_Apache, "Area_ID:int")
 			{
 				ActionParamsStruct params;
 				params.Set_Basic(this, 90, 0);
-				params.Set_Movement(Vector3(0,0,0), 0.2 + (0.1 * DIFFICULTY), 5.0f);
+				params.Set_Movement(Vector3(0,0,0), 0.2f + (0.1f * DIFFICULTY), 5.0f);
 				params.WaypathID = waypath_id;
 				params.WaypathSplined = true;
 				params.Set_Attack(STAR, 200.0f, 0.0f, true);
@@ -1559,7 +1563,7 @@ DECLARE_SCRIPT (MDD_Nod_Apache, "Area_ID:int")
 
 			ActionParamsStruct params;
 			params.Set_Basic(this, 90, 0);
-			params.Set_Movement(myloc, 0.0, 5.0f);
+			params.Set_Movement(myloc, 0.0f, 5.0f);
 			//DEMO params.Set_Attack(STAR, 200.0f, 0.0f, true);
 			params.Set_Attack(target, 200.0f, 0.0f, true);
 			//DEMO

--- a/Code/Scripts/Test_Cinematic.cpp
+++ b/Code/Scripts/Test_Cinematic.cpp
@@ -39,6 +39,7 @@
 #include <string.h>
 #include "wwlib/wwstring.h"
 #include <limits>
+#include <stdlib.h>
 
 #define		LAST_VALID_TIMESTAMP		999000.0f
 
@@ -49,8 +50,8 @@ DECLARE_SCRIPT (M00_Cinematic_Attack_Command_DLS, "AttackDuration=1.0:float")
 	{
 		float facing = Commands->Get_Facing(Owner());
 		Vector3 target = Commands->Get_Position(Owner());
-		target.X += cos(DEG_TO_RADF(facing)) * 10.0f;
-		target.Y += sin(DEG_TO_RADF(facing)) * 10.0f;
+		target.X += WWMath::Cos(DEG_TO_RADF(facing)) * 10.0f;
+		target.Y += WWMath::Sin(DEG_TO_RADF(facing)) * 10.0f;
 		target.Z += 2.0f;
 
 		ActionParamsStruct params;
@@ -228,7 +229,7 @@ public:
 
 			if ( *line && *line != ';' ) {	// ignore comments
 				float	time;
-				time = atof( line );
+				time = strtof( line , NULL);
 
 				if ( time < 0 ) {	// handle frame numbers
 					time = -time / 30.f;
@@ -822,7 +823,7 @@ public:
 	void	Command_Sniper_Control( char * params )
 	{
 		int enabled = atoi( Get_First_Parameter( params ) );
-		float zoom = atof( Get_Next_Parameter() );
+		float zoom = strtof( Get_Next_Parameter() , NULL);
 
 		Commands->Cinematic_Sniper_Control( enabled != 0, zoom );
 	}
@@ -830,8 +831,8 @@ public:
 	void	Command_Shake_Camera( char * params )
 	{
 		int obj_slot = atoi( Get_First_Parameter( params ) );
-		float intensity = atof( Get_Next_Parameter() );
-		float duration = atof( Get_Next_Parameter() );
+		float intensity = strtof( Get_Next_Parameter() , NULL);
+		float duration = strtof( Get_Next_Parameter() , NULL);
 
 		if ( (obj_slot < 0) || ( obj_slot >= NUM_SLOTS ) ) {
 //			Commands->Debug_Message( "Bad Obj Slot Number %d\n", obj_slot );
@@ -874,25 +875,25 @@ public:
 	void	Command_Enable_Letterbox( char * params )
 	{
 		int onoff = atoi( Get_First_Parameter( params ) );
-		float time = atof( Get_Next_Parameter() );
+		float time = strtof( Get_Next_Parameter() , NULL);
 
 		Commands->Enable_Letterbox(!!onoff,time);
 	}
 
 	void Command_Set_Screen_Fade_Color( char * params )
 	{
-		float r = atof( Get_First_Parameter( params ) );
-		float g = atof( Get_Next_Parameter() );
-		float b = atof( Get_Next_Parameter() );
-		float time = atof( Get_Next_Parameter() );
+		float r = strtof( Get_First_Parameter( params ) , NULL);
+		float g = strtof( Get_Next_Parameter() , NULL);
+		float b = strtof( Get_Next_Parameter() , NULL);
+		float time = strtof( Get_Next_Parameter() , NULL);
 
 		Commands->Set_Screen_Fade_Color(r,g,b,time);
 	}
 
 	void Command_Set_Screen_Fade_Opacity( char * params )
 	{
-		float opacity = atof( Get_First_Parameter( params ) );
-		float time = atof( Get_Next_Parameter() );
+		float opacity = strtof( Get_First_Parameter( params ) , NULL);
+		float time = strtof( Get_Next_Parameter() , NULL);
 
 		Commands->Set_Screen_Fade_Opacity(opacity,time);
 	}

--- a/Code/Scripts/Test_DAK.cpp
+++ b/Code/Scripts/Test_DAK.cpp
@@ -147,8 +147,9 @@ DECLARE_SCRIPT(DAK_Electric_Death_DAK, "" )
 {
 	void Created ( GameObject *obj ) override
 	{
-		int time = Commands->Get_Random(1, 3);
-		Commands->Send_Custom_Event ( obj, obj, 0, 0, time );
+		// TODO Why is this casting like this to round rather than calling Get_Random_Int?
+		int time = int(Commands->Get_Random(1, 3));
+		Commands->Send_Custom_Event ( obj, obj, 0, 0, float(time) );
 	}
 
 	void Damaged (GameObject *obj, GameObject * /*damager*/, float /*amount*/ ) override

--- a/Code/Scripts/Test_DLS.cpp
+++ b/Code/Scripts/Test_DLS.cpp
@@ -664,8 +664,8 @@ DECLARE_SCRIPT(M06_Camera_Behavior, "Angle:float")
 	{
 		float facing = Commands->Get_Facing(Owner());
 		Vector3 target = Commands->Get_Position(Owner());
-		target.X += cos(DEG_TO_RADF(facing)) * 10.0f;
-		target.Y += sin(DEG_TO_RADF(facing)) * 10.0f;
+		target.X += WWMath::Cos(DEG_TO_RADF(facing)) * 10.0f;
+		target.Y += WWMath::Sin(DEG_TO_RADF(facing)) * 10.0f;
 		target.Z -= 0.9f;
 		float angle = Get_Float_Parameter(0);
 		angle = WWMath::Clamp(angle, 0.0f, 360.0f);
@@ -701,8 +701,8 @@ DECLARE_SCRIPT(M06_Camera_Behavior, "Angle:float")
 		float facing = Commands->Get_Facing(Owner());
 		angle = angle / 2;
 		Vector3 target = Commands->Get_Position(Owner());
-		target.X += cos(DEG_TO_RADF(facing)) * 10.0f;
-		target.Y += sin(DEG_TO_RADF(facing)) * 10.0f;
+		target.X += WWMath::Cos(DEG_TO_RADF(facing)) * 10.0f;
+		target.Y += WWMath::Sin(DEG_TO_RADF(facing)) * 10.0f;
 		target.Z -= 1.0f;
 		target -= Commands->Get_Position(Owner());
 		target.Rotate_Z(DEG_TO_RADF(angle));
@@ -1683,8 +1683,8 @@ DECLARE_SCRIPT(DLS_Math, "")
 	{
 		Vector3 pos = Commands->Get_Position(obj);
 		float facing = Commands->Get_Facing(obj);
-		float a = cos(DEG_TO_RADF(facing));
-		float b = sin(DEG_TO_RADF(facing));
+		float a = WWMath::Cos(DEG_TO_RADF(facing));
+		float b = WWMath::Sin(DEG_TO_RADF(facing));
 		Commands->Debug_Message("", a);
 		Commands->Debug_Message("", b);
 	}
@@ -2056,7 +2056,7 @@ DECLARE_SCRIPT (MX0_Area4_Controller_DLS, "")
 		}
 
 		const char *conv_name = Wrong_Way_Conv_Table[conv_num];
-		int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+		int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 		Commands->Join_Conversation(obj, conv_id, false, true, true);
 		Commands->Start_Conversation (conv_id, 10);
 		conv_num++;
@@ -2250,7 +2250,7 @@ DECLARE_SCRIPT (MX0_Area4_Controller_DLS, "")
 		{
 			// Havoc, you�ve got  to clear out those SAM sites!
 			const char *conv_name = ("MX0_A04_CON005");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 1);
 			// RocketTrooper - It�s down! The Obelisk is down!
@@ -2355,7 +2355,7 @@ DECLARE_SCRIPT (MX0_Area4_Controller_DLS, "")
 					Commands->Fade_Background_Music( "Renegade_A10_Outro.mp3", 1, 1);
 					// A10 - This is Eagle Claw 1 �Starting  attack run
 					const char *conv_name = ("MX0_A04_CON010");
-					int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+					int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 					Commands->Join_Conversation(NULL, conv_id, false, true, true);
 					Commands->Start_Conversation (conv_id, 1);
 					// A10 - I�m hit! I�m hit!
@@ -2379,7 +2379,7 @@ DECLARE_SCRIPT (MX0_Area4_Controller_DLS, "")
 		if(timer_id == A10_HIT)
 		{
 			const char *conv_name = ("MX0_A04_CON011");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 1);
 
@@ -2389,7 +2389,7 @@ DECLARE_SCRIPT (MX0_Area4_Controller_DLS, "")
 			// We have a lock on that base
 			// This is Eagle Base.  I�m not risking any more pilots.
 			const char *conv_name = ("MX0_A04_CON012");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 1);
 			// Ion Cannon strike
@@ -2533,7 +2533,7 @@ DECLARE_SCRIPT (MX0_Vehicle_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Attack_L
 			{
 				// Eagle Base� We found it!
 				const char *conv_name = ("MX0_A04_CON001");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, CON001);
 				Commands->Monitor_Conversation (obj, conv_id);
@@ -2543,7 +2543,7 @@ DECLARE_SCRIPT (MX0_Vehicle_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Attack_L
 			{
 				// We need you up here, Sir.
 				const char *conv_name = ("MX0_A04_CON013");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, 10);
 
@@ -2557,7 +2557,7 @@ DECLARE_SCRIPT (MX0_Vehicle_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Attack_L
 		{
 			// Confirmed.  Excellent work!
 			const char *conv_name = ("MX0_A04_CON002");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, CON002);
 		//	Commands->Monitor_Conversation (obj, conv_id);
@@ -2566,7 +2566,7 @@ DECLARE_SCRIPT (MX0_Vehicle_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Attack_L
 		{
 			// They have an Obelisk!
 			const char *conv_name = ("MX0_A04_CON003");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(obj, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, CON002);
 
@@ -2922,7 +2922,7 @@ DECLARE_SCRIPT (MX0_GDI_Soldier_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Atta
 
 				// Death #1 - Bullet death scream
 				const char *conv_name = ("MX0_A04_CON019");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, 10);
 			}
@@ -2931,7 +2931,7 @@ DECLARE_SCRIPT (MX0_GDI_Soldier_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Atta
 			{
 				// They have an Obelisk!
 				const char *conv_name = ("MX0_A04_CON003");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, MX0_ROCKETTROOPER_SEES_OBELISK);
 
@@ -2944,7 +2944,7 @@ DECLARE_SCRIPT (MX0_GDI_Soldier_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Atta
 			{
 				// The Obelisk is hot!  Look out!
 				const char *conv_name = ("MX0_A04_CON004");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, MX0_ROCKETTROOPER_HOT_OBELISK);
 			}
@@ -2953,7 +2953,7 @@ DECLARE_SCRIPT (MX0_GDI_Soldier_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Atta
 			{
 				// It�s down! The Obelisk is down!
 				const char *conv_name = ("MX0_A04_CON006");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, MX0_ROCKETTROOPER_OBELISK_DOWN);
 			}
@@ -2962,7 +2962,7 @@ DECLARE_SCRIPT (MX0_GDI_Soldier_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Atta
 			{
 				// Go! Go!  Knock out those SAMs!
 				const char *conv_name = ("MX0_A04_CON007");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, MX0_ROCKETTROOPER_TAKE_SAMS);
 			}
@@ -2971,7 +2971,7 @@ DECLARE_SCRIPT (MX0_GDI_Soldier_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Atta
 			{
 				// The SAMs are history!
 				const char *conv_name = ("MX0_A04_CON008");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, MX0_ROCKETTROOPER_SAMS_HISTORY);
 			}
@@ -2980,7 +2980,7 @@ DECLARE_SCRIPT (MX0_GDI_Soldier_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Atta
 			{
 				// There, on the wall!
 				const char *conv_name = ("MX0_A04_CON009");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, MX0_TROOPER_UP_ON_WALL);
 			}
@@ -2989,7 +2989,7 @@ DECLARE_SCRIPT (MX0_GDI_Soldier_DLS, "Attack_Loc0=0:int, Attack_Loc1=0:int, Atta
 			{
 				// We need your help - over here, Sir!
 				const char *conv_name = ("MX0_A04_CON014");
-				int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+				int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 				Commands->Join_Conversation(obj, conv_id, false, true, true);
 				Commands->Start_Conversation (conv_id, MX0_ROCKETTROOPER_CANT_TURN_BACK);
 			}

--- a/Code/Scripts/Test_DME.cpp
+++ b/Code/Scripts/Test_DME.cpp
@@ -604,8 +604,8 @@ DECLARE_SCRIPT (DME_Test_Worker_Wander, "Work_Area=3:int")
 						Vector3 pos = Commands->Get_Position(obj);				//specifies drop location and plays droping anim.
 						float obj_facing = Commands->Get_Facing(obj);
 						Commands->Set_Animation( obj, "H_A_J12C", false, NULL, 0.0f, -1.0f, false );
-						float a = cos(DEG_TO_RADF(obj_facing)) * 1.5;
-						float b = sin(DEG_TO_RADF(obj_facing)) * 1.5;
+						float a = WWMath::Cos(DEG_TO_RADF(obj_facing)) * 1.5f;
+						float b = WWMath::Sin(DEG_TO_RADF(obj_facing)) * 1.5f;
 						Vector3 powerup_loc = pos + Vector3(a, b, 0.5f);
 
 						switch (reward_type)									//random reward type.

--- a/Code/Scripts/Test_GTH.cpp
+++ b/Code/Scripts/Test_GTH.cpp
@@ -48,7 +48,7 @@ DECLARE_SCRIPT(GTH_Drop_Object_On_Death, "Drop_Object=:string,Drop_Height=0.25:f
 		const char * obj_name = Get_Parameter("Drop_Object");
 
 		bool doit = false;
-		float probability = Get_Int_Parameter("Probability");
+		float probability = float(Get_Int_Parameter("Probability")); // TODO Why is this float?
 
 		if (probability >= 100) {
 			doit = true;
@@ -110,7 +110,7 @@ DECLARE_SCRIPT(GTH_Drop_Object_On_Death_Zone, "Custom_Message=20000:int,Drop_Obj
 		const char * obj_name = Get_Parameter("Drop_Object");
 
 		bool doit = false;
-		float probability = Get_Int_Parameter("Probability");
+		float probability = float(Get_Int_Parameter("Probability")); // TODO Why is this float?
 
 		if (probability >= 100) {
 			doit = true;
@@ -218,7 +218,7 @@ protected:
 		}
 
 		// Check probability, if the check fails, just return
-		float probability = Get_Int_Parameter("Probability");
+		float probability = float(Get_Int_Parameter("Probability")); // TODO Why is this float?
 		if (probability < 100) {
 			int random = Commands->Get_Random_Int(0,100);
 			if (random > probability) {
@@ -711,10 +711,10 @@ DECLARE_SCRIPT (GTH_User_Controllable_Base_Defense, "MinAttackDistance=0:int, Ma
 			{
 				ActionParamsStruct params;
 				params.Set_Basic(this, 100, 2);
-				params.Set_Attack(enemy, Get_Int_Parameter("MaxAttackDistance"), 0.0f, true);
+				params.Set_Attack(enemy, float(Get_Int_Parameter("MaxAttackDistance")), 0.0f, true);
 				params.AttackCheckBlocked = false;
 				Commands->Action_Attack(obj, params);
-				Commands->Start_Timer (obj, this, Get_Int_Parameter( "AttackTimer"), 2);
+				Commands->Start_Timer (obj, this, float(Get_Int_Parameter( "AttackTimer")), 2);
 			}
 		}
 	}
@@ -781,8 +781,8 @@ DECLARE_SCRIPT(GTH_Credit_Trickle, "Credits=1:int,Delay=2.0:float")
 	{
 		if (timer_id == TRICKLE_TIMER)
 		{
-			Commands->Give_Money( obj, Get_Int_Parameter("Credits"), true );
-			Commands->Start_Timer (obj, this, Get_Int_Parameter("Delay"), TRICKLE_TIMER);
+			Commands->Give_Money( obj, float(Get_Int_Parameter("Credits")), true );
+			Commands->Start_Timer (obj, this, float(Get_Int_Parameter("Delay")), TRICKLE_TIMER);
 		}
 	}
 };
@@ -1061,7 +1061,7 @@ DECLARE_SCRIPT(GTH_CTF_Object2, "Update_Delay=0.05:float,Enemy_Player_Type=0:int
 
 					captured_by_id = 0;
 					// start the flag respawn timer.
-					capture_timer = (((float)Commands->Get_Sync_Time()) / 1000.0);
+					capture_timer = (((float)Commands->Get_Sync_Time()) / 1000.0f);
 					Commands->Attach_To_Object_Bone(obj,NULL,NULL);
 					GTH_DEBUG_INT(0,"Capturer killed!\n");
 

--- a/Code/Scripts/Test_RAD.cpp
+++ b/Code/Scripts/Test_RAD.cpp
@@ -965,7 +965,7 @@ DECLARE_SCRIPT (MX0_A02_Controller, "")
 					{
 						pre_ambient_count = 1;
 					}
-					Commands->Start_Timer (obj, this, Get_Int_Random (2, 4), MX0_A02_TIMER_PRE_AMBIENT);
+					Commands->Start_Timer (obj, this, float(Get_Int_Random (2, 4)), MX0_A02_TIMER_PRE_AMBIENT);
 				}
 				break;
 			}
@@ -2425,7 +2425,7 @@ DECLARE_SCRIPT (MX0_A02_ACTOR, "ActorID=0:int")
 							params.Set_Movement(Commands->Get_Position (moveloc), RUN, 0.5f, false);
 							Commands->Action_Goto (obj, params);
 						}
-						Commands->Start_Timer (obj, this, (MX0_A02_TIMERLENGTH_BASIC_MOVE + Get_Int_Random(0, MX0_A02_TIMERLENGTH_BASIC_MOVE)), MX0_A02_TIMER_BASIC_MOVE_02);
+						Commands->Start_Timer (obj, this, float(MX0_A02_TIMERLENGTH_BASIC_MOVE + Get_Int_Random(0, MX0_A02_TIMERLENGTH_BASIC_MOVE)), MX0_A02_TIMER_BASIC_MOVE_02);
 					}
 					break;
 				}
@@ -2488,7 +2488,7 @@ DECLARE_SCRIPT (MX0_A02_ACTOR, "ActorID=0:int")
 							params.Set_Movement(Commands->Get_Position (moveloc), RUN, 0.5f, false);
 							Commands->Action_Goto (obj, params);
 						}
-						Commands->Start_Timer (obj, this, (MX0_A02_TIMERLENGTH_BASIC_MOVE + Get_Int_Random(0, MX0_A02_TIMERLENGTH_BASIC_MOVE)), MX0_A02_TIMER_BASIC_MOVE_01);
+						Commands->Start_Timer (obj, this, float(MX0_A02_TIMERLENGTH_BASIC_MOVE + Get_Int_Random(0, MX0_A02_TIMERLENGTH_BASIC_MOVE)), MX0_A02_TIMER_BASIC_MOVE_01);
 					}
 					break;
 				}

--- a/Code/Scripts/Test_RMV.cpp
+++ b/Code/Scripts/Test_RMV.cpp
@@ -63,7 +63,7 @@ DECLARE_SCRIPT(M00_C130_Dropoff_RMV, "ObjToCreate=:string")
 		int drop_frame;
 		drop_frame = 460;
 		float drop_time;
-		drop_time= ( float )drop_frame / 30.0;
+		drop_time= ( float )drop_frame / 30.0f;
 		Commands->Start_Timer( obj, this, drop_time, M00_TIMER_DROP_OBJECT_RMV );
 	}
 
@@ -247,8 +247,8 @@ DECLARE_SCRIPT(RMV_Camera_Behavior, "Angle:float, Alarm_ID=0:int, Is_Gun=0:int, 
 	{
 		float facing = Commands->Get_Facing(Owner());
 		Vector3 target = Commands->Get_Position(Owner());
-		target.X += cos(DEG_TO_RADF(facing)) * 10.0f;
-		target.Y += sin(DEG_TO_RADF(facing)) * 10.0f;
+		target.X += WWMath::Cos(DEG_TO_RADF(facing)) * 10.0f;
+		target.Y += WWMath::Sin(DEG_TO_RADF(facing)) * 10.0f;
 		target.Z -= 0.9f;
 		float angle = Get_Float_Parameter(0);
 		angle = WWMath::Clamp(angle, 0.0f, 360.0f);
@@ -284,8 +284,8 @@ DECLARE_SCRIPT(RMV_Camera_Behavior, "Angle:float, Alarm_ID=0:int, Is_Gun=0:int, 
 		float facing = Commands->Get_Facing(Owner());
 		angle = angle / 2;
 		Vector3 target = Commands->Get_Position(Owner());
-		target.X += cos(DEG_TO_RADF(facing)) * 10.0f;
-		target.Y += sin(DEG_TO_RADF(facing)) * 10.0f;
+		target.X += WWMath::Cos(DEG_TO_RADF(facing)) * 10.0f;
+		target.Y += WWMath::Sin(DEG_TO_RADF(facing)) * 10.0f;
 		target.Z -= 1.0f;
 		target -= Commands->Get_Position(Owner());
 		target.Rotate_Z(DEG_TO_RADF(angle));

--- a/Code/Scripts/Toolkit.cpp
+++ b/Code/Scripts/Toolkit.cpp
@@ -674,7 +674,7 @@ DECLARE_SCRIPT(M00_ChainRxn_Barrel_JDG, "Controller_ID :int")
 				8,//8
 			};
 
-			Commands->Set_Animation ( obj, barrels_animations[number], false, NULL, 0, barrels_endframe[number], false );
+			Commands->Set_Animation ( obj, barrels_animations[number], false, NULL, 0, float(barrels_endframe[number]), false );
 			Commands->Set_Health ( obj, 0.25f );
 
 			GameObject * controller = Commands->Find_Object ( controller_id );
@@ -2042,10 +2042,10 @@ DECLARE_SCRIPT (M00_Base_Defense, "MinAttackDistance=0:int, MaxAttackDistance=30
 		{
 			ActionParamsStruct params;
 			params.Set_Basic(this, 100, 2);
-			params.Set_Attack(enemy, Get_Int_Parameter("MaxAttackDistance"), 0.0f, true);
+			params.Set_Attack(enemy, float(Get_Int_Parameter("MaxAttackDistance")), 0.0f, true);
 			params.AttackCheckBlocked = false;
 			Commands->Action_Attack(obj, params);
-			Commands->Start_Timer (obj, this, Get_Int_Parameter( "AttackTimer"), 2);
+			Commands->Start_Timer (obj, this, float(Get_Int_Parameter( "AttackTimer")), 2);
 		}
 	}
 

--- a/Code/Scripts/Toolkit_Actions.cpp
+++ b/Code/Scripts/Toolkit_Actions.cpp
@@ -100,7 +100,7 @@ DECLARE_SCRIPT(M00_Action, "Start_Now=0:int, Receive_Type=14:int, Receive_Param_
 		current_attack_location = Get_Vector3_Parameter("_Attack_Location");
 		empty_vector = Vector3(0.0f,0.0f,0.0f);
 
-		params.Set_Basic(this, Get_Int_Parameter("Action_Priority"), Get_Int_Parameter("Action_ID"));
+		params.Set_Basic(this, float(Get_Int_Parameter("Action_Priority")), Get_Int_Parameter("Action_ID"));
 		params.Set_Movement(Get_Vector3_Parameter("_Move_Destination"), Get_Float_Parameter("_Move_Speed"), Get_Float_Parameter("_Move_Arrive_Distance"));
 		params.Set_Attack(Get_Vector3_Parameter("_Attack_Location"), Get_Float_Parameter("_Attack_Range"), Get_Float_Parameter("_Attack_Deviation"), primary_weapon);
 
@@ -185,7 +185,7 @@ DECLARE_SCRIPT(M00_Action, "Start_Now=0:int, Receive_Type=14:int, Receive_Param_
 				attack_target = Commands->Find_Object(Get_Int_Parameter("_Attack_Target_ID"));
 
 				ActionParamsStruct params;
-				params.Set_Basic(this, Get_Int_Parameter("Action_Priority"), Get_Int_Parameter("Action_ID"));
+				params.Set_Basic(this, float(Get_Int_Parameter("Action_Priority")), Get_Int_Parameter("Action_ID"));
 				params.Set_Movement(Get_Vector3_Parameter("_Move_Destination"), Get_Float_Parameter("_Move_Speed"), Get_Float_Parameter("_Move_Arrive_Distance"));
 				params.Set_Attack(Get_Vector3_Parameter("_Attack_Location"), Get_Float_Parameter("_Attack_Range"), Get_Float_Parameter("_Attack_Deviation"), primary_weapon);
 
@@ -256,7 +256,7 @@ DECLARE_SCRIPT(M00_Action, "Start_Now=0:int, Receive_Type=14:int, Receive_Param_
 		{
 			SCRIPT_DEBUG_MESSAGE(("M00_Action DEACTIVATED.\n"));
 			script_active = false;
-			Commands->Action_Reset(obj, Get_Int_Parameter("Action_Priority")+1);
+			Commands->Action_Reset(obj, float(Get_Int_Parameter("Action_Priority")+1));
 		}
 	}
 }

--- a/Code/Scripts/Toolkit_Animations.cpp
+++ b/Code/Scripts/Toolkit_Animations.cpp
@@ -59,7 +59,7 @@ Function - M00_Controller_Animation_RMV
 void M00_Controller_Animation_RMV (GameObject * obj, GameObjObserverClass * script, const char * animation_name, bool loop, int priority, int action_id, int drop_frame, const char * drop_object, const char * drop_bone)
 {
 	ActionParamsStruct params;
-	params.Set_Basic(script, priority, action_id);
+	params.Set_Basic(script, float(priority), action_id);
 	params.Set_Animation(animation_name, loop);
 	Commands->Action_Play_Animation(obj, params);
 	if (drop_frame != 0)
@@ -68,7 +68,7 @@ void M00_Controller_Animation_RMV (GameObject * obj, GameObjObserverClass * scri
 		{
 			if (drop_bone != NULL)
 			{
-				Commands->Send_Custom_Event(obj, obj, M00_CUSTOM_ANIMATION_DROP_OBJECT, 0, drop_frame/30);
+				Commands->Send_Custom_Event(obj, obj, M00_CUSTOM_ANIMATION_DROP_OBJECT, 0, float(drop_frame/30));
 			}
 		}
 	}
@@ -114,7 +114,7 @@ DECLARE_SCRIPT(M00_Animation_Play_RMV, "Start_Now=0:int, Receive_Type:int, Recei
 			}
 			if (param == Get_Int_Parameter("Receive_Param_Off"))
 			{
-				Commands->Action_Reset(obj, (priority + 1));
+				Commands->Action_Reset(obj, float(priority + 1));
 				SCRIPT_DEBUG_MESSAGE(("M00_Animation_Play_RMV DEACTIVATED.\n"));
 			}
 		}
@@ -182,7 +182,7 @@ DECLARE_SCRIPT(M00_Animation_Play_Drop_Object_RMV, "Start_Now=0:int, Receive_Typ
 			}
 			if (param == Get_Int_Parameter("Receive_Param_Off"))
 			{
-				Commands->Action_Reset(obj, (priority + 1));
+				Commands->Action_Reset(obj, float(priority + 1));
 				SCRIPT_DEBUG_MESSAGE(("M00_Animation_Play_Drop_Object_RMV DEACTIVATED.\n"));
 			}
 		}
@@ -253,7 +253,7 @@ DECLARE_SCRIPT(M00_Animation_Play_Drop_Object_Attach_Script_RMV, "Start_Now=0:in
 			if (param == Get_Int_Parameter("Receive_Param_Off"))
 			{
 				SCRIPT_DEBUG_MESSAGE(("M00_Animation_Play_Drop_Object_Attach_Script_RMV DEACTIVATED.\n"));
-				Commands->Action_Reset(obj, (priority + 1));
+				Commands->Action_Reset(obj, float(priority + 1));
 			}
 		}
 		if ((type == M00_CUSTOM_ANIMATION_DROP_OBJECT) && (param == 0))

--- a/Code/Scripts/Toolkit_Broadcaster.cpp
+++ b/Code/Scripts/Toolkit_Broadcaster.cpp
@@ -101,7 +101,7 @@ DECLARE_SCRIPT (M00_Broadcaster_Register_RAD, "Terminal_ID:int, Send_Attempts=3:
 				}
 				else
 				{
-					Commands->Start_Timer (obj, this, send_delay, 0);
+					Commands->Start_Timer (obj, this, float(send_delay), 0);
 				}
 			}
 		}
@@ -112,7 +112,7 @@ DECLARE_SCRIPT (M00_Broadcaster_Register_RAD, "Terminal_ID:int, Send_Attempts=3:
 		if (type == M00_CUSTOM_BROADCASTER_REGISTRY_ERROR)
 		{
 			SCRIPT_DEBUG_MESSAGE(("M00_Broadcaster_Registry_RAD received custom type M00_CUSTOM_BROADCASTER_REGISTRY_ERROR, param %d.\n", param));
-			Commands->Start_Timer (obj, this, send_delay, 0);
+			Commands->Start_Timer (obj, this, float(send_delay), 0);
 		}
 		else
 		{
@@ -370,7 +370,7 @@ DECLARE_SCRIPT (M00_Broadcaster_Terminal_RAD, "Random_Percentage=100.0:float, Ra
 
 								for (object_count = 0;object_count < M00_BROADCASTER_TERMINAL_SIZE_RAD; object_count++)
 								{
-									random_value = Commands->Get_Random (0.0f, 100.0f);
+									random_value = Commands->Get_Random_Int (0, 100);
 									if (random_value <= Get_Float_Parameter ("Random_Percentage"))
 									{
 										if (object_random_record [object_count])
@@ -402,7 +402,7 @@ DECLARE_SCRIPT (M00_Broadcaster_Terminal_RAD, "Random_Percentage=100.0:float, Ra
 										target_obj = Commands->Find_Object (object_specific_record [object_count]);
 										if (target_obj)
 										{
-											random_value = int(Commands->Get_Random (float(parameter_low), float(parameter_high)));
+											random_value = Commands->Get_Random_Int (parameter_low, parameter_high);
 											SCRIPT_DEBUG_MESSAGE(("M00_Broadcaster_Terminal_RAD is sending custom type %d, param %d.\n", type, random_value));
 											Commands->Send_Custom_Event (obj, target_obj, type, random_value, 0.0f);
 										}
@@ -424,13 +424,13 @@ DECLARE_SCRIPT (M00_Broadcaster_Terminal_RAD, "Random_Percentage=100.0:float, Ra
 								{
 									if (object_random_record [object_count])
 									{
-										random_value = Commands->Get_Random (0.0f, 100.0f);
+										random_value = Commands->Get_Random_Int (0, 100);
 										if (random_value <= Get_Float_Parameter ("Random_Percentage"))
 										{
 											target_obj = Commands->Find_Object (object_random_record [object_count]);
 											if (target_obj)
 											{
-												random_value2 = int(Commands->Get_Random (float(parameter_low), float(parameter_high)));
+												random_value2 = Commands->Get_Random_Int (parameter_low, parameter_high);
 												SCRIPT_DEBUG_MESSAGE(("M00_Broadcaster_Terminal_RAD is sending custom type %d, param %d.\n", type, random_value2));
 												Commands->Send_Custom_Event (obj, target_obj, type, random_value2, 0.0f);
 											}

--- a/Code/Scripts/Toolkit_Objectives.cpp
+++ b/Code/Scripts/Toolkit_Objectives.cpp
@@ -361,7 +361,7 @@ DECLARE_SCRIPT(M00_Global_Objective_Controller_RMV, "Set_Type:int, Set_Status:in
 			f_obj = (float)param;
 			f_obj /= 10.0;
 			i_obj = int(f_obj);
-			i_new = (f_obj - i_obj) * 10;
+			i_new = int((f_obj - i_obj) * 10);
 			switch (i_new) {
 			case 1: Commands->Change_Objective_Type(i_obj, OBJECTIVE_TYPE_PRIMARY);
 			case 2: Commands->Change_Objective_Type(i_obj, OBJECTIVE_TYPE_SECONDARY);
@@ -373,7 +373,7 @@ DECLARE_SCRIPT(M00_Global_Objective_Controller_RMV, "Set_Type:int, Set_Status:in
 			f_obj = (float)param;
 			f_obj /= 10.0;
 			i_obj = int(f_obj);
-			i_new = (f_obj - i_obj) * 10;
+			i_new = int((f_obj - i_obj) * 10);
 			switch (i_new) {
 			case 1: Commands->Set_Objective_Status(i_obj, OBJECTIVE_STATUS_PENDING);
 			case 2: Commands->Set_Objective_Status(i_obj, OBJECTIVE_STATUS_ACCOMPLISHED);

--- a/Code/Scripts/Toolkit_Powerup.cpp
+++ b/Code/Scripts/Toolkit_Powerup.cpp
@@ -382,7 +382,7 @@ DECLARE_SCRIPT (M00_Tiberium_Refinery, "MoneyAmount:int,TimerLength:int")
 {
 	void Created (GameObject * obj) override
 	{
-		Commands->Start_Timer (obj, this, Get_Int_Parameter("TimerLength"), 1);
+		Commands->Start_Timer (obj, this, float(Get_Int_Parameter("TimerLength")), 1);
 	}
 
 	void Timer_Expired (GameObject * obj, int timer_id) override
@@ -392,8 +392,8 @@ DECLARE_SCRIPT (M00_Tiberium_Refinery, "MoneyAmount:int,TimerLength:int")
 			float health = Commands->Get_Health (obj);
 			if (health)
 			{
-				Commands->Give_Money (obj, Get_Int_Parameter ("MoneyAmount"), true);
-				Commands->Start_Timer (obj, this, Get_Int_Parameter("TimerLength"), 1);
+				Commands->Give_Money (obj, float(Get_Int_Parameter ("MoneyAmount")), true);
+				Commands->Start_Timer (obj, this, float(Get_Int_Parameter("TimerLength")), 1);
 			}
 		}
 	}

--- a/Code/Scripts/Toolkit_Sounds.cpp
+++ b/Code/Scripts/Toolkit_Sounds.cpp
@@ -740,9 +740,9 @@ DECLARE_SCRIPT(RMV_Sound_Play_Near_Player, "Receive_Type:int, Receive_Param:int,
 			GameObject *player;
 			player = Commands->Get_A_Star(Vector3(0,0,0));
 			Vector3 player_pos = Commands->Get_Position(player);
-			current.X = (int)Commands->Get_Random(-offset.X, offset.X);
-			current.Y = (int)Commands->Get_Random(-offset.Y, offset.Y);
-			current.Z = (int)Commands->Get_Random(0.0, offset.Z);
+			current.X = Commands->Get_Random(-offset.X, offset.X);
+			current.Y = Commands->Get_Random(-offset.Y, offset.Y);
+			current.Z = Commands->Get_Random(0.0, offset.Z);
 			Vector3 sound_pos = player_pos + current;
 			if (freq_max == 0.0)
 				freq = freq_min;

--- a/Code/Scripts/Toolkit_Triggers.cpp
+++ b/Code/Scripts/Toolkit_Triggers.cpp
@@ -1252,9 +1252,9 @@ DECLARE_SCRIPT(M00_Trigger_Timer_Expired_RAD, "Start_Now=0:int, Receive_Type=15:
 			{
 				GameObject* target_obj;
 				int target_id;
-				int min_delay;
-				int max_delay;
-				int delay_value;
+				float min_delay;
+				float max_delay;
+				float delay_value;
 
 				target_id = Get_Int_Parameter("Target_ID");
 

--- a/Code/Scripts/mission08.cpp
+++ b/Code/Scripts/mission08.cpp
@@ -356,7 +356,7 @@ DECLARE_SCRIPT(M08_Activate_Objective_802, "")
 
 			// Nick, Those scientists you've been digging for are being held in a Nod Research Facility at the far end of the canyon. Figure'd you might want to know.\n
 			const char *conv_name = ("M08_CON001");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300502);
@@ -415,7 +415,7 @@ DECLARE_SCRIPT(M08_Activate_Objective_803, "")
 
 			// Nick, we're going to lose contact when you head inside, there's no radio communication possible due to jamming signals.\n
 			const char *conv_name = ("M08_CON002");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300803);
@@ -475,7 +475,7 @@ DECLARE_SCRIPT(M08_Activate_Objective_804, "")
 
 			// Don't know if you care, hon, but there's a Nod Helipad in back of the Prison Facility. Might help if you blow it up.\n
 			const char *conv_name = ("M08_CON003");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300804);
@@ -535,7 +535,7 @@ DECLARE_SCRIPT(M08_Activate_Objective_806, "")
 
 			// Disable Research Station Alpha.\n
 			const char *conv_name = ("M08_CON004");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(STAR, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300806);
 			Commands->Monitor_Conversation (obj, conv_id);
@@ -3005,13 +3005,13 @@ DECLARE_SCRIPT(M08_Encounter_Unit, "Waypath_ID=0:int, Priority=0:int, Suicide=0:
 		}
 		else if(waypath_id == 1)
 		{
-			params.Set_Basic( this, priority, GO_STAR );
+			params.Set_Basic( this, float(priority), GO_STAR );
 			params.Set_Movement( STAR, RUN, 2.0f );
 			Commands->Action_Goto (  obj, params );
 		}
 		else
 		{
-			params.Set_Basic( this, priority, WAYPATH );
+			params.Set_Basic( this, float(priority), WAYPATH );
 			params.Set_Movement( Vector3(0,0,0), RUN, 1.5f );
 			params.WaypathID = waypath_id;
 			Commands->Action_Goto( obj, params );
@@ -3083,7 +3083,7 @@ DECLARE_SCRIPT(M08_Warden_Announcement1, "")
 
 			// This is the warden, we have a probable escape situation in solitary. Full lockdown, all personnel initiate response protocols.\n
 			const char *conv_name = ("M08_CON006");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300502);
 			Commands->Monitor_Conversation (obj, conv_id);
@@ -3120,7 +3120,7 @@ DECLARE_SCRIPT(M08_Warden_Announcement2, "")
 
 			// This is the warden, we have a confirmed prison break, repeat, confirmed prison break! Assume all GDI as hostile, kill every last one of them!\n
 			const char *conv_name = ("M08_CON007");
-			int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+			int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 			Commands->Join_Conversation(NULL, conv_id, false, true, true);
 			Commands->Start_Conversation (conv_id, 300502);
 			Commands->Monitor_Conversation (obj, conv_id);
@@ -4527,8 +4527,8 @@ DECLARE_SCRIPT(M08_Facility_APC, "")
 
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * -4.0;
-			float b = sin(DEG_TO_RADF(facing)) * -4.0;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * -4.0f;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * -4.0f;
 
 			Vector3 soldier_loc1 = pos + Vector3(a, b + .5f, 0.5f);
 			GameObject * soldier1 = Commands->Create_Object("Nod_MiniGunner_1Off", soldier_loc1);
@@ -4568,8 +4568,8 @@ DECLARE_SCRIPT(M08_Facility_APC, "")
 
 				Vector3 pos = Commands->Get_Position(obj);
 				float facing = Commands->Get_Facing(obj);
-				float a = cos(DEG_TO_RADF(facing)) * -4.0;
-				float b = sin(DEG_TO_RADF(facing)) * -4.0;
+				float a = WWMath::Cos(DEG_TO_RADF(facing)) * -4.0f;
+				float b = WWMath::Sin(DEG_TO_RADF(facing)) * -4.0f;
 
 				Vector3 soldier_loc1 = pos + Vector3(a, b + .5f, 0.5f);
 				GameObject * soldier1 = Commands->Create_Object("Nod_MiniGunner_1Off", soldier_loc1);
@@ -4607,8 +4607,8 @@ DECLARE_SCRIPT(M08_Facility_APC, "")
 
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * -4.0;
-			float b = sin(DEG_TO_RADF(facing)) * -4.0;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * -4.0f;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * -4.0f;
 
 			Vector3 soldier_loc1 = pos + Vector3(a, b + .5f, 0.5f);
 			GameObject * soldier1 = Commands->Create_Object("Nod_MiniGunner_1Off", soldier_loc1);
@@ -5246,8 +5246,8 @@ DECLARE_SCRIPT(M08_Cavern_Tunnel_APC, "")
 
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * -4.0;
-			float b = sin(DEG_TO_RADF(facing)) * -4.0;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * -4.0f;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * -4.0f;
 
 			Vector3 soldier_loc1 = pos + Vector3(a, b + .5f, 0.5f);
 			GameObject * soldier1 = Commands->Create_Object("Nod_FlameThrower_2SF", soldier_loc1);
@@ -5285,8 +5285,8 @@ DECLARE_SCRIPT(M08_Cavern_Tunnel_APC, "")
 
 				Vector3 pos = Commands->Get_Position(obj);
 				float facing = Commands->Get_Facing(obj);
-				float a = cos(DEG_TO_RADF(facing)) * -4.0;
-				float b = sin(DEG_TO_RADF(facing)) * -4.0;
+				float a = WWMath::Cos(DEG_TO_RADF(facing)) * -4.0f;
+				float b = WWMath::Sin(DEG_TO_RADF(facing)) * -4.0f;
 
 				Vector3 soldier_loc1 = pos + Vector3(a, b + .5f, 0.5f);
 				GameObject * soldier1 = Commands->Create_Object("Nod_FlameThrower_2SF", soldier_loc1);
@@ -5324,8 +5324,8 @@ DECLARE_SCRIPT(M08_Cavern_Tunnel_APC, "")
 
 			Vector3 pos = Commands->Get_Position(obj);
 			float facing = Commands->Get_Facing(obj);
-			float a = cos(DEG_TO_RADF(facing)) * -4.0;
-			float b = sin(DEG_TO_RADF(facing)) * -4.0;
+			float a = WWMath::Cos(DEG_TO_RADF(facing)) * -4.0f;
+			float b = WWMath::Sin(DEG_TO_RADF(facing)) * -4.0f;
 
 			Vector3 soldier_loc1 = pos + Vector3(a, b + .5f, 0.5f);
 			GameObject * soldier1 = Commands->Create_Object("Nod_FlameThrower_2SF", soldier_loc1);
@@ -6459,8 +6459,8 @@ DECLARE_SCRIPT(M08_Apache, "Area:int")
 		{
 			Vector3 pos = Commands->Get_Position(STAR);
 			float facing = Commands->Get_Facing(STAR);
-			pos.X -= cos(DEG_TO_RADF(facing)) * 6.0f;
-			pos.Y -= sin(DEG_TO_RADF(facing)) * 6.0f;
+			pos.X -= WWMath::Cos(DEG_TO_RADF(facing)) * 6.0f;
+			pos.Y -= WWMath::Sin(DEG_TO_RADF(facing)) * 6.0f;
 
 			pos.Z = WWMath::Max(pos.Z + 12.0f, Commands->Get_Safe_Flight_Height(pos.X, pos.Y) + 6.0f);
 
@@ -6637,8 +6637,8 @@ DECLARE_SCRIPT(M08_Mobile_Apache, "Entrance_Path_ID=0:int, Helipad_ID=0:int")
 	{
 		Vector3 pos = Commands->Get_Position(STAR);
 		float facing = Commands->Get_Facing(STAR);
-		pos.X -= cos(DEG_TO_RADF(facing)) * 6.0f;
-		pos.Y -= sin(DEG_TO_RADF(facing)) * 6.0f;
+		pos.X -= WWMath::Cos(DEG_TO_RADF(facing)) * 6.0f;
+		pos.Y -= WWMath::Sin(DEG_TO_RADF(facing)) * 6.0f;
 
 		pos.Z = WWMath::Max(pos.Z + 12.0f, Commands->Get_Safe_Flight_Height(pos.X, pos.Y) + 6.0f);
 
@@ -6802,7 +6802,7 @@ DECLARE_SCRIPT(M08_Prisoner_Conversation, "Orator_ID=0:int, Captive=0:int")
 				{
 					// Save us!\n
 					const char *conv_name = ("M08_CON010");
-					int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+					int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 					Commands->Join_Conversation(Commands->Find_Object(orator_id), conv_id, false, true, true);
 					Commands->Start_Conversation (conv_id, 2);
 
@@ -6811,7 +6811,7 @@ DECLARE_SCRIPT(M08_Prisoner_Conversation, "Orator_ID=0:int, Captive=0:int")
 				{
 					// It's the Commando!\n
 					const char *conv_name = ("M08_CON009");
-					int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+					int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 					Commands->Join_Conversation(Commands->Find_Object(orator_id), conv_id, false, true, true);
 					Commands->Start_Conversation (conv_id, 2);
 				}
@@ -7006,7 +7006,7 @@ DECLARE_SCRIPT(M08_Prisoner_Poke_Conversation, "")
 	void Play_Conversation(GameObject * obj, int Min, int Max)
 	{
 		const char *conv_name = Prisoner_Conv_Table[Index(Min, Max)];
-		int conv_id = Commands->Create_Conversation (conv_name, 100.0f, 200.0f, false);
+		int conv_id = Commands->Create_Conversation (conv_name, 100, 200.0f, false);
 		Commands->Join_Conversation(obj, conv_id, false, true, true);
 		Commands->Start_Conversation (conv_id, 0);
 	}

--- a/Code/Tools/LevelEdit/Box3D.cpp
+++ b/Code/Tools/LevelEdit/Box3D.cpp
@@ -669,8 +669,8 @@ Box3DClass::Drag_VertexXY (int vertex_index, POINT point, const Vector3 &locked_
 	//
 	// Ensure the 'point' is correct for this mode (fullscreen/windowed)
 	//
-	float xpos = point.x;
-	float ypos = point.y;
+	float xpos = float(point.x);
+	float ypos = float(point.y);
 	::Constrain_Point_To_Aspect_Ratio (xpos, ypos);
 
 	//
@@ -683,14 +683,14 @@ Box3DClass::Drag_VertexXY (int vertex_index, POINT point, const Vector3 &locked_
 	//
 	// If the ray isn't parallel to the z-axis, then move the corner vertex
 	//
-	if (fabs(ray_end.Z - ray_start.Z) > 1.0F) {
+	if (WWMath::Fabs(ray_end.Z - ray_start.Z) > 1.0F) {
 
 		Vector3 vertex_pos = Get_Vertex_Position (vertex_index);
 
 		// Calculate the fraction of the distance along the ray where the
 		// Z value of the ray is the same as the Z value of the vertex we are moving.
 		// This simulates an intersection of the ray with the x-y plane at height 'z'.
-		double fraction = double(vertex_pos.Z - ray_start.Z) / double(ray_end.Z - ray_start.Z);
+		float fraction = vertex_pos.Z - ray_start.Z / ray_end.Z - ray_start.Z;
 
 		// Now calcuate the 2nd point based on this fraction.
 		// To do this we use the parameterized form of a line equation:
@@ -720,8 +720,8 @@ Box3DClass::Drag_VertexZ (int vertex_index, POINT point, const Vector3 &locked_v
 	//
 	// Ensure the 'point' is correct for this mode (fullscreen/windowed)
 	//
-	float xpos = point.x;
-	float ypos = point.y;
+	float xpos = float(point.x);
+	float ypos = float(point.y);
 	::Constrain_Point_To_Aspect_Ratio (xpos, ypos);
 
 	//
@@ -734,8 +734,8 @@ Box3DClass::Drag_VertexZ (int vertex_index, POINT point, const Vector3 &locked_v
 	//
 	// Determine which plane (y-z or x-z) to base the movement on
 	//
-	float deltax = ::fabs (ray_end.X - ray_start.X);
-	float deltay = ::fabs (ray_end.Y - ray_start.Y);
+	float deltax = WWMath::Fabs (ray_end.X - ray_start.X);
+	float deltay = WWMath::Fabs (ray_end.Y - ray_start.Y);
 
 	//
 	// Determine where the ray intersects this plane
@@ -766,7 +766,7 @@ Box3DClass::Drag_VertexZ (int vertex_index, POINT point, const Vector3 &locked_v
 		// P = P1 + (P2 - P1) * t
 		// (Where t is a percentage between 0 and 1)
 		Vector3 new_point = vertex_pos;
-		new_point.Z = ray_start.Z + ((ray_end.Z - ray_start.Z) * fraction);
+		new_point.Z = float(ray_start.Z + ((ray_end.Z - ray_start.Z) * fraction));
 		Make_Box (locked_vertex, new_point);
 	}
 

--- a/Code/Tools/LevelEdit/CameraMgr.cpp
+++ b/Code/Tools/LevelEdit/CameraMgr.cpp
@@ -377,7 +377,7 @@ CameraMgr::Auto_Level (void)
 
 		// Linerally-interpolate between the 2 rotations (from 0.0 - 1.0)
 		Quaternion rotation_now;
-		::Slerp (rotation_now, initial_quat, end_quat, m_AutoLevelPercent);
+		::Slerp (rotation_now, initial_quat, end_quat, float(m_AutoLevelPercent));
 
 		// Increment the current interpolation percent
 		m_AutoLevelPercent += 0.04F;
@@ -964,8 +964,8 @@ CameraMgr::Update_Camera_ORBIT
 
 	Vector3 viewpos;
 	Vector3 last_viewpos;
-	camera.Device_To_View_Space (Vector2 (last_point.x, last_point.y), &last_viewpos);
-	camera.Device_To_View_Space (Vector2 (point.x, point.y), &viewpos);
+	camera.Device_To_View_Space (Vector2 (float(last_point.x), float(last_point.y)), &last_viewpos);
+	camera.Device_To_View_Space (Vector2 (float(point.x), float(point.y)), &viewpos);
 
 	// Rotate the camara like a trackball
 	Quaternion rotation = ::Trackball (last_viewpos.X, last_viewpos.Y, viewpos.X, viewpos.Y, 0.4F);

--- a/Code/Tools/LevelEdit/EditDialogueDialog.cpp
+++ b/Code/Tools/LevelEdit/EditDialogueDialog.cpp
@@ -170,7 +170,7 @@ EditDialogueDialogClass::OnOK (void)
 	//	Read the silence configuration
 	//
 	int new_weight = GetDlgItemInt (IDC_SILENCE_WEIGHT_EDIT);
-	m_Dialogue->Set_Silence_Weight (new_weight);
+	m_Dialogue->Set_Silence_Weight (float(new_weight));
 
 	//
 	//	Start with a fresh list of options

--- a/Code/Tools/LevelEdit/EditorSaveLoad.cpp
+++ b/Code/Tools/LevelEdit/EditorSaveLoad.cpp
@@ -298,7 +298,7 @@ EditorSaveLoadClass::Load_Micro_Chunks (ChunkLoadClass &cload)
 
 				double double_zfar = 0;
 				cload.Read (&double_zfar, sizeof (double_zfar));
-				zfar = double_zfar;
+				zfar = float(double_zfar);
 				::Get_Camera_Mgr ()->Get_Camera ()->Set_Clip_Planes (znear, zfar);
 			}
 			break;

--- a/Code/Tools/LevelEdit/GeneratingEdgeSampledVisDialog.cpp
+++ b/Code/Tools/LevelEdit/GeneratingEdgeSampledVisDialog.cpp
@@ -219,7 +219,7 @@ GeneratingEdgeSampledVisDialogClass::Update_Stats (void)
 		//
 		SetDlgItemInt (IDC_TOTAL_EDGE_COUNT,		m_ProgressObj->Get_Total_Edge_Count ());
 		SetDlgItemInt (IDC_TOTAL_SAMPLE_COUNT,		m_ProgressObj->Get_Total_Sample_Count ());
-		SetDlgItemInt (IDC_AVG_SAMPLES_PER_NODE,	m_ProgressObj->Get_Average_Samples_Per_Node ());
+		SetDlgItemInt (IDC_AVG_SAMPLES_PER_NODE,	int(m_ProgressObj->Get_Average_Samples_Per_Node ()));
 		SetDlgItemInt (IDC_EDGE_COUNT,				m_ProgressObj->Get_Current_Node_Edge_Count ());
 		SetDlgItemInt (IDC_SAMPLE_COUNT,				m_ProgressObj->Get_Current_Node_Sample_Count ());
 
@@ -229,7 +229,7 @@ GeneratingEdgeSampledVisDialogClass::Update_Stats (void)
 		int processed		= m_ProgressObj->Get_Processed_Node_Count ();
 		int total			= m_ProgressObj->Get_Node_Count ();
 		float percent		= static_cast<float>(processed) / static_cast<float>(total);
-		m_ProgressCtrl.SetPos (percent * 100);
+		m_ProgressCtrl.SetPos (int(percent * 100));
 
 		//
 		//	Update the status text

--- a/Code/Tools/LevelEdit/GeneratingPathfindDialog.cpp
+++ b/Code/Tools/LevelEdit/GeneratingPathfindDialog.cpp
@@ -133,7 +133,7 @@ void
 GeneratingPathfindDialogClass::Set_Status (LPCTSTR text, float percent)
 {
 	if (percent > 0) {
-		m_ProgressBar.SetPos (percent * 100);
+		m_ProgressBar.SetPos (int(percent * 100));
 	}
 
 	SetDlgItemText (IDC_STATUS_TEXT, text);

--- a/Code/Tools/LevelEdit/GotoLocationDialog.cpp
+++ b/Code/Tools/LevelEdit/GotoLocationDialog.cpp
@@ -118,7 +118,7 @@ GotoLocationDialogClass::OnInitDialog (void)
 	::SetDlgItemFloat (m_hWnd, IDC_XPOS_EDIT, position.X);
 	::SetDlgItemFloat (m_hWnd, IDC_YPOS_EDIT, position.Y);
 	::SetDlgItemFloat (m_hWnd, IDC_ZPOS_EDIT, position.Z);
-	::SetDlgItemFloat (m_hWnd, IDC_FACING_EDIT, RAD_TO_DEG (facing));
+	::SetDlgItemFloat (m_hWnd, IDC_FACING_EDIT, RAD_TO_DEGF (facing));
 	return true;
 }
 
@@ -144,8 +144,8 @@ GotoLocationDialogClass::OnOK (void)
 	//
 	//	Create a transform for the camera using these new settings
 	//
-	float x_val = ::cos (DEG_TO_RADF (facing));
-	float y_val = ::sin (DEG_TO_RADF (facing));
+	float x_val = WWMath::Cos (DEG_TO_RADF (facing));
+	float y_val = WWMath::Sin (DEG_TO_RADF (facing));
 	Vector3 y_axis = Vector3 (0, 0, 1);
 	Vector3 z_axis = Vector3 (x_val, y_val, 0);
 	Vector3 x_axis = Vector3::Cross_Product (y_axis, z_axis);

--- a/Code/Tools/LevelEdit/Grid3D.h
+++ b/Code/Tools/LevelEdit/Grid3D.h
@@ -78,13 +78,13 @@ class Grid3DClass
 
 		// Information methods
 		Vector3			Get_Grid_Size (void) const { return m_GridSize; }
-		int				Get_Cells_X (void) const { return m_GridSize.X; }
-		int				Get_Cells_Y (void) const { return m_GridSize.Y; }
-		int				Get_Cells_Z (void) const { return m_GridSize.Z; }
+		int				Get_Cells_X (void) const { return int(m_GridSize.X); }
+		int				Get_Cells_Y (void) const { return int(m_GridSize.Y); }
+		int				Get_Cells_Z (void) const { return int(m_GridSize.Z); }
 
 		// 'Flat' methods, for enumerating every cell
 		T &				Get_At_Flat (int index)		{ return m_Grid[index]; }
-		int				Get_Flat_Size (void) const	{ return (m_GridSize.X * m_GridSize.Y * m_GridSize.Z); }
+		int				Get_Flat_Size (void) const	{ return int(m_GridSize.X * m_GridSize.Y * m_GridSize.Z); }
 
 	protected:
 
@@ -121,7 +121,7 @@ Grid3DClass<T>::Create_Grid (const Vector3 &grid_size, const T &inital_value)
 	//
 	//	Allocate a flat array we can index into like a 3-D grid
 	//
-	int flat_size = m_GridSize.X * m_GridSize.Y * m_GridSize.Z;
+	int flat_size = int(m_GridSize.X * m_GridSize.Y * m_GridSize.Z);
 	WWASSERT ((flat_size * sizeof (T)) < 16000000L);
 	m_Grid = new T[flat_size];
 
@@ -164,7 +164,7 @@ template<class T>
 inline int
 Grid3DClass<T>::Cell_Coord_To_Index (int x, int y, int z)
 {
-	return (x + (y * m_GridSize.X) + (z * m_GridSize.X * m_GridSize.Y));
+	return int(x + (y * m_GridSize.X) + (z * m_GridSize.X * m_GridSize.Y));
 }
 
 

--- a/Code/Tools/LevelEdit/LevelEditView.cpp
+++ b/Code/Tools/LevelEdit/LevelEditView.cpp
@@ -261,7 +261,7 @@ CLevelEditView::Initialize_Render_Device (void)
 	}
 
 	// Reset the camera's FOV
-	m_pCameraMgr->Get_Camera ()->Set_View_Plane (m_HorzFOV, m_VertFOV);
+	m_pCameraMgr->Get_Camera ()->Set_View_Plane (float(m_HorzFOV), float(m_VertFOV));
 
 	if (m_p2DCamera == NULL) {
 
@@ -368,11 +368,11 @@ CLevelEditView::OnSize
 	m_HorzFOV = 0.0F;
 	m_VertFOV = 0.0F;
 	if (cy > cx) {
-		m_VertFOV = (float)DEG_TO_RAD(45.0f);
+		m_VertFOV = DEG_TO_RAD(45.0);
 		m_HorzFOV = (double)cx / (double)cy * m_VertFOV;
 	}
 	else {
-		m_HorzFOV = (float)DEG_TO_RAD(45.0f);
+		m_HorzFOV = DEG_TO_RAD(45.0);
 		m_VertFOV = (double)cy / (double)cx * m_HorzFOV;
 	}
 
@@ -385,7 +385,7 @@ CLevelEditView::OnSize
 		}
 
 		// Reset the field of view
-		m_pCameraMgr->Get_Camera ()->Set_View_Plane (m_HorzFOV, m_VertFOV);
+		m_pCameraMgr->Get_Camera ()->Set_View_Plane (float(m_HorzFOV), float(m_VertFOV));
 
 		// Force a repaint of the screen
 		Repaint_View ();

--- a/Code/Tools/LevelEdit/LightAmbientForm.cpp
+++ b/Code/Tools/LevelEdit/LightAmbientForm.cpp
@@ -136,9 +136,9 @@ LightAmbientFormClass::Update_Settings (void)
 	//
 	Vector3 light_settings = ::Get_Scene_Editor()->Get_Ambient_Light ();
 
-	int red		= light_settings.X * 255;
-	int green	= light_settings.Y * 255;
-	int blue		= light_settings.Z * 255;
+	int red		= int(light_settings.X * 255);
+	int green	= int(light_settings.Y * 255);
+	int blue		= int(light_settings.Z * 255);
 
 	//
 	//	Pass these colors onto the form

--- a/Code/Tools/LevelEdit/LightNode.cpp
+++ b/Code/Tools/LevelEdit/LightNode.cpp
@@ -459,8 +459,8 @@ LightNodeClass::Update_Light (void)
 		Vector3 diffuse		= m_InstanceSettings.Get_Diffuse_Color ();
 		Vector3 specular		= m_InstanceSettings.Get_Specular_Color ();
 		float intensity		= m_InstanceSettings.Get_Intensity ();
-		double inner_radius	= m_InstanceSettings.Get_Inner_Radius ();
-		double outer_radius	= m_InstanceSettings.Get_Outer_Radius ();
+		float inner_radius	= m_InstanceSettings.Get_Inner_Radius ();
+		float outer_radius	= m_InstanceSettings.Get_Outer_Radius ();
 		float spot_angle		= m_InstanceSettings.Get_Spot_Angle ();
 		Vector3 spot_dir		= m_InstanceSettings.Get_Spot_Direction ();
 		float spot_exp			= m_InstanceSettings.Get_Spot_Exponent ();

--- a/Code/Tools/LevelEdit/LightNode.cpp
+++ b/Code/Tools/LevelEdit/LightNode.cpp
@@ -552,8 +552,8 @@ LightNodeClass::Initialize_From_Light (LightClass *light)
 	light->Get_Diffuse (&diffuse_color);
 	light->Get_Specular (&specular_color);
 
-	double inner = 0;
-	double outer = 0;
+	float inner = 0;
+	float outer = 0;
 	light->Get_Far_Attenuation_Range (inner, outer);
 
 	float intensity				= light->Get_Intensity ();

--- a/Code/Tools/LevelEdit/Mover.cpp
+++ b/Code/Tools/LevelEdit/Mover.cpp
@@ -98,8 +98,8 @@ MoverClass::Get_Mouse_Ray
 	//
 	// Ensure the 'point' is correct for this mode (fullscreen/windowed)
 	//
-	float xpos = mouse_pos.x;
-	float ypos = mouse_pos.y;
+	float xpos = float(mouse_pos.x);
+	float ypos = float(mouse_pos.y);
 	::Constrain_Point_To_Aspect_Ratio (xpos, ypos);
 
 	// The 'end' of the ray is the world coordinates of the supplied point
@@ -429,7 +429,7 @@ MoverClass::Calc_Ray_Intersection_XY
 		// Calculate the fraction of the distance along the ray where the
 		// Z value of the ray is the same as the Z value of the plane.
 		// This simulates an intersection of the ray with the x-y plane at depth 'z'.
-		double fraction = double(plane - ray_start.Z) / double(ray_end.Z - ray_start.Z);
+		float fraction = (plane - ray_start.Z) / (ray_end.Z - ray_start.Z);
 
 		// If the fraction is between 0 and 1, then the ray intersects the plane
 		if ((fraction >= 0) && (fraction <= 1.0F)) {
@@ -472,7 +472,7 @@ MoverClass::Calc_Ray_Intersection_XZ
 		// Calculate the fraction of the distance along the ray where the
 		// Y value of the ray is the same as the Y value of the plane.
 		// This simulates an intersection of the ray with the x-z plane at depth 'y'.
-		double fraction = double(plane - ray_start.Y) / double(ray_end.Y - ray_start.Y);
+		float fraction = (plane - ray_start.Y) / (ray_end.Y - ray_start.Y);
 
 		// If the fraction is between 0 and 1, then the ray intersects the plane
 		if ((fraction >= 0) && (fraction <= 1.0F)) {
@@ -515,7 +515,7 @@ MoverClass::Calc_Ray_Intersection_YZ
 		// Calculate the fraction of the distance along the ray where the
 		// X value of the ray is the same as the X value of the plane.
 		// This simulates an intersection of the ray with the y-z plane at depth 'x'.
-		double fraction = double(plane - ray_start.X) / double(ray_end.X - ray_start.X);
+		float fraction = (plane - ray_start.X) / (ray_end.X - ray_start.X);
 
 		// If the fraction is between 0 and 1, then the ray intersects the plane
 		if ((fraction >= 0) && (fraction <= 1.0F)) {
@@ -739,8 +739,8 @@ MoverClass::Calc_New_Position
 		point = (*mouse_pos);
 	}
 
-	float xpos = point.x;
-	float ypos = point.y;
+	float xpos = float(point.x);
+	float ypos = float(point.y);
 	::Constrain_Point_To_Aspect_Ratio (xpos, ypos);
 
 	//
@@ -987,11 +987,11 @@ MoverClass::Rotate_Nodes_Z
 		//
 		Matrix3D rotation_matrix (1);
 		if (restrict_rotation == false) {
-			rotation_matrix.Rotate_Z (DEG_TO_RAD (5.0F) * multiplier);
+			rotation_matrix.Rotate_Z (DEG_TO_RADF (5.0F) * multiplier);
 		} else if (multiplier > 0.0F) {
-			rotation_matrix.Rotate_Z ((float)DEG_TO_RAD (-90));
+			rotation_matrix.Rotate_Z (DEG_TO_RADF (-90));
 		} else {
-			rotation_matrix.Rotate_Z ((float)DEG_TO_RAD (90));
+			rotation_matrix.Rotate_Z (DEG_TO_RADF (90));
 		}
 
 		// Rotate the node

--- a/Code/Tools/LevelEdit/NewHeightfieldDialog.cpp
+++ b/Code/Tools/LevelEdit/NewHeightfieldDialog.cpp
@@ -73,8 +73,8 @@ END_MESSAGE_MAP()
 void
 NewHeightfieldDialogClass::OnOK (void)
 {
-	int width		= GetDlgItemInt (IDC_WIDTH_EDIT);
-	int height		= GetDlgItemInt (IDC_HEIGHT_EDIT);
+	float width		= float(GetDlgItemInt (IDC_WIDTH_EDIT));
+	float height	= float(GetDlgItemInt (IDC_HEIGHT_EDIT));
 	float density	= ::GetDlgItemFloat (m_hWnd, IDC_DENSITY_EDIT, false);
 
 	//

--- a/Code/Tools/LevelEdit/ParameterCtrls.cpp
+++ b/Code/Tools/LevelEdit/ParameterCtrls.cpp
@@ -742,7 +742,7 @@ FloatParameterCtrlClass::Create
 
 
 	::SetWindowFloat (m_EditCtrl, m_Parameter->Get_Value ());
-	m_SpinCtrl.SetRange32 (m_Parameter->Get_Min () * 100, m_Parameter->Get_Max () * 100);
+	m_SpinCtrl.SetRange32 (int(m_Parameter->Get_Min () * 100), int(m_Parameter->Get_Max () * 100));
 
 	if (m_IsReadOnly) {
 		m_EditCtrl.EnableWindow (false);
@@ -830,14 +830,14 @@ AngleParameterCtrlClass::Create
 	//
 	//	Set the initial value of the control
 	//
-	::SetWindowFloat (m_EditCtrl, RAD_TO_DEG (m_Parameter->Get_Value ()));
+	::SetWindowFloat (m_EditCtrl, RAD_TO_DEGF (m_Parameter->Get_Value ()));
 
 	//
 	//	Set the ranges on the spinner
 	//
-	float min_ang = RAD_TO_DEG (m_Parameter->Get_Min ());
-	float max_ang = RAD_TO_DEG (m_Parameter->Get_Max ());
-	m_SpinCtrl.SetRange32 (min_ang * 100, max_ang * 100);
+	float min_ang = RAD_TO_DEGF (m_Parameter->Get_Min ());
+	float max_ang = RAD_TO_DEGF (m_Parameter->Get_Max ());
+	m_SpinCtrl.SetRange32 (int(min_ang * 100), int(max_ang * 100));
 
 	//
 	//	Make the controls read-only if necessary
@@ -874,7 +874,7 @@ AngleParameterCtrlClass::Resize (const CRect &rect)
 void
 AngleParameterCtrlClass::Read_Data (HWND /*parent_wnd*/)
 {
-	m_Parameter->Set_Value (DEG_TO_RAD (::GetWindowFloat (m_EditCtrl, true)));
+	m_Parameter->Set_Value (DEG_TO_RADF (::GetWindowFloat (m_EditCtrl, true)));
 	return ;
 }
 
@@ -1717,9 +1717,9 @@ ColorParameterCtrlClass::On_Command
 		//	Get the current color fron the control
 		//
 		Vector3 color = m_Parameter->Get_Value ();
-		int red		= color.X * 255;
-		int green	= color.Y * 255;
-		int blue		= color.Z * 255;
+		int red		= int(color.X * 255);
+		int green	= int(color.Y * 255);
+		int blue		= int(color.Z * 255);
 
 		//
 		//	Show the color picker to the user

--- a/Code/Tools/LevelEdit/PathfindSectorBuilder.cpp
+++ b/Code/Tools/LevelEdit/PathfindSectorBuilder.cpp
@@ -390,8 +390,8 @@ PathfindSectorBuilderClass::Initialize (void)
 	Vector3 lev_min;
 	Vector3 lev_max;
 	PhysicsSceneClass::Get_Instance ()->Get_Level_Extents (lev_min, lev_max);
-	int width = (lev_max.X - lev_min.X) / m_SimBoundingBox.X;
-	int height = (lev_max.Y - lev_min.Y) / m_SimBoundingBox.Y;
+	int width = int((lev_max.X - lev_min.X) / m_SimBoundingBox.X);
+	int height = int((lev_max.Y - lev_min.Y) / m_SimBoundingBox.Y);
 	m_TotalBoxGuess = width * height;
 
 	//
@@ -1521,7 +1521,7 @@ PathfindSectorBuilderClass::Find_Perimeter (FloodfillBoxClass *start_box, BOX_PE
 	//
 	//	Determine what the maximum number of cells in a given direction can be
 	//
-	int max_dim = m_MaxSectorDim / std::max (m_SimBoundingBox.X, m_SimBoundingBox.Y);
+	int max_dim = int(m_MaxSectorDim / std::max (m_SimBoundingBox.X, m_SimBoundingBox.Y));
 
 	//
 	//	Create an object that will allow us to break the sector if

--- a/Code/Tools/LevelEdit/PositionPage.cpp
+++ b/Code/Tools/LevelEdit/PositionPage.cpp
@@ -141,9 +141,9 @@ PositionPageClass::HandleInitDialog (void)
 	::SetDlgItemFloat (m_hWnd, IDC_ZPOS_EDIT, translation.Z);
 
 	// Fill the rotation controls
-	::SetDlgItemFloat (m_hWnd, IDC_XROT_EDIT, RAD_TO_DEG (transform.Get_X_Rotation ()));
-	::SetDlgItemFloat (m_hWnd, IDC_YROT_EDIT, RAD_TO_DEG (transform.Get_Y_Rotation ()));
-	::SetDlgItemFloat (m_hWnd, IDC_ZROT_EDIT, RAD_TO_DEG (transform.Get_Z_Rotation ()));
+	::SetDlgItemFloat (m_hWnd, IDC_XROT_EDIT, RAD_TO_DEGF (transform.Get_X_Rotation ()));
+	::SetDlgItemFloat (m_hWnd, IDC_YROT_EDIT, RAD_TO_DEGF (transform.Get_Y_Rotation ()));
+	::SetDlgItemFloat (m_hWnd, IDC_ZROT_EDIT, RAD_TO_DEGF (transform.Get_Z_Rotation ()));
 
 	// Enable/disable the 'restrict rotation' checkbox, and set its check state
 	::EnableWindow (::GetDlgItem (m_hWnd, IDC_RESTRICT_CHECK), m_pNode->Can_Be_Rotated_Freely ());
@@ -175,7 +175,7 @@ PositionPageClass::Apply_Changes (void)
 	// Get the rotation angle
 	if (m_bInclueRotation) {
 		float zrot = ::GetDlgItemFloat (m_hWnd, IDC_ZROT_EDIT);
-		transform.Rotate_Z (DEG_TO_RAD (zrot));
+		transform.Rotate_Z (DEG_TO_RADF (zrot));
 	} else {
 		transform = m_pNode->Get_Transform ();
 	}

--- a/Code/Tools/LevelEdit/SceneEditor.cpp
+++ b/Code/Tools/LevelEdit/SceneEditor.cpp
@@ -2596,10 +2596,10 @@ SceneEditorClass::Compare_Lights (LightClass *light1, LightClass *light2)
 			//
 			//	Are their attenuation ranges the same?
 			//
-			double inner1 = 0;
-			double inner2 = 0;
-			double outer1 = 0;
-			double outer2 = 0;
+			float inner1 = 0;
+			float inner2 = 0;
+			float outer1 = 0;
+			float outer2 = 0;
 			light1->Get_Far_Attenuation_Range (inner1, outer1);
 			light2->Get_Far_Attenuation_Range (inner2, outer2);
 			if (inner1 == inner2 && outer1 == outer2) {

--- a/Code/Tools/LevelEdit/SkyPropPage.cpp
+++ b/Code/Tools/LevelEdit/SkyPropPage.cpp
@@ -98,8 +98,8 @@ BOOL SkyPropPageClass::OnInitDialog()
 	systemtime.wYear	 = 2000;
 	systemtime.wMonth	 = 01;
 	systemtime.wDay	 = 01;
-	systemtime.wHour	 = hours;
-	systemtime.wMinute = minutes;
+	systemtime.wHour	 = WORD(hours);
+	systemtime.wMinute = WORD(minutes);
 	TimeCtrl.SetTime (&systemtime);
 
 	lightsourcetype = BackgroundMgrClass::Get_Light_Source_Type();

--- a/Code/Tools/LevelEdit/SoundSettingsPage.cpp
+++ b/Code/Tools/LevelEdit/SoundSettingsPage.cpp
@@ -205,7 +205,7 @@ SoundSettingsPageClass::OnHScroll (UINT nSBCode, UINT nPos, CScrollBar *pScrollB
 	//
 	//	Update the edit control
 	//
-	::SetDlgItemFloat (m_hWnd, IDC_VOLUME_EDIT, m_VolumeSlider.GetPos ());
+	::SetDlgItemFloat (m_hWnd, IDC_VOLUME_EDIT, float(m_VolumeSlider.GetPos ()));
 
 	DockableFormClass::OnHScroll (nSBCode, nPos, pScrollBar);
 	return ;
@@ -225,7 +225,7 @@ SoundSettingsPageClass::OnChangeVolumeEdit (void)
 	//
 	float volume = ::GetDlgItemFloat (m_hWnd, IDC_VOLUME_EDIT);
 	volume = WWMath::Clamp (volume, 0, 100.0F);
-	m_VolumeSlider.SetPos (volume);
+	m_VolumeSlider.SetPos (int(volume));
 	return ;
 }
 

--- a/Code/Tools/LevelEdit/StringsCategoryViewDialog.cpp
+++ b/Code/Tools/LevelEdit/StringsCategoryViewDialog.cpp
@@ -259,7 +259,7 @@ StringsCategoryViewDialogClass::Update_Controls (void)
 	//	Configure the columns
 	//
 	for (int index = 0; index < Columns.Count (); index ++) {
-		m_ListCtrl.SetColumnWidth (index, ColumnSettings[index].width * width);
+		m_ListCtrl.SetColumnWidth (index, int(ColumnSettings[index].width * width));
 	}
 
 	return ;

--- a/Code/Tools/LevelEdit/SunlightDialog.cpp
+++ b/Code/Tools/LevelEdit/SunlightDialog.cpp
@@ -103,9 +103,9 @@ SunlightDialogClass::OnInitDialog (void)
 	m_PitchSlider.SetRange (0, 90);
 	m_IntensitySlider.SetRange (0, 100);
 
-	m_YawSlider.SetPos ((int)(RAD_TO_DEG (m_Yaw) + 0.5F));
-	m_PitchSlider.SetPos ((int)(RAD_TO_DEG (m_Pitch) + 0.5F));
-	m_IntensitySlider.SetPos ((m_Intensity * 100));
+	m_YawSlider.SetPos ((int)(RAD_TO_DEGF (m_Yaw) + 0.5F));
+	m_PitchSlider.SetPos ((int)(RAD_TO_DEGF (m_Pitch) + 0.5F));
+	m_IntensitySlider.SetPos ((int)(m_Intensity * 100));
 
 	::SetDlgItemFloat (m_hWnd, IDC_YAW_EDIT, (float)m_YawSlider.GetPos ());
 	::SetDlgItemFloat (m_hWnd, IDC_PITCH_EDIT, (float)m_PitchSlider.GetPos ());
@@ -127,14 +127,14 @@ SunlightDialogClass::OnHScroll
 )
 {
 	if (pScrollBar == GetDlgItem (IDC_YAW_SLIDER)) {
-		m_Yaw = DEG_TO_RAD ((float)m_YawSlider.GetPos ());
+		m_Yaw = DEG_TO_RADF ((float)m_YawSlider.GetPos ());
 		::Get_Scene_Editor ()->Set_Sun_Light_Orientation (m_Yaw, m_Pitch);
 		::Get_Scene_Editor ()->Update_Lighting ();
 		::SetDlgItemFloat (m_hWnd, IDC_YAW_EDIT, (float)m_YawSlider.GetPos ());
 		::Get_Scene_Editor ()->Update_Lighting ();
 
 	} else if (pScrollBar == GetDlgItem (IDC_PITCH_SLIDER)) {
-		m_Pitch = DEG_TO_RAD ((float)m_PitchSlider.GetPos ());
+		m_Pitch = DEG_TO_RADF ((float)m_PitchSlider.GetPos ());
 		::Get_Scene_Editor ()->Set_Sun_Light_Orientation (m_Yaw, m_Pitch);
 		::Get_Scene_Editor ()->Update_Lighting ();
 		::SetDlgItemFloat (m_hWnd, IDC_PITCH_EDIT, (float)m_PitchSlider.GetPos ());
@@ -163,9 +163,9 @@ SunlightDialogClass::OnHScroll
 void
 SunlightDialogClass::OnColor (void)
 {
-	int red		= m_Color.X * 255;
-	int green	= m_Color.Y * 255;
-	int blue		= m_Color.Z * 255;
+	int red		= int(m_Color.X * 255);
+	int green	= int(m_Color.Y * 255);
+	int blue		= int(m_Color.Z * 255);
 
 	//
 	// Display a dialog to the user that will allow them to select a color
@@ -241,7 +241,7 @@ void
 SunlightDialogClass::OnUpdatePitchEdit (void)
 {
 	float pitch_deg	= ::GetDlgItemFloat (m_hWnd, IDC_PITCH_EDIT);
-	m_Pitch				= DEG_TO_RAD (pitch_deg);
+	m_Pitch				= DEG_TO_RADF (pitch_deg);
 	::Get_Scene_Editor ()->Set_Sun_Light_Orientation (m_Yaw, m_Pitch);
 	::Get_Scene_Editor ()->Update_Lighting ();
 	m_PitchSlider.SetPos ((int)pitch_deg);
@@ -264,7 +264,7 @@ SunlightDialogClass::OnKillfocusPitchEdit (void)
 		pitch_deg = 90.0F;
 		::SetDlgItemFloat (m_hWnd, IDC_PITCH_EDIT, pitch_deg);
 
-		m_Pitch = DEG_TO_RAD (pitch_deg);
+		m_Pitch = DEG_TO_RADF (pitch_deg);
 		::Get_Scene_Editor ()->Set_Sun_Light_Orientation (m_Yaw, m_Pitch);
 		::Get_Scene_Editor ()->Update_Lighting ();
 		::Refresh_Main_View ();
@@ -287,7 +287,7 @@ SunlightDialogClass::OnKillfocusYawEdit (void)
 		yaw_deg = 360.0F;
 		::SetDlgItemFloat (m_hWnd, IDC_YAW_EDIT, yaw_deg);
 
-		m_Yaw = DEG_TO_RAD (yaw_deg);
+		m_Yaw = DEG_TO_RADF (yaw_deg);
 		::Get_Scene_Editor ()->Set_Sun_Light_Orientation (m_Yaw, m_Pitch);
 		::Get_Scene_Editor ()->Update_Lighting ();
 		::Refresh_Main_View ();
@@ -305,7 +305,7 @@ void
 SunlightDialogClass::OnUpdateYawEdit (void)
 {
 	float yaw_deg = ::GetDlgItemFloat (m_hWnd, IDC_YAW_EDIT);
-	m_Yaw = DEG_TO_RAD (yaw_deg);
+	m_Yaw = DEG_TO_RADF (yaw_deg);
 	::Get_Scene_Editor ()->Set_Sun_Light_Orientation (m_Yaw, m_Pitch);
 	::Get_Scene_Editor ()->Update_Lighting ();
 	m_YawSlider.SetPos ((int)yaw_deg);

--- a/Code/Tools/LevelEdit/TransitionEditDialog.cpp
+++ b/Code/Tools/LevelEdit/TransitionEditDialog.cpp
@@ -213,14 +213,14 @@ TransitionEditDialogClass::OnInitDialog (void)
 	//
 	//	Configure the camera
 	//
-	double hfov = 0;
-	double vfov = 0;
+	float hfov = 0;
+	float vfov = 0;
 	if (cy > cx) {
-		vfov = (float)DEG_TO_RAD(45.0f);
-		hfov = (double)cx / (double)cy * vfov;
+		vfov = DEG_TO_RADF(45.0f);
+		hfov = (float)cx / (float)cy * vfov;
 	} else {
-		hfov = (float)DEG_TO_RAD(45.0f);
-		vfov = (double)cy / (double)cx * hfov;
+		hfov = DEG_TO_RADF(45.0f);
+		vfov = (float)cy / (float)cx * hfov;
 	}
 	m_Camera->Set_View_Plane (hfov, vfov);
 
@@ -808,7 +808,7 @@ TransitionEditDialogClass::Handle_Keypress (void)
 		{
 			Matrix3D tm = m_CharacterObj->Get_Transform ();
 			float deg = (::GetAsyncKeyState (VK_RIGHT) < 0) ? 5.0F : -5.0F;
-			tm.Rotate_Z (DEG_TO_RAD (deg));
+			tm.Rotate_Z (DEG_TO_RADF (deg));
 			m_CharacterObj->Set_Transform (tm);
 		}
 

--- a/Code/Tools/LevelEdit/Utils.cpp
+++ b/Code/Tools/LevelEdit/Utils.cpp
@@ -1316,7 +1316,7 @@ GetWindowFloat (HWND hwnd, bool interpret)
 	if (interpret) {
 		value = ((float)::atol (string_value)) / 100.0F;
 	} else {
-		value = ::atof (string_value);
+		value = ::strtof (string_value, NULL);
 	}
 
 	return value;
@@ -1347,7 +1347,7 @@ GetDlgItemFloat
 	if (interpret) {
 		value = ((float)::atol (string_value)) / 100.0F;
 	} else {
-		value = ::atof (string_value);
+		value = ::strtof (string_value, NULL);
 	}
 
 	return value;
@@ -1866,7 +1866,7 @@ fnEditToFloatProc
 		result				= ::CallWindowProc (old_proc, hwnd, message, wparam, lparam);
 		LPCTSTR string		= (LPCTSTR)lparam;
 		if (::strchr (string, '.') != 0) {
-			float float_value	= ::atof (string);
+			float float_value	= ::strtof (string, NULL);
 			int int_value		= int(float_value * 100);
 			::itoa (int_value, (LPTSTR)lparam, 10);
 		} else {
@@ -2229,7 +2229,7 @@ Perform_Job (LPCTSTR filename, bool delete_on_completion)
 
 	CString granularity_string;
 	::GetPrivateProfileString ("Job Description", "Granularity", "1", granularity_string.GetBufferSetLength (20), 20, filename);
-	float granularity = ::atof (granularity_string);
+	float granularity = ::strtof (granularity_string, NULL);
 
 	CString level_file;
 	::GetPrivateProfileString ("Job Description", "LVL", "", level_file.GetBufferSetLength (MAX_PATH), MAX_PATH, filename);

--- a/Code/Tools/LevelEdit/VisErrorReportDialog.cpp
+++ b/Code/Tools/LevelEdit/VisErrorReportDialog.cpp
@@ -243,7 +243,7 @@ VisErrorReportDialogClass::Re_Sync_Data (void)
 
 	// Reset the range of values in the y-axis
 	int max	= (m_TotalPoints >> 1) - (m_ZoomSlider.GetPos () - 2);
-	m_Graph.Set_Y_Axis_Range (0, max);
+	m_Graph.Set_Y_Axis_Range (0, float(max));
 
 	//
 	//	Add the vis error points to the graph
@@ -338,7 +338,7 @@ VisErrorReportDialogClass::OnVScroll
 {
 	// Reset the range of values in the y-axis
 	int max	= m_TotalPoints - (m_ZoomSlider.GetPos () - 2);
-	m_Graph.Set_Y_Axis_Range (0, max);
+	m_Graph.Set_Y_Axis_Range (0, float(max));
 	SetDlgItemInt (IDC_MAX_POINTS, max);
 
 	//

--- a/Code/Tools/LevelEdit/VisPointGenerator.cpp
+++ b/Code/Tools/LevelEdit/VisPointGenerator.cpp
@@ -68,7 +68,7 @@ const float FLAT_FACE_NORMAL_MIN				= 0.0F;
 const float VIEWPLANE_BOX_HALF_DEPTH		= 0.0005F;
 const float DEF_VIS_SAMPLE_HEIGHT			= 20.0F;		// we sample up to 20 meters above the vis sector
 const float VERTICAL_GRANULARITY				= 5.0F;		// granularity of sampling in the Z axis
-const float DEF_CAM_SIM_POINT_COUNT			= 32.0F;
+const int DEF_CAM_SIM_POINT_COUNT			= 32;
 const float CAMERA_SIM_RADIUS					= 10.0F;
 
 const char * VIS_BIAS_STRING					= "visbias";
@@ -109,8 +109,8 @@ VisPointGeneratorClass::VisPointGeneratorClass (float granularity)
 	// extruded the view plane by one millimeter.
 	// Note: The extents are half-extents.
 	//
-	float y_dim = znear * ::tan (hfov / 2);
-	float z_dim = znear * ::tan (vfov / 2);
+	float y_dim = float(znear * WWMath::Tan (hfov / 2));
+	float z_dim = float(znear * WWMath::Tan (vfov / 2));
 	float max_dim = std::max (y_dim, z_dim);
 	max_dim += 0.001F;
 
@@ -207,7 +207,7 @@ Read_Float_Param (LPCTSTR text, LPCTSTR key, float *value)
 				//
 				char *number_str = new char[index];
 				::lstrcpyn (number_str, key_value, index);
-				(*value) = ::atof (number_str);
+				(*value) = ::strtof (number_str, NULL);
 				delete [] number_str;
 
 				retval = true;
@@ -280,9 +280,9 @@ VisPointGeneratorClass::Submit_Mesh (MeshClass &mesh)
 	//
 	AABoxClass box;
 	mesh.Get_Obj_Space_Bounding_Box (box);
-	int cells_x = (int)fabs(((box.Extent.X * 2) / m_Granularity));
-	int cells_y = (int)fabs(((box.Extent.Y * 2) / m_Granularity));
-	int cells_z = (int)fabs((((box.Extent.Z * 2) + DEF_POINT_RAISE_HEIGHT) / m_Granularity));
+	float cells_x = WWMath::Trunc(WWMath::Fabs(((box.Extent.X * 2) / m_Granularity)));
+	float cells_y = WWMath::Trunc(WWMath::Fabs(((box.Extent.Y * 2) / m_Granularity)));
+	float cells_z = WWMath::Trunc(WWMath::Fabs((((box.Extent.Z * 2) + DEF_POINT_RAISE_HEIGHT) / m_Granularity)));
 	m_Grid.Create_Grid (Vector3 (cells_x + 1, cells_y + 1, cells_z + 1), 0);
 
 	//
@@ -705,7 +705,7 @@ VisPointGeneratorClass::Is_Grid_Cell_Empty (const Vector3 &position)
 	grid_pos.Y = grid_pos.Y / m_Granularity;
 	grid_pos.Z = grid_pos.Z / m_Granularity;
 
-	return (m_Grid.Get_At (grid_pos.X, grid_pos.Y, grid_pos.Z) == NULL);
+	return (m_Grid.Get_At (int(grid_pos.X), int(grid_pos.Y), int(grid_pos.Z)) == NULL);
 }
 
 
@@ -751,7 +751,7 @@ VisPointGeneratorClass::Submit_Point
 	//	Only insert the point into the grid if the grid cell is
 	//	empty.
 	//
-	VisPointInfo *cell_contents = m_Grid.Get_At (grid_pos.X, grid_pos.Y, grid_pos.Z);
+	VisPointInfo *cell_contents = m_Grid.Get_At (int(grid_pos.X), int(grid_pos.Y), int(grid_pos.Z));
 	if ((cell_contents == NULL) ||
 		 ((cell_contents->m_Transform.Get_Translation () - cell_center).Length () > new_point_dist)) {
 
@@ -772,7 +772,7 @@ VisPointGeneratorClass::Submit_Point
 			vis_info->m_DoCameraRing	= do_camera_ring;
 
 			// Insert this point into the grid
-			m_Grid.Set_At (grid_pos.X, grid_pos.Y, grid_pos.Z, vis_info);
+			m_Grid.Set_At (int(grid_pos.X), int(grid_pos.Y), int(grid_pos.Z), vis_info);
 			SAFE_DELETE (cell_contents);
 		}
 	}

--- a/Code/Tools/LevelEdit/VisPointNode.cpp
+++ b/Code/Tools/LevelEdit/VisPointNode.cpp
@@ -243,7 +243,7 @@ VisPointNodeClass::Load_Variables (ChunkLoadClass &cload)
 			{
 				double double_value = 0;
 				cload.Read (&double_value, sizeof (double_value));
-				m_NearClipPlane = double_value;
+				m_NearClipPlane = float(double_value);
 			}
 			break;
 		}

--- a/Code/Tools/LevelEdit/VisSectorSampler.cpp
+++ b/Code/Tools/LevelEdit/VisSectorSampler.cpp
@@ -240,7 +240,7 @@ void VisSectorSamplerClass::Process(RenderObjClass * model)
 
 void VisSectorSamplerClass::Reset(int poly_count)
 {
-	MeshBuilder->Reset(1,poly_count,0.5f*poly_count + 1);
+	MeshBuilder->Reset(1,poly_count,int(0.5f*poly_count + 1));
 }
 
 int VisSectorSamplerClass::Collect_Polygons(RenderObjClass * renderobj)

--- a/Code/Tools/LevelEdit/WeatherPropPage.cpp
+++ b/Code/Tools/LevelEdit/WeatherPropPage.cpp
@@ -119,8 +119,8 @@ BOOL WeatherPropPageClass::OnInitDialog()
 	WeatherMgrClass::Get_Fog_Range (fogstart, fogend);
 	FogStartSpin.SetRange (0, fogstartmax);
 	FogEndSpin.SetRange (0, fogendmax);
-	FogStartSpin.SetPos (fogstart);
-	FogEndSpin.SetPos (fogend);
+	FogStartSpin.SetPos (int(fogstart));
+	FogEndSpin.SetPos (int(fogend));
 
 	// Load the lightning/war-blitz settings into the dialog controls.
 	BackgroundMgrClass::Get_Lightning (lightningintensity, lightningstartdistance, lightningenddistance, lightningheading, lightningdistribution);
@@ -200,9 +200,9 @@ void WeatherPropPageClass::OnFogColor()
 {
 	int red, green, blue;
 
-	red	= MIN (UCHAR_MAX, FogColor.X * ((float) (UCHAR_MAX + 1)));
-	green = MIN (UCHAR_MAX, FogColor.Y * ((float) (UCHAR_MAX + 1)));
-	blue	= MIN (UCHAR_MAX, FogColor.Z * ((float) (UCHAR_MAX + 1)));
+	red	= std::min (UCHAR_MAX, int(FogColor.X * ((float) (UCHAR_MAX + 1))));
+	green = std::min (UCHAR_MAX, int(FogColor.Y * ((float) (UCHAR_MAX + 1))));
+	blue	= std::min (UCHAR_MAX, int(FogColor.Z * ((float) (UCHAR_MAX + 1))));
 	if (::Show_Color_Picker (&red, &green, &blue)) {
 
 		const float ooucharmaxplusone = 1.0f / (UCHAR_MAX + 1);
@@ -236,9 +236,9 @@ void WeatherPropPageClass::OnDrawItem (int nIDCtl, LPDRAWITEMSTRUCT lpDrawItemSt
 	// Fill the button with the appropriate color.
 	dc.Attach (lpDrawItemStruct->hDC);
 
-	r = MIN (UCHAR_MAX, FogColor.X * ((float) (UCHAR_MAX + 1)));
-	g = MIN (UCHAR_MAX, FogColor.Y * ((float) (UCHAR_MAX + 1)));
-	b = MIN (UCHAR_MAX, FogColor.Z * ((float) (UCHAR_MAX + 1)));
+	r = std::min (UCHAR_MAX, int(FogColor.X * ((float) (UCHAR_MAX + 1))));
+	g = std::min (UCHAR_MAX, int(FogColor.Y * ((float) (UCHAR_MAX + 1))));
+	b = std::min (UCHAR_MAX, int(FogColor.Z * ((float) (UCHAR_MAX + 1))));
 	dc.FillSolidRect (&rect, RGB (r, g, b));
 	dc.Detach();
 
@@ -393,7 +393,7 @@ void WeatherPropPageClass::OnOK()
 	WeatherMgrClass::Set_Fog_Enable (IsDlgButtonChecked (IDC_FOG_CHECK) == 1);
 	::Get_Scene_Editor()->Set_Fog_Color (FogColor);
 //	::Get_Scene_Editor()->Set_Fog_Range (FogStartSpin.GetPos(), FogEndSpin.GetPos());
-	WeatherMgrClass::Set_Fog_Range (FogStartSpin.GetPos(), FogEndSpin.GetPos());
+	WeatherMgrClass::Set_Fog_Range (float(FogStartSpin.GetPos()), float(FogEndSpin.GetPos()));
 
 	// Configure lightning/war-blitz.
 	lightningintensity	  = LightningIntensitySlider.GetPos() * oosliderresolution;
@@ -416,7 +416,7 @@ void WeatherPropPageClass::OnOK()
 	}
 
 	// Configure wind.
-	windheading		 = WindHeadingSlider.GetPos();
+	windheading		 = float(WindHeadingSlider.GetPos());
 	windspeed		 = GetWindowFloat (WindSpeedSpin.GetBuddy()->m_hWnd, true);
 	windvariability = WindVariabilitySlider.GetPos() * oosliderresolution;
 	WeatherMgrClass::Set_Wind (windheading, windspeed, windvariability);

--- a/Code/Tools/LevelEdit/ZoneEditDialog.cpp
+++ b/Code/Tools/LevelEdit/ZoneEditDialog.cpp
@@ -171,14 +171,14 @@ ZoneEditDialogClass::OnInitDialog (void)
 	//
 	//	Configure the camera
 	//
-	double hfov = 0;
-	double vfov = 0;
+	float hfov = 0;
+	float vfov = 0;
 	if (cy > cx) {
-		vfov = (float)DEG_TO_RAD(45.0f);
-		hfov = (double)cx / (double)cy * vfov;
+		vfov = DEG_TO_RADF(45.0f);
+		hfov = (float)cx / (float)cy * vfov;
 	} else {
-		hfov = (float)DEG_TO_RAD(45.0f);
-		vfov = (double)cy / (double)cx * hfov;
+		hfov = DEG_TO_RADF(45.0f);
+		vfov = (float)cy / (float)cx * hfov;
 	}
 	m_Camera->Set_View_Plane (hfov, vfov);
 
@@ -1013,7 +1013,7 @@ ZoneEditDialogClass::OnLastFrame (void)
 		//
 		HAnimClass *animation = anim_mgr.Peek_Animation ();
 		if (animation != NULL) {
-			m_RenderObj->Set_Animation (animation, animation->Get_Num_Frames () - 1);
+			m_RenderObj->Set_Animation (animation, float(animation->Get_Num_Frames () - 1));
 		}
 	}
 

--- a/Code/Tools/LevelEdit/editableheightfield.cpp
+++ b/Code/Tools/LevelEdit/editableheightfield.cpp
@@ -1812,10 +1812,10 @@ EditableHeightfieldClass::Create
 				//
 				//	Clip the region to the bitmap
 				//
-				int pixel_x0 = WWMath::Clamp (pixel_x_start, 0, (bmp_info.bmWidth - 1));
-				int pixel_y0 = WWMath::Clamp (pixel_y_start, 0, (bmp_info.bmHeight - 1));
-				int pixel_x1 = WWMath::Clamp (pixel_x_end, 0, (bmp_info.bmWidth - 1));
-				int pixel_y1 = WWMath::Clamp (pixel_y_end, 0, (bmp_info.bmHeight - 1));
+				int pixel_x0 = std::clamp<int> (int(pixel_x_start), 0, (bmp_info.bmWidth - 1));
+				int pixel_y0 = std::clamp<int> (int(pixel_y_start), 0, (bmp_info.bmHeight - 1));
+				int pixel_x1 = std::clamp<int> (int(pixel_x_end), 0, (bmp_info.bmWidth - 1));
+				int pixel_y1 = std::clamp<int> (int(pixel_y_end), 0, (bmp_info.bmHeight - 1));
 				float total_intensity	= 0.0F;
 				int count					= 0;
 

--- a/Code/Tools/RenRem/RenRem.cpp
+++ b/Code/Tools/RenRem/RenRem.cpp
@@ -161,7 +161,7 @@ int main(int argc, char **argv)
 	}
 
 	ServerControl.Allow_Remote_Admin(true);
-	if (ServerControl.Start_Listening(local_port, password, &App_Request_Callback, &App_Response_Callback) == false) {
+	if (ServerControl.Start_Listening((unsigned short)local_port, password, &App_Request_Callback, &App_Response_Callback) == false) {
 		cprintf("Failed to open socket for port %d\n", local_port);
 		WSACleanup();
 		return(0);
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
 	if (RequestBuffer[0] != 0) {
 		Connected = false;
 		GotResponse = false;
-		ServerControl.Send_Message(password, ip, port);
+		ServerControl.Send_Message(password, ip, (unsigned short)port);
 	}
 
 
@@ -228,7 +228,7 @@ int main(int argc, char **argv)
 						}
 
 						if (send) {
-							ServerControl.Send_Message(&CommandBuffer[1], ip, port);
+							ServerControl.Send_Message(&CommandBuffer[1], ip, (unsigned short)port);
 							TruncateFile = true;
 						}
 					}
@@ -273,7 +273,7 @@ int main(int argc, char **argv)
 				Connected = true;
 				GotResponse = false;
 				DumpOutput = true;
-				ServerControl.Send_Message(&RequestBuffer[3], ip, port);
+				ServerControl.Send_Message(&RequestBuffer[3], ip, (unsigned short)port);
 			} else {
 				/*
 				** Must be request response - we are done.

--- a/Code/Tools/W3DView/CameraSettingsDialog.cpp
+++ b/Code/Tools/W3DView/CameraSettingsDialog.cpp
@@ -109,8 +109,8 @@ CameraSettingsDialogClass::OnInitDialog (void)
 	//
 	//	Setup the FOV controls
 	//
-	int hfov_deg = (int)RAD_TO_DEG (camera->Get_Horizontal_FOV ());
-	int vfov_deg = (int)RAD_TO_DEG (camera->Get_Vertical_FOV ());
+	float hfov_deg = WWMath::Trunc(RAD_TO_DEGF (camera->Get_Horizontal_FOV ()));
+	float vfov_deg = WWMath::Trunc(RAD_TO_DEGF (camera->Get_Vertical_FOV ()));
 	::Initialize_Spinner (m_HFOVSpin, hfov_deg, 0.0F, 180.0F);
 	::Initialize_Spinner (m_VFOVSpin, vfov_deg, 0.0F, 180.0F);
 
@@ -119,7 +119,7 @@ CameraSettingsDialogClass::OnInitDialog (void)
 	//
 	float hfov = camera->Get_Horizontal_FOV ();
 	const float constant	= (18.0F / 1000.0F);
-	float lens				= (constant / (::tan (hfov / 2))) * 1000.0F;
+	float lens				= (constant / (WWMath::Tan (hfov / 2))) * 1000.0F;
 	::Initialize_Spinner (m_LensSpin, lens, 1.0F, 200.0F);
 
 	OnFovCheck ();
@@ -154,7 +154,7 @@ CameraSettingsDialogClass::OnOK (void)
 		//
 		float hfov_deg = ::GetDlgItemFloat (m_hWnd, IDC_HFOV_EDIT);
 		float vfov_deg = ::GetDlgItemFloat (m_hWnd, IDC_VFOV_EDIT);
-		camera->Set_View_Plane (DEG_TO_RAD (hfov_deg), DEG_TO_RAD (vfov_deg));
+		camera->Set_View_Plane (DEG_TO_RADF (hfov_deg), DEG_TO_RADF (vfov_deg));
 	}
 
 	//
@@ -257,8 +257,8 @@ CameraSettingsDialogClass::OnReset (void)
 	//
 	//	Update the FOV controls
 	//
-	int hfov_deg = (int)RAD_TO_DEG (camera->Get_Horizontal_FOV ());
-	int vfov_deg = (int)RAD_TO_DEG (camera->Get_Vertical_FOV ());
+	float hfov_deg = WWMath::Trunc(RAD_TO_DEGF (camera->Get_Horizontal_FOV ()));
+	float vfov_deg = WWMath::Trunc(RAD_TO_DEGF (camera->Get_Vertical_FOV ()));
 	::SetDlgItemFloat (m_hWnd, IDC_HFOV_EDIT, hfov_deg);
 	::SetDlgItemFloat (m_hWnd, IDC_VFOV_EDIT, vfov_deg);
 
@@ -266,7 +266,7 @@ CameraSettingsDialogClass::OnReset (void)
 	//	Setup the camera lens controls
 	//
 	float vfov = camera->Get_Vertical_FOV ();
-	float lens = ((::atan ((18.0F / 1000.0F)) / vfov) * 2.0F) * 1000.0F;
+	float lens = ((WWMath::Atan ((18.0F / 1000.0F)) / vfov) * 2.0F) * 1000.0F;
 	::SetDlgItemFloat (m_hWnd, IDC_LENS_EDIT, lens);
 	return ;
 }
@@ -326,7 +326,7 @@ CameraSettingsDialogClass::Update_Camera_Lens (void)
 	//
 	if (hfov > 0) {
 		const float constant	= (18.0F / 1000.0F);
-		float lens				= (constant / (::tan (DEG_TO_RAD (hfov) / 2))) * 1000.0F;
+		float lens				= (constant / (WWMath::Tan (DEG_TO_RADF (hfov) / 2))) * 1000.0F;
 		::SetDlgItemFloat (m_hWnd, IDC_LENS_EDIT, lens);
 	}
 
@@ -352,14 +352,14 @@ CameraSettingsDialogClass::Update_FOV (void)
 	//
 	if (lens > 0) {
 		const float constant	= (18.0F / 1000.0F);
-		float hfov				= (::atan (constant / lens) * 2.0F);
+		float hfov				= (WWMath::Atan (constant / lens) * 2.0F);
 		float vfov				= (3 * hfov / 4);
 
 		//
 		//	Pass the new FOV settings onto the dialog
 		//
-		::SetDlgItemFloat (m_hWnd, IDC_HFOV_EDIT, RAD_TO_DEG (hfov));
-		::SetDlgItemFloat (m_hWnd, IDC_VFOV_EDIT, RAD_TO_DEG (vfov));
+		::SetDlgItemFloat (m_hWnd, IDC_HFOV_EDIT, RAD_TO_DEGF (hfov));
+		::SetDlgItemFloat (m_hWnd, IDC_VFOV_EDIT, RAD_TO_DEGF (vfov));
 	}
 	return ;
 }

--- a/Code/Tools/W3DView/ColorSelectionDialog.cpp
+++ b/Code/Tools/W3DView/ColorSelectionDialog.cpp
@@ -327,12 +327,12 @@ ColorSelectionDialogClass::Update_Sliders (int slider_id)
 	}
 
 	// Update the edit controls (and their spin controls)
-	float red_val = m_RedSlider.GetPos ();
-	float green_val = m_GreenSlider.GetPos ();
-	float blue_val = m_BlueSlider.GetPos ();
-	m_RedSpin.SetPos (red_val);
-	m_GreenSpin.SetPos (green_val);
-	m_BlueSpin.SetPos (blue_val);
+	float red_val = float(m_RedSlider.GetPos ());
+	float green_val = float(m_GreenSlider.GetPos ());
+	float blue_val = float(m_BlueSlider.GetPos ());
+	m_RedSpin.SetPos (int(red_val));
+	m_GreenSpin.SetPos (int(green_val));
+	m_BlueSpin.SetPos (int(blue_val));
 
 	// Record the selected color for later use
 	m_PaintColor.X = red_val / 255.00F;

--- a/Code/Tools/W3DView/EditLODDialog.cpp
+++ b/Code/Tools/W3DView/EditLODDialog.cpp
@@ -191,7 +191,7 @@ CEditLODDialog::OnOK (void)
 
                 // Convert the string to a float and pass this value
                 // onto the LOD manager
-                float switchDistance = ::atof (stringTemp);
+                float switchDistance = strtof (stringTemp, NULL);
                 pLOD->Set_Switch_Up_Dist (iObject, switchDistance);
 
                 // Get the switch down distance from the list control
@@ -199,7 +199,7 @@ CEditLODDialog::OnOK (void)
 
                 // Convert the string to a float and pass this value
                 // onto the LOD manager
-                switchDistance = ::atof (stringTemp);
+                switchDistance = strtof (stringTemp, NULL);
                 pLOD->Set_Switch_Down_Dist (iObject, switchDistance);
             }
         }
@@ -358,7 +358,7 @@ CEditLODDialog::ResetControls (int iIndex)
     SetDlgItemText (IDC_SWITCH_UP_EDIT, stringTemp);
 
     // Set the current position of the spin control
-    float switchDistance = ::atof (stringTemp);
+    float switchDistance = strtof (stringTemp, NULL);
     m_switchUpSpin.SetPos (int(switchDistance * 10.00F));
 
     //
@@ -372,7 +372,7 @@ CEditLODDialog::ResetControls (int iIndex)
     SetDlgItemText (IDC_SWITCH_DN_EDIT, stringTemp);
 
     // Set the current position of the spin control
-    switchDistance = ::atof (stringTemp);
+    switchDistance = strtof (stringTemp, NULL);
     m_switchDownSpin.SetPos (int(switchDistance * 10.00F));
     return ;
 }
@@ -404,7 +404,7 @@ CEditLODDialog::OnUpdateSwitchDnEdit (void)
     // Get the switching distance from the edit control
     CString stringTemp;
     GetDlgItemText (IDC_SWITCH_DN_EDIT, stringTemp);
-    float newVal = ::atof (stringTemp);
+    float newVal = strtof (stringTemp, NULL);
 
     // Change the switching distance in the spin control
     m_switchDownSpin.SetPos (int(newVal * 10.00F));
@@ -429,7 +429,7 @@ void CEditLODDialog::OnUpdateSwitchUpEdit (void)
     // Get the switching distance from the edit control
     CString stringTemp;
     GetDlgItemText (IDC_SWITCH_UP_EDIT, stringTemp);
-    float newVal = ::atof (stringTemp);
+    float newVal = strtof (stringTemp, NULL);
 
     // Change the switching distance in the spin control
     m_switchUpSpin.SetPos (int(newVal * 10.00F));
@@ -454,11 +454,11 @@ void CEditLODDialog::OnRecalc (void)
     // Get the up switching distance from the edit control
     CString stringTemp;
     GetDlgItemText (IDC_SWITCH_UP_EDIT, stringTemp);
-    float switchUp = ::atof (stringTemp);
+    float switchUp = strtof (stringTemp, NULL);
 
     // Get the down switching distance from the edit control
     GetDlgItemText (IDC_SWITCH_DN_EDIT, stringTemp);
-    float switchDown = ::atof (stringTemp);
+    float switchDown = strtof (stringTemp, NULL);
 
     if (switchUp < switchDown)
     {

--- a/Code/Tools/W3DView/EmitterColorPropPage.cpp
+++ b/Code/Tools/W3DView/EmitterColorPropPage.cpp
@@ -179,10 +179,10 @@ EmitterColorPropPageClass::OnInitDialog (void)
 	m_GreenRandomSpin.SetRange (0, 255);
 	m_BlueRandomSpin.SetRange (0, 255);
 
-	m_OpacityRandomSpin.SetPos (m_OrigOpacities.Rand * 100);
-	m_RedRandomSpin.SetPos (m_OrigColors.Rand.X * 255);
-	m_GreenRandomSpin.SetPos (m_OrigColors.Rand.Y * 255);
-	m_BlueRandomSpin.SetPos (m_OrigColors.Rand.Z * 255);
+	m_OpacityRandomSpin.SetPos (int(m_OrigOpacities.Rand * 100));
+	m_RedRandomSpin.SetPos (int(m_OrigColors.Rand.X * 255));
+	m_GreenRandomSpin.SetPos (int(m_OrigColors.Rand.Y * 255));
+	m_BlueRandomSpin.SetPos (int(m_OrigColors.Rand.Z * 255));
 
 	//
 	//	Reset the color bars
@@ -333,9 +333,9 @@ EmitterColorPropPageClass::OnNotify
 				if (Show_Color_Picker (&red, &green, &blue)) {
 					m_ColorBar->Modify_Point (color_bar_hdr->key_index,
 														color_bar_hdr->position,
-														red,
-														green,
-														blue);
+														(float)red,
+														(float)green,
+														(float)blue);
 
 					// Update the emitter
 					Update_Colors ();
@@ -358,7 +358,7 @@ EmitterColorPropPageClass::OnNotify
 			// Update the emitter
 			NMUPDOWN *pudnotif = (NMUPDOWN *)lParam;
 			if (pudnotif->hdr.code == UDN_DELTAPOS) {
-				float pos = (pudnotif->iPos + pudnotif->iDelta);
+				float pos = float(pudnotif->iPos + pudnotif->iDelta);
 				m_CurrentColors.Rand.X = pos / 255.0F;
 				m_pEmitterList->Set_Color_Keyframes (m_CurrentColors);
 				SetModified ();
@@ -371,7 +371,7 @@ EmitterColorPropPageClass::OnNotify
 			// Update the emitter
 			NMUPDOWN *pudnotif = (NMUPDOWN *)lParam;
 			if (pudnotif->hdr.code == UDN_DELTAPOS) {
-				float pos = (pudnotif->iPos + pudnotif->iDelta);
+				float pos = float(pudnotif->iPos + pudnotif->iDelta);
 				m_CurrentColors.Rand.Y = pos / 255.0F;
 				m_pEmitterList->Set_Color_Keyframes (m_CurrentColors);
 				SetModified ();
@@ -384,7 +384,7 @@ EmitterColorPropPageClass::OnNotify
 			// Update the emitter
 			NMUPDOWN *pudnotif = (NMUPDOWN *)lParam;
 			if (pudnotif->hdr.code == UDN_DELTAPOS) {
-				float pos = (pudnotif->iPos + pudnotif->iDelta);
+				float pos = float(pudnotif->iPos + pudnotif->iDelta);
 				m_CurrentColors.Rand.Z = pos / 255.0F;
 				m_pEmitterList->Set_Color_Keyframes (m_CurrentColors);
 				SetModified ();
@@ -397,7 +397,7 @@ EmitterColorPropPageClass::OnNotify
 			// Update the emitter
 			NMUPDOWN *pudnotif = (NMUPDOWN *)lParam;
 			if (pudnotif->hdr.code == UDN_DELTAPOS) {
-				float pos = (pudnotif->iPos + pudnotif->iDelta);
+				float pos = float(pudnotif->iPos + pudnotif->iDelta);
 				m_CurrentOpacities.Rand = pos / 100.0F;
 				m_pEmitterList->Set_Opacity_Keyframes (m_CurrentOpacities);
 				SetModified ();

--- a/Code/Tools/W3DView/EmitterParticlePropPage.cpp
+++ b/Code/Tools/W3DView/EmitterParticlePropPage.cpp
@@ -112,7 +112,7 @@ EmitterParticlePropPageClass::Initialize (void)
 		//
 		m_Rate			= m_pEmitterList->Get_Emission_Rate ();
 		m_BurstSize		= m_pEmitterList->Get_Burst_Size ();
-		m_MaxParticles	= m_pEmitterList->Get_Max_Emissions ();
+		m_MaxParticles	= int(m_pEmitterList->Get_Max_Emissions ());
 		m_Randomizer	= m_pEmitterList->Get_Creation_Volume ();
 	}
 
@@ -175,7 +175,7 @@ EmitterParticlePropPageClass::OnApply (void)
 	//
 	m_pEmitterList->Set_Emission_Rate (m_Rate);
 	m_pEmitterList->Set_Burst_Size (m_BurstSize);
-	m_pEmitterList->Set_Max_Emissions (m_MaxParticles);
+	m_pEmitterList->Set_Max_Emissions (float(m_MaxParticles));
 	m_pEmitterList->Set_Creation_Volume (m_Randomizer->Clone ());
 
 	// Allow the base class to process this message

--- a/Code/Tools/W3DView/GraphicView.cpp
+++ b/Code/Tools/W3DView/GraphicView.cpp
@@ -451,7 +451,7 @@ CGraphicView::RepaintView
 
 		// Update the W3D frame times according to our elapsed tick count
 		if (ticks_to_use == 0) {
-			WW3D::Sync (WW3D::Get_Sync_Time() + (ticks_elapsed * m_animationSpeed));
+			WW3D::Sync (int(WW3D::Get_Sync_Time() + (ticks_elapsed * m_animationSpeed)));
 		} else {
 			WW3D::Sync (WW3D::Get_Sync_Time() + ticks_to_use);
 		}
@@ -559,7 +559,7 @@ CGraphicView::RepaintView
 		//
 		//	Update the frame time in the status bar
 		//
-		((CMainFrame *)::AfxGetMainWnd ())->Update_Frame_Time (clock_cycles);
+		((CMainFrame *)::AfxGetMainWnd ())->Update_Frame_Time (DWORD(clock_cycles));
 	}
 
 	_already_painting = false;
@@ -1686,7 +1686,7 @@ CGraphicView::Set_FOV (double hfov, double vfov, bool force)
 	CW3DViewDoc *doc = (CW3DViewDoc *)GetDocument();
 
 	if (force || (doc->Is_FOV_Manual () == false)) {
-		m_pCamera->Set_View_Plane (hfov, vfov);
+		m_pCamera->Set_View_Plane (float(hfov), float(vfov));
 	}
 
 	return ;

--- a/Code/Tools/W3DView/MainFrm.cpp
+++ b/Code/Tools/W3DView/MainFrm.cpp
@@ -590,7 +590,7 @@ CMainFrame::OnCreateClient
 				// restore gamma settings
 				int setting=::AfxGetApp()->GetProfileInt("Config","EnableGamma",0);
 				if (setting) {
-					float gamma=::AfxGetApp()->GetProfileInt("Config","Gamma",10);
+					float gamma=float(::AfxGetApp()->GetProfileInt("Config","Gamma",10));
 					gamma=gamma/10.0f;
 					if (gamma<1.0) gamma=1.0;
 					if (gamma>3.0) gamma=3.0;
@@ -2218,7 +2218,7 @@ CMainFrame::Select_Device (bool show_dlg)
 					if (::strstr (driver_name, "glide2") != NULL) {
 
 						// Is this glide driver an acceptable version?
-						float driver_version = ::atof (string_version);
+						float driver_version = ::strtof (string_version, NULL);
 						bool is_voodoo2 = (::strstr (chipset , "VOODOO2") != NULL);
 						if ((is_voodoo2 && (driver_version < 2.54F)) ||
 							 ((is_voodoo2 == false) && (driver_version < 2.46F))) {
@@ -4427,7 +4427,7 @@ void CMainFrame::OnEnableGammaCorrection()
 	enable_gamma=!enable_gamma;
 	::AfxGetApp()->WriteProfileInt("Config", "EnableGamma", enable_gamma?1:0);
 	if (enable_gamma) {
-		float gamma=::AfxGetApp()->GetProfileInt("Config","Gamma",10);
+		float gamma=float(::AfxGetApp()->GetProfileInt("Config","Gamma",10));
 		gamma=gamma/10.0f;
 		if (gamma<1.0) gamma=1.0;
 		if (gamma>3.0) gamma=3.0;

--- a/Code/Tools/W3DView/OpacityVectorDialog.cpp
+++ b/Code/Tools/W3DView/OpacityVectorDialog.cpp
@@ -100,7 +100,7 @@ OpacityVectorDialogClass::OnInitDialog (void)
 	m_OpacityBar->Modify_Point (0, 0, 255, 255, 255);
 	m_OpacityBar->Insert_Point (1, 10, 0, 0, 0);
 
-	float value =  ::atan (((m_Value.intensity / 10.0F) * 11.0F)) / DEG_TO_RAD (84.5) * 10.0F;
+	float value =  WWMath::Atan (((m_Value.intensity / 10.0F) * 11.0F)) / DEG_TO_RADF (84.5f) * 10.0F;
 	m_OpacityBar->Set_Selection_Pos (value);
 
 	//
@@ -152,8 +152,8 @@ OpacityVectorDialogClass::OnInitDialog (void)
 
 	EulerAnglesClass euler_angle (rotation, EulerOrderXYZr);
 	//float x_rot = RAD_TO_DEG (euler_angle.Get_Angle (0));
-	float y_rot = RAD_TO_DEG (euler_angle.Get_Angle (1));
-	float z_rot = RAD_TO_DEG (euler_angle.Get_Angle (2));
+	float y_rot = RAD_TO_DEGF (euler_angle.Get_Angle (1));
+	float z_rot = RAD_TO_DEGF (euler_angle.Get_Angle (2));
 
 	//float y_rot = RAD_TO_DEG (rotation.Get_Y_Rotation ());
 	//float z_rot = RAD_TO_DEG (rotation.Get_Z_Rotation ());
@@ -218,7 +218,7 @@ OpacityVectorDialogClass::Update_Value (void)
 
 	value.angle = ::Build_Quaternion (rot_mat);
 
-	float percent = ::tan ((m_OpacityBar->Get_Selection_Pos () / 10.0F) * DEG_TO_RAD (84.5)) / 11.0F;
+	float percent = WWMath::Tan ((m_OpacityBar->Get_Selection_Pos () / 10.0F) * DEG_TO_RADF (84.5F)) / 11.0F;
 	percent = std::clamp (percent, 0.0F, 1.0F);
 
 	value.intensity = 10.0F * percent;

--- a/Code/Tools/W3DView/RingColorPropPage.cpp
+++ b/Code/Tools/W3DView/RingColorPropPage.cpp
@@ -271,9 +271,9 @@ RingColorPropPageClass::OnNotify
 				if (Show_Color_Picker (&red, &green, &blue)) {
 					m_ColorBar->Modify_Point (	color_bar_hdr->key_index,
 														color_bar_hdr->position,
-														red,
-														green,
-														blue);
+														float(red),
+														float(green),
+														float(blue));
 
 					//
 					// Update the object

--- a/Code/Tools/W3DView/SceneLightDialog.cpp
+++ b/Code/Tools/W3DView/SceneLightDialog.cpp
@@ -155,15 +155,15 @@ CSceneLightDialog::OnInitDialog (void)
 
 		// Set-up the spin controls
 		m_DistanceSpin.SetRange32 (0, 1000000);
-		m_DistanceSpin.SetPos ((distance * 100));
+		m_DistanceSpin.SetPos (int(distance * 100));
 		m_StartAttenSpin.SetRange32 (0, 1000000);
-		m_StartAttenSpin.SetPos ((start * 100));
+		m_StartAttenSpin.SetPos (int(start * 100));
 		m_EndAttenSpin.SetRange32 (0, 1000000);
-		m_EndAttenSpin.SetPos ((end * 100));
+		m_EndAttenSpin.SetPos (int(end * 100));
 
 		// Setup the slider control
 		m_IntensitySlider.SetRange (0, 100);
-		m_IntensitySlider.SetPos (intensity * 100.0F);
+		m_IntensitySlider.SetPos (int(intensity * 100.0F));
 
 		// Record the initial settings so we can restore them on cancel
 		m_InitialStartAtten = start;

--- a/Code/Tools/W3DView/SceneLightDialog.cpp
+++ b/Code/Tools/W3DView/SceneLightDialog.cpp
@@ -127,8 +127,8 @@ CSceneLightDialog::OnInitDialog (void)
 		Set_Color_Control_State (diffuse);
 
 		// Get the light's attenuation
-		double start = 0;
-		double end = 0;
+		float start = 0;
+		float end = 0;
 		pCDoc->GetSceneLight ()->Get_Far_Attenuation_Range (start, end);
 		BOOL atten_on = pCDoc->GetSceneLight ()->Get_Flag (LightClass::FAR_ATTENUATION);
 		SendDlgItemMessage (IDC_ATTENUATION_CHECK, BM_SETCHECK, (WPARAM)atten_on);

--- a/Code/Tools/W3DView/ScreenCursor.cpp
+++ b/Code/Tools/W3DView/ScreenCursor.cpp
@@ -214,8 +214,8 @@ ScreenCursorClass::On_Frame_Update (void)
 	//
 	float normal_width = ((float)m_Width) / (float)screen_cx;
 	float normal_height = ((float)m_Height) / (float)screen_cy;
-	float x_pos = floor(m_ScreenPos.X * ((float)screen_cx) + 0.5F) / ((float)screen_cx);
-	float y_pos = floor(m_ScreenPos.Y * ((float)screen_cy) + 0.5F) / ((float)screen_cy);
+	float x_pos = WWMath::Floor(m_ScreenPos.X * ((float)screen_cx) + 0.5F) / ((float)screen_cx);
+	float y_pos = WWMath::Floor(m_ScreenPos.Y * ((float)screen_cy) + 0.5F) / ((float)screen_cy);
 	float z_pos = 0;
 
 	//
@@ -295,9 +295,9 @@ ScreenCursorClass::Render (RenderInfoClass & /* rinfo */)
 		DynamicIBAccessClass::WriteLockClass lock(&ibaccess);
 		unsigned short * indices = lock.Get_Index_Array();
 		for (int i=0; i<FACE_COUNT; i++) {
-			indices[3*i+0] = m_Triangles[i][0];
-			indices[3*i+1] = m_Triangles[i][1];
-			indices[3*i+2] = m_Triangles[i][2];
+			indices[3*i+0] = (unsigned short)m_Triangles[i][0];
+			indices[3*i+1] = (unsigned short)m_Triangles[i][1];
+			indices[3*i+2] = (unsigned short)m_Triangles[i][2];
 		}
 	}
 
@@ -334,7 +334,7 @@ void
 ScreenCursorClass::Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const
 {
 	sphere.Center = Get_Transform().Get_Translation();
-	sphere.Radius = std::max (m_Width, m_Height);
+	sphere.Radius = float(std::max (m_Width, m_Height));
 }
 
 
@@ -348,7 +348,7 @@ ScreenCursorClass::Get_Obj_Space_Bounding_Box(AABoxClass & box) const
 {
 	Matrix3D transform = Get_Transform ();
 	box.Center = transform.Get_Translation ();
-	box.Extent.Set(0.1F, m_Width, m_Height);
+	box.Extent.Set(0.1F, float(m_Width), float(m_Height));
 }
 
 

--- a/Code/Tools/W3DView/SoundEditDialog.cpp
+++ b/Code/Tools/W3DView/SoundEditDialog.cpp
@@ -169,7 +169,7 @@ SoundEditDialogClass::OnInitDialog (void)
 		priority				= sound->Peek_Priority ();
 		is_3d					= (sound_3d != NULL);
 		is_music				= (sound->Get_Type () == AudibleSoundClass::TYPE_MUSIC);
-		loop_count			= sound->Get_Loop_Count ();
+		loop_count			= float(sound->Get_Loop_Count ());
 		volume				= sound->Get_Volume ();
 
 		if (sound_3d != NULL) {

--- a/Code/Tools/W3DView/SphereColorPropPage.cpp
+++ b/Code/Tools/W3DView/SphereColorPropPage.cpp
@@ -324,9 +324,9 @@ SphereColorPropPageClass::OnNotify
 				if (Show_Color_Picker (&red, &green, &blue)) {
 					m_ColorBar->Modify_Point (	color_bar_hdr->key_index,
 														color_bar_hdr->position,
-														red,
-														green,
-														blue);
+														float(red),
+														float(green),
+														float(blue));
 
 					//
 					// Update the object

--- a/Code/Tools/W3DView/Utils.cpp
+++ b/Code/Tools/W3DView/Utils.cpp
@@ -201,7 +201,7 @@ GetDlgItemFloat
 	::GetDlgItemText (hdlg, child_id, string_value, sizeof (string_value));
 
 	// Convert the string to a float and return the value
-	return ::atof (string_value);
+	return ::strtof (string_value, NULL);
 }
 
 
@@ -365,7 +365,7 @@ GetWindowFloat (HWND hwnd)
 	::GetWindowText (hwnd, string_value, sizeof (string_value));
 
 	// Convert the string to a float and return the value
-	return ::atof (string_value);
+	return ::strtof (string_value, NULL);
 }
 
 

--- a/Code/Tools/W3DView/W3DViewDoc.cpp
+++ b/Code/Tools/W3DView/W3DViewDoc.cpp
@@ -1634,8 +1634,8 @@ CW3DViewDoc::SaveSettings
                                          (LPCTSTR)stringCompleteFilename);
 
             // Write the start attenuation out to the file
-				double start = 0;
-				double end = 0;
+				float start = 0;
+				float end = 0;
 				m_pCSceneLight->Get_Far_Attenuation_Range (start, end);
             stringValue.Format ("%f", start);
             ::WritePrivateProfileString ("Settings",

--- a/Code/Tools/W3DView/W3DViewDoc.cpp
+++ b/Code/Tools/W3DView/W3DViewDoc.cpp
@@ -818,7 +818,7 @@ CW3DViewDoc::StepAnimation (int iFrameInc)
 			m_animTime = 0.00F;
 		}
 		else if (m_CurrentFrame < 0) {
-			m_CurrentFrame = iTotalFrames-1;
+			m_CurrentFrame = float(iTotalFrames-1);
 		}
 
 		//
@@ -826,7 +826,7 @@ CW3DViewDoc::StepAnimation (int iFrameInc)
 		//
 		float frame_rate = m_pCAnimation->Get_Frame_Rate ();
 		float anim_speed = ::Get_Graphic_View ()->GetAnimationSpeed ();
-		((CMainFrame *)::AfxGetMainWnd ())->UpdateFrameCount (m_CurrentFrame, iTotalFrames - 1, frame_rate * anim_speed);
+		((CMainFrame *)::AfxGetMainWnd ())->UpdateFrameCount (int(m_CurrentFrame), iTotalFrames - 1, frame_rate * anim_speed);
 
 		//
 		// Update the animation frame
@@ -1103,7 +1103,7 @@ CW3DViewDoc::UpdateFrame (float relativeTimeSlice)
 		// Update the status bar on the main window
 		//
 		float anim_speed = ::Get_Graphic_View ()->GetAnimationSpeed ();
-		((CMainFrame *)::AfxGetMainWnd ())->UpdateFrameCount (m_CurrentFrame, total_frames - 1, frame_rate * anim_speed);
+		((CMainFrame *)::AfxGetMainWnd ())->UpdateFrameCount (int(m_CurrentFrame), total_frames - 1, frame_rate * anim_speed);
 
 		if (m_pCAnimCombo) {
 
@@ -1118,7 +1118,7 @@ CW3DViewDoc::UpdateFrame (float relativeTimeSlice)
 		} else if (m_bAnimBlend) {
 			m_pCRenderObj->Set_Animation (m_pCAnimation, m_CurrentFrame);
 		} else {
-			m_pCRenderObj->Set_Animation (m_pCAnimation, (int)m_CurrentFrame);
+			m_pCRenderObj->Set_Animation (m_pCAnimation, WWMath::Trunc(m_CurrentFrame));
 		}
 
 		Update_Camera ();
@@ -2443,7 +2443,7 @@ CW3DViewDoc::Make_Movie (void)
 		WW3D::Start_Movie_Capture ("Grab", 30);
 		WW3D::Pause_Movie (true);
 
-		float frames = m_pCAnimation->Get_Num_Frames ();
+		float frames = float(m_pCAnimation->Get_Num_Frames ());
 		float frame_inc = m_pCAnimation->Get_Frame_Rate () / 30.0F;
 		DWORD ticks = 1000 / 30;
 
@@ -3048,8 +3048,8 @@ CW3DViewDoc::Load_Camera_Settings (void)
 				CString hfov_string = theApp.GetProfileString ("Config", "hfov", "0");
 				CString vfov_string = theApp.GetProfileString ("Config", "vfov", "0");
 
-				double hfov = ::atof (hfov_string);
-				double vfov = ::atof (vfov_string);
+				float hfov = ::strtof (hfov_string, NULL);
+				float vfov = ::strtof (vfov_string, NULL);
 
 				camera->Set_View_Plane (hfov, vfov);
 			}
@@ -3062,8 +3062,8 @@ CW3DViewDoc::Load_Camera_Settings (void)
 				CString znear_string	= theApp.GetProfileString ("Config", "znear", "0.1F");
 				CString zfar_string	= theApp.GetProfileString ("Config", "zfar", "100.0F");
 
-				float znear	= ::atof (znear_string);
-				float zfar		= ::atof (zfar_string);
+				float znear	= ::strtof (znear_string, NULL);
+				float zfar		= ::strtof (zfar_string, NULL);
 
 				camera->Set_Clip_Planes (znear, zfar);
 

--- a/Code/Tools/WWConfig/PerformanceConfigDialog.cpp
+++ b/Code/Tools/WWConfig/PerformanceConfigDialog.cpp
@@ -303,7 +303,7 @@ PerformanceConfigDialogClass::Build_Expert_Window_List (void)
 	//
 	CRect rect;
 	::GetWindowRect (::GetDlgItem (m_hWnd, IDC_EXPERT_CHECK), &rect);
-	float y_pos = rect.top;
+	LONG y_pos = rect.top;
 
 	//
 	//	Loop over all the child windows of the dialog

--- a/Code/WWAudio/AudibleSound.cpp
+++ b/Code/WWAudio/AudibleSound.cpp
@@ -499,7 +499,7 @@ AudibleSoundClass::Play (bool alloc_handle)
 			m_SoundHandle->Start_Sample ();
 		}
 
-		m_CurrentPosition	= m_StartOffset * m_Length;
+		m_CurrentPosition	= unsigned(m_StartOffset * m_Length);
 		if (m_CurrentPosition > 0) {
 			Seek (m_CurrentPosition);
 		}

--- a/Code/WWAudio/AudibleSound.h
+++ b/Code/WWAudio/AudibleSound.h
@@ -237,7 +237,7 @@ class AudibleSoundClass : public SoundSceneObjClass
 		//
 		virtual unsigned int	Get_Duration (void) const								{ return m_Length; }
 		virtual unsigned int	Get_Play_Position (void) const						{ return m_CurrentPosition; }
-		virtual void				Set_Play_Position (float position)					{ Seek (position * m_Length); }
+		virtual void				Set_Play_Position (float position)					{ Seek (unsigned(position * m_Length)); }
 		virtual void				Set_Play_Position (unsigned int milliseconds)	{ Seek (milliseconds); }
 
 		virtual void				Set_Start_Offset (float offset)						{ m_StartOffset = offset; }

--- a/Code/WWAudio/miles/MilesAudio.cpp
+++ b/Code/WWAudio/miles/MilesAudio.cpp
@@ -97,7 +97,7 @@ MilesAudioClass::MilesAudioClass (bool lite)
 
 	_theInstance = this;
 
-	m_Max3DBufferSize = m_Max3DBufferSize * 2.0F;
+	m_Max3DBufferSize *= 2;
 
 	return;
 }
@@ -244,8 +244,8 @@ MilesAudioClass::Open_2D_Device
 	wave_format.wf.nChannels = stereo ? 2 : 1;
 	wave_format.wf.nSamplesPerSec = hertz;
 	wave_format.wf.nAvgBytesPerSec = (wave_format.wf.nChannels * wave_format.wf.nSamplesPerSec * bits) >> 3;
-	wave_format.wf.nBlockAlign = (wave_format.wf.nChannels * bits) >> 3;
-	wave_format.wBitsPerSample = bits;
+	wave_format.wf.nBlockAlign = WORD((wave_format.wf.nChannels * bits) >> 3);
+	wave_format.wBitsPerSample = WORD(bits);
 	DRIVER_TYPE_2D type = DRIVER2D_ERROR;
 
 	while (((type = Open_2D_Device (&wave_format.wf)) == DRIVER2D_ERROR) &&
@@ -256,7 +256,7 @@ MilesAudioClass::Open_2D_Device
 		//
 		wave_format.wf.nSamplesPerSec = wave_format.wf.nSamplesPerSec >> 1;
 		wave_format.wf.nAvgBytesPerSec = (wave_format.wf.nChannels * wave_format.wf.nSamplesPerSec * bits) >> 3;
-		wave_format.wf.nBlockAlign = (wave_format.wf.nChannels * bits) >> 3;
+		wave_format.wf.nBlockAlign = WORD((wave_format.wf.nChannels * bits) >> 3);
 	}
 
 	// Pass this structure onto the function that actually opens the device

--- a/Code/WWMath/aabox.h
+++ b/Code/WWMath/aabox.h
@@ -113,7 +113,7 @@ public:
 	void		Transform(const Matrix3D & tm);
 	void		Translate(const Vector3 & pos);
 
-	WWINLINE float Volume(void) const { return 2.0*Extent.X * 2.0*Extent.Y * 2.0*Extent.Z; }
+	WWINLINE float Volume(void) const { return 2.0f*Extent.X * 2.0f*Extent.Y * 2.0f*Extent.Z; }
 	WWINLINE bool		Contains(const Vector3 & point) const;
 	WWINLINE bool		Contains(const AABoxClass & other_box) const;
 	WWINLINE bool		Contains(const MinMaxAABoxClass & other_box) const;

--- a/Code/WWMath/colmathaabox.cpp
+++ b/Code/WWMath/colmathaabox.cpp
@@ -583,7 +583,7 @@ exit:
 
 		result->Fraction = context.MaxFrac;
 		result->Normal.Set(0,0,0);
-		result->Normal[context.AxisId] = -context.Side;
+		result->Normal[context.AxisId] = float(-context.Side);
 
 		if (result->ComputeContactPoint) {
 			//WWASSERT(0); // TODO

--- a/Code/WWMath/colmathaabtri.cpp
+++ b/Code/WWMath/colmathaabtri.cpp
@@ -37,7 +37,6 @@
  *   aabtri_check_cross_axis -- projects aab and tri onto a "cross" axis                       *
  *   aabtri_check_basis_axis -- projects the aab and tri onto a basis axis                     *
  *   aabtri_check_normal_axis -- project the box and tri onto the tri-normal                   *
- *   eval_side -- returns -1,0,+1 depending on the sign of val and side                        *
  *   aabtri_compute_contact_normal -- computes the normal of the collision                     *
  *   CollisionMath::Collide -- collide an aabox into a triangle                                *
  *   aabtri_intersect_cross_axis -- intersection check for a "cross-product" axis              *
@@ -282,9 +281,9 @@ static inline bool aabtri_check_axis(void)
 		dist = -dist;
 		axismove = -axismove;
 		CollisionContext.TestAxis = -CollisionContext.TestAxis;
-		CollisionContext.TestSide = -1.0f;
+		CollisionContext.TestSide = -1;
 	} else {
-		CollisionContext.TestSide = 1.0f;
+		CollisionContext.TestSide = 1;
 	}
 
 	// compute coordinates of the leading edge of the box at t0 and t1
@@ -340,9 +339,9 @@ static inline bool aabtri_check_cross_axis
 		axismove = -axismove;
 		dp = -dp;
 		CollisionContext.TestAxis = -CollisionContext.TestAxis;
-		CollisionContext.TestSide = -1.0f;
+		CollisionContext.TestSide = -1;
 	} else {
-		CollisionContext.TestSide = 1.0f;
+		CollisionContext.TestSide = 1;
 	}
 
 	// compute coordinates of the leading edge of the box at t1
@@ -395,9 +394,9 @@ static inline bool aabtri_check_basis_axis
 		dp1 = -dp1;
 		dp2 = -dp2;
 		CollisionContext.TestAxis = -CollisionContext.TestAxis;
-		CollisionContext.TestSide = -1.0f;
+		CollisionContext.TestSide = -1;
 	} else {
-		CollisionContext.TestSide = 1.0f;
+		CollisionContext.TestSide = 1;
 	}
 
 	// this is the "optimization", leb0 = one of the extents
@@ -444,9 +443,9 @@ static inline bool aabtri_check_normal_axis(void)
 		dist = -dist;
 		axismove = -axismove;
 		CollisionContext.TestAxis = -CollisionContext.TestAxis;
-		CollisionContext.TestSide = -1.0f;
+		CollisionContext.TestSide = -1;
 	} else {
-		CollisionContext.TestSide = 1.0f;
+		CollisionContext.TestSide = 1;
 	}
 
 	leb0 =	CollisionContext.Box->Extent.X * WWMath::Fabs(CollisionContext.AN[0]) +
@@ -457,29 +456,6 @@ static inline bool aabtri_check_normal_axis(void)
 	lp = dist;	// this is the "optimization", don't have to find lp
 
 	return aabtri_separation_test(/*CollisionContext,*/lp,leb0,leb1);
-}
-
-/***********************************************************************************************
- * eval_side -- returns -1,0,+1 depending on the sign of val and side                          *
- *                                                                                             *
- * INPUT:                                                                                      *
- *                                                                                             *
- * OUTPUT:                                                                                     *
- *                                                                                             *
- * WARNINGS:                                                                                   *
- *                                                                                             *
- * HISTORY:                                                                                    *
- *   4/8/99     GTH : Created.                                                                 *
- *=============================================================================================*/
-static inline float eval_side(float val,int side)
-{
-	if (val > 0.0f) {
-		return side;
-	} else if (val < 0.0f) {
-		return -side;
-	} else {
-		return 0.0f;
-	}
 }
 
 /***********************************************************************************************
@@ -507,52 +483,52 @@ static inline void aabtri_compute_contact_normal
 			set_norm.Normalize();
 			break;
 		case AXIS_N:
-			set_norm = -CollisionContext.Side * CollisionContext.N;
+			set_norm = float(-CollisionContext.Side) * CollisionContext.N;
 			set_norm.Normalize();
 			break;
 		case AXIS_A0:
-			set_norm = -CollisionContext.Side * Vector3(1.0f,0.0f,0.0f);
+			set_norm = float(-CollisionContext.Side) * Vector3(1.0f,0.0f,0.0f);
 			break;
 		case AXIS_A1:
-			set_norm = -CollisionContext.Side * Vector3(0.0f,1.0f,0.0f);
+			set_norm = float(-CollisionContext.Side) * Vector3(0.0f,1.0f,0.0f);
 			break;
 		case AXIS_A2:
-			set_norm = -CollisionContext.Side * Vector3(0.0f,0.0f,1.0f);
+			set_norm = float(-CollisionContext.Side) * Vector3(0.0f,0.0f,1.0f);
 			break;
 		case AXIS_A0E0:
-			set_norm = -CollisionContext.Side * CollisionContext.AxE[0][0];
+			set_norm = float(-CollisionContext.Side) * CollisionContext.AxE[0][0];
 			set_norm.Normalize();
 			break;
 		case AXIS_A1E0:
-			set_norm = -CollisionContext.Side * CollisionContext.AxE[1][0];
+			set_norm = float(-CollisionContext.Side) * CollisionContext.AxE[1][0];
 			set_norm.Normalize();
 			break;
 		case AXIS_A2E0:
-			set_norm = -CollisionContext.Side * CollisionContext.AxE[2][0];
+			set_norm = float(-CollisionContext.Side) * CollisionContext.AxE[2][0];
 			set_norm.Normalize();
 			break;
 		case AXIS_A0E1:
-			set_norm = -CollisionContext.Side * CollisionContext.AxE[0][1];
+			set_norm = float(-CollisionContext.Side) * CollisionContext.AxE[0][1];
 			set_norm.Normalize();
 			break;
 		case AXIS_A1E1:
-			set_norm = -CollisionContext.Side * CollisionContext.AxE[1][1];
+			set_norm = float(-CollisionContext.Side) * CollisionContext.AxE[1][1];
 			set_norm.Normalize();
 			break;
 		case AXIS_A2E1:
-			set_norm = -CollisionContext.Side * CollisionContext.AxE[2][1];
+			set_norm = float(-CollisionContext.Side) * CollisionContext.AxE[2][1];
 			set_norm.Normalize();
 			break;
 		case AXIS_A0E2:
-			set_norm = -CollisionContext.Side * CollisionContext.AxE[0][2];
+			set_norm = float(-CollisionContext.Side) * CollisionContext.AxE[0][2];
 			set_norm.Normalize();
 			break;
 		case AXIS_A1E2:
-			set_norm = -CollisionContext.Side * CollisionContext.AxE[1][2];
+			set_norm = float(-CollisionContext.Side) * CollisionContext.AxE[1][2];
 			set_norm.Normalize();
 			break;
 		case AXIS_A2E2:
-			set_norm = -CollisionContext.Side * CollisionContext.AxE[2][2];
+			set_norm = float(-CollisionContext.Side) * CollisionContext.AxE[2][2];
 			set_norm.Normalize();
 			break;
 	}

--- a/Code/WWMath/colmathobbobb.cpp
+++ b/Code/WWMath/colmathobbobb.cpp
@@ -831,7 +831,7 @@ static inline void compute_contact_normal(ObbCollisionStruct & context,CastResul
 		break;
 	}
 
-	result->Normal *= -context.Side;
+	result->Normal *= float(-context.Side);
 }
 
 
@@ -847,12 +847,12 @@ static inline void compute_contact_normal(ObbCollisionStruct & context,CastResul
  * HISTORY:                                                                                    *
  *   4/8/99     GTH : Created.                                                                 *
  *=============================================================================================*/
-static inline float eval_side(float ab,float side)
+static inline float eval_side(float ab,int side)
 {
 	if (ab > 0.0f) {
-		return side;
+		return float(side);
 	} else if (ab < 0.0f) {
-		return -side;
+		return float(-side);
 	} else {
 		return 0.0f;
 	}

--- a/Code/WWMath/colmathobbtri.cpp
+++ b/Code/WWMath/colmathobbtri.cpp
@@ -307,9 +307,9 @@ static inline bool obbtri_check_collision_axis(BTCollisionStruct & context)
 		dist = -dist;
 		axismove = -axismove;
 		context.TestAxis = -context.TestAxis;
-		context.TestSide = -1.0f;
+		context.TestSide = -1;
 	} else {
-		context.TestSide = 1.0f;
+		context.TestSide = 1;
 	}
 
 	// compute coordinates of the leading edge of the box at t0 and t1
@@ -367,9 +367,9 @@ static inline bool obbtri_check_collision_cross_axis
 		axismove = -axismove;
 		dp = -dp;
 		context.TestAxis = -context.TestAxis;
-		context.TestSide = -1.0f;
+		context.TestSide = -1;
 	} else {
-		context.TestSide = 1.0f;
+		context.TestSide = 1;
 	}
 
 	// compute coordinates of the leading edge of the box at t1
@@ -424,9 +424,9 @@ static inline bool obbtri_check_collision_basis_axis
 		dp1 = -dp1;
 		dp2 = -dp2;
 		context.TestAxis = -context.TestAxis;
-		context.TestSide = -1.0f;
+		context.TestSide = -1;
 	} else {
-		context.TestSide = 1.0f;
+		context.TestSide = 1;
 	}
 
 	// this is the "optimization", leb0 = one of the extents
@@ -474,9 +474,9 @@ static inline bool obbtri_check_collision_normal_axis(BTCollisionStruct & contex
 		dist = -dist;
 		axismove = -axismove;
 		context.TestAxis = -context.TestAxis;
-		context.TestSide = -1.0f;
+		context.TestSide = -1;
 	} else {
-		context.TestSide = 1.0f;
+		context.TestSide = 1;
 	}
 
 	leb0 =	context.Box.Extent.X * WWMath::Fabs(context.AN[0]) +
@@ -504,9 +504,9 @@ static inline bool obbtri_check_collision_normal_axis(BTCollisionStruct & contex
 static inline float eval_side(float val,int side)
 {
 	if (val > 0.0f) {
-		return side;
+		return float(side);
 	} else if (val < 0.0f) {
-		return -side;
+		return float(-side);
 	} else {
 		return 0.0f;
 	}
@@ -536,51 +536,51 @@ static inline void obbtri_compute_contact_normal
 //			WWASSERT(0);
 			break;
 		case AXIS_N:
-			*set_normal = -context.Side * *context.Tri.N;
+			*set_normal = float(-context.Side) * *context.Tri.N;
 			break;
 		case AXIS_A0:
-			*set_normal = -context.Side * context.A[0];
+			*set_normal = float(-context.Side) * context.A[0];
 			break;
 		case AXIS_A1:
-			*set_normal = -context.Side * context.A[1];
+			*set_normal = float(-context.Side) * context.A[1];
 			break;
 		case AXIS_A2:
-			*set_normal = -context.Side * context.A[2];
+			*set_normal = float(-context.Side) * context.A[2];
 			break;
 		case AXIS_A0E0:
-			*set_normal = -context.Side * context.AxE[0][0];
+			*set_normal = float(-context.Side) * context.AxE[0][0];
 			set_normal->Normalize();
 			break;
 		case AXIS_A1E0:
-			*set_normal = -context.Side * context.AxE[1][0];
+			*set_normal = float(-context.Side) * context.AxE[1][0];
 			set_normal->Normalize();
 			break;
 		case AXIS_A2E0:
-			*set_normal = -context.Side * context.AxE[2][0];
+			*set_normal = float(-context.Side) * context.AxE[2][0];
 			set_normal->Normalize();
 			break;
 		case AXIS_A0E1:
-			*set_normal = -context.Side * context.AxE[0][1];
+			*set_normal = float(-context.Side) * context.AxE[0][1];
 			set_normal->Normalize();
 			break;
 		case AXIS_A1E1:
-			*set_normal = -context.Side * context.AxE[1][1];
+			*set_normal = float(-context.Side) * context.AxE[1][1];
 			set_normal->Normalize();
 			break;
 		case AXIS_A2E1:
-			*set_normal = -context.Side * context.AxE[2][1];
+			*set_normal = float(-context.Side) * context.AxE[2][1];
 			set_normal->Normalize();
 			break;
 		case AXIS_A0E2:
-			*set_normal = -context.Side * context.AxE[0][2];
+			*set_normal = float(-context.Side) * context.AxE[0][2];
 			set_normal->Normalize();
 			break;
 		case AXIS_A1E2:
-			*set_normal = -context.Side * context.AxE[1][2];
+			*set_normal = float(-context.Side) * context.AxE[1][2];
 			set_normal->Normalize();
 			break;
 		case AXIS_A2E2:
-			*set_normal = -context.Side * context.AxE[2][2];
+			*set_normal = float(-context.Side) * context.AxE[2][2];
 			set_normal->Normalize();
 			break;
 	}

--- a/Code/WWMath/euler.cpp
+++ b/Code/WWMath/euler.cpp
@@ -176,7 +176,7 @@ void EulerAnglesClass::From_Matrix(const Matrix3D & M, int order)
 	_euler_unpack_order(order,i,j,k,h,n,s,f);
 
 	if (s == EULER_REPEAT_YES) {
-		double sy = sqrt(M[i][j]*M[i][j] + M[i][k]*M[i][k]);
+		float sy = WWMath::Sqrt(M[i][j]*M[i][j] + M[i][k]*M[i][k]);
 
 		if (sy > 16*FLT_EPSILON) {
 
@@ -193,7 +193,7 @@ void EulerAnglesClass::From_Matrix(const Matrix3D & M, int order)
 
 	} else {
 
-		double cy = sqrt(M[i][i]*M[i][i] + M[j][i]*M[j][i]);
+		float cy = WWMath::Sqrt(M[i][i]*M[i][i] + M[j][i]*M[j][i]);
 
 		if (cy > 16*FLT_EPSILON) {
 

--- a/Code/WWMath/gridcull.h
+++ b/Code/WWMath/gridcull.h
@@ -328,9 +328,9 @@ WWINLINE void GridCullSystemClass::clamp_indices_to_grid(int * i,int * j,int * k
 WWINLINE bool GridCullSystemClass::map_point_to_cell(const Vector3 & pt,int & set_i,int & set_j,int & set_k)
 {
 	Vector3 dp = pt - Origin;
-	set_i = floor(dp.X * OOCellDim.X);
-	set_j = floor(dp.Y * OOCellDim.Y);
-	set_k = floor(dp.Z * OOCellDim.Z);
+	set_i = int(WWMath::Floor(dp.X * OOCellDim.X));
+	set_j = int(WWMath::Floor(dp.Y * OOCellDim.Y));
+	set_k = int(WWMath::Floor(dp.Z * OOCellDim.Z));
 
 	if (	(set_i >= 0) && (set_j >= 0) && (set_k >= 0) &&
 			(set_i < CellCount[0]) && (set_j < CellCount[1]) && (set_k < CellCount[2])	)

--- a/Code/WWMath/obbox.h
+++ b/Code/WWMath/obbox.h
@@ -102,7 +102,7 @@ public:
 	void		Init_From_Box_Points(Vector3 * points,int num_points);
 	void		Init_Random(float min_extent = 0.5f,float max_extent = 1.0f);
 	float		Project_To_Axis(const Vector3 & axis) const;
-	float		Volume(void) const { return 2.0*Extent.X * 2.0*Extent.Y * 2.0*Extent.Z; }
+	float		Volume(void) const { return 2.0f*Extent.X * 2.0f*Extent.Y * 2.0f*Extent.Z; }
 	void		Compute_Point(float params[3],Vector3 * set_point) const;
 	void		Compute_Axis_Aligned_Extent(Vector3 * set_extent) const;
 

--- a/Code/WWMath/quat.cpp
+++ b/Code/WWMath/quat.cpp
@@ -481,9 +481,9 @@ Quaternion Build_Quaternion(const Matrix3D & mat)
 
 	if (tr > 0.0f) {
 
-		s = sqrt(tr + 1.0);
-		q[3] = s * 0.5;
-		s = 0.5 / s;
+		s = WWMath::Sqrt(tr + 1.0f);
+		q[3] = s * 0.5f;
+		s = 0.5f / s;
 
 		q[0] = (mat[2][1] - mat[1][2]) * s;
 		q[1] = (mat[0][2] - mat[2][0]) * s;
@@ -497,11 +497,11 @@ Quaternion Build_Quaternion(const Matrix3D & mat)
 		j = _nxt[i];
 		k = _nxt[j];
 
-		s = sqrt((mat[i][i] - (mat[j][j] + mat[k][k])) + 1.0);
+		s = WWMath::Sqrt((mat[i][i] - (mat[j][j] + mat[k][k])) + 1.0f);
 
-		q[i] = s * 0.5;
-		if (s != 0.0) {
-			s = 0.5 / s;
+		q[i] = s * 0.5f;
+		if (s != 0.0f) {
+			s = 0.5f / s;
 		}
 
 		q[3] = 	( mat[k][j] - mat[j][k] ) * s;
@@ -522,11 +522,11 @@ Quaternion Build_Quaternion(const Matrix3 & mat)
 	// sum the diagonal of the rotation matrix
 	tr = mat[0][0] + mat[1][1] + mat[2][2];
 
-	if (tr > 0.0) {
+	if (tr > 0.0f) {
 
-		s = sqrt(tr + 1.0);
-		q[3] = s * 0.5;
-		s = 0.5 / s;
+		s = WWMath::Sqrt(tr + 1.0f);
+		q[3] = s * 0.5f;
+		s = 0.5f / s;
 
 		q[0] = (mat[2][1] - mat[1][2]) * s;
 		q[1] = (mat[0][2] - mat[2][0]) * s;
@@ -541,12 +541,12 @@ Quaternion Build_Quaternion(const Matrix3 & mat)
 		j = _nxt[i];
 		k = _nxt[j];
 
-		s = sqrt( (mat[i][i] - (mat[j][j]+mat[k][k])) + 1.0);
+		s = WWMath::Sqrt( (mat[i][i] - (mat[j][j]+mat[k][k])) + 1.0f);
 
-		q[i] =	s * 0.5;
+		q[i] =	s * 0.5f;
 
-		if (s != 0.0) {
-			s = 0.5/s;
+		if (s != 0.0f) {
+			s = 0.5f/s;
 		}
 
 		q[3] = 	( mat[k][j] - mat[j][k] ) * s;
@@ -568,9 +568,9 @@ Quaternion Build_Quaternion(const Matrix4 & mat)
 
 	if (tr > 0.0) {
 
-		s = sqrt(tr + 1.0);
-		q[3] = s * 0.5;
-		s = 0.5 / s;
+		s = WWMath::Sqrt(tr + 1.0f);
+		q[3] = s * 0.5f;
+		s = 0.5f / s;
 
 		q[0] = (mat[2][1] - mat[1][2]) * s;
 		q[1] = (mat[0][2] - mat[2][0]) * s;
@@ -585,11 +585,11 @@ Quaternion Build_Quaternion(const Matrix4 & mat)
 		j = _nxt[i];
 		k = _nxt[j];
 
-		s = sqrt( (mat[i][i] - (mat[j][j]+mat[k][k])) + 1.0);
+		s = WWMath::Sqrt( (mat[i][i] - (mat[j][j]+mat[k][k])) + 1.0f);
 
-		q[i] =	s * 0.5;
-		if (s != 0.0) {
-			s = 0.5/s;
+		q[i] =	s * 0.5f;
+		if (s != 0.0f) {
+			s = 0.5f/s;
 		}
 		q[3] = 	( mat[k][j] - mat[j][k] ) * s;
 		q[j] =	( mat[j][i] + mat[i][j] ) * s;

--- a/Code/WWMath/sphere.h
+++ b/Code/WWMath/sphere.h
@@ -220,14 +220,14 @@ inline SphereClass::SphereClass(const Vector3 *Position,const int VertCount)
 			radsqr = radius * radius;
 
 			double oldtonew = testrad - radius;
-			center.X = (radius * center.X + oldtonew * Position[i].X) / testrad;
-			center.Y = (radius * center.Y + oldtonew * Position[i].Y) / testrad;
-			center.Z = (radius * center.Z + oldtonew * Position[i].Z) / testrad;
+			center.X = float((radius * center.X + oldtonew * Position[i].X) / testrad);
+			center.Y = float((radius * center.Y + oldtonew * Position[i].Y) / testrad);
+			center.Z = float((radius * center.Z + oldtonew * Position[i].Z) / testrad);
 		}
 	}
 
 	Center = center;
-	Radius = radius;
+	Radius = float(radius);
 }
 
 
@@ -348,7 +348,7 @@ inline void SphereClass::Transform(const Matrix3D & tm)
  *=============================================================================================*/
 inline float SphereClass::Volume(void) const
 {
-	return (4.0 / 3.0) * WWMATH_PI * (Radius * Radius * Radius);
+	return (4.0f / 3.0f) * WWMATH_PI * (Radius * Radius * Radius);
 }
 
 /***********************************************************************************************

--- a/Code/WWMath/wwmath.cpp
+++ b/Code/WWMath/wwmath.cpp
@@ -55,13 +55,13 @@ void		WWMath::Init(void)
 
 	for (a=0;a<ARC_TABLE_SIZE;++a) {
 		float cv=float(a-ARC_TABLE_SIZE/2)*(1.0f/(ARC_TABLE_SIZE/2));
-		_FastAcosTable[a]=acos(cv);
-		_FastAsinTable[a]=asin(cv);
+		_FastAcosTable[a]=WWMath::Acos(cv);
+		_FastAsinTable[a]=WWMath::Asin(cv);
 	}
 
 	for (a=0;a<SIN_TABLE_SIZE;++a) {
 		float cv= (float)a * 2.0f * WWMATH_PI / SIN_TABLE_SIZE; //float(a-SIN_TABLE_SIZE/2)*(1.0f/(SIN_TABLE_SIZE/2));
-		_FastSinTable[a]=sin(cv);
+		_FastSinTable[a]=WWMath::Sin(cv);
 
 		if (a>0) {
 			_FastInvSinTable[a]=1.0f/_FastSinTable[a];

--- a/Code/WWMath/wwmath.h
+++ b/Code/WWMath/wwmath.h
@@ -115,8 +115,13 @@ static WWINLINE int Float_To_Int_Floor(const float& f);
 
 static WWINLINE int Float_To_Long(float f);
 static WWINLINE float Cos(float val);
+static WWINLINE double Cos(double val);
 static WWINLINE float Sin(float val);
+static WWINLINE double Sin(double val);
+static WWINLINE float Tan(float val);
+static WWINLINE double Tan(double val);
 static WWINLINE float Sqrt(float val);
+static WWINLINE double Sqrt(double val);
 static WWINLINE float Inv_Sqrt(float a);
 
 
@@ -131,11 +136,18 @@ static WWINLINE float Fast_Asin(float val);
 static WWINLINE float Asin(float val);
 
 
-static float		Atan(float x) { return static_cast<float>(atan(x)); }
-static float		Atan2(float y,float x) { return static_cast<float>(atan2(y,x)); }
+static float		Atan(float x) { return atanf(x); }
+static double		Atan(double x) { return atan(x); }
+static float		Atan2(float y,float x) { return atan2f(y,x); }
+static double		Atan2(double y,double x) { return atan2(y,x); }
 static float		Sign(float val);
 static float		Ceil(float val) { return ceilf(val); }
 static float		Floor(float val) { return floorf(val); }
+static double		Floor(double val) { return floor(val); }
+static float		Trunc(float val) { return truncf(val); }
+static float		Round(float val) { return roundf(val); }
+static float		Pow(float x, float y) { return powf(x, y); }
+static double		Pow(double x, double y) { return pow(x, y); }
 static bool			Fast_Is_Float_Positive(const float & val);
 
 static float		Random_Float(void);
@@ -302,6 +314,11 @@ WWINLINE float WWMath::Cos(float val)
 	return cosf(val);
 }
 
+WWINLINE double WWMath::Cos(double val)
+{
+	return cos(val);
+}
+
 // ----------------------------------------------------------------------------
 // Sin
 // ----------------------------------------------------------------------------
@@ -309,6 +326,25 @@ WWINLINE float WWMath::Cos(float val)
 WWINLINE float WWMath::Sin(float val)
 {
 	return sinf(val);
+}
+
+WWINLINE double WWMath::Sin(double val)
+{
+	return sin(val);
+}
+
+// ----------------------------------------------------------------------------
+// Tan
+// ----------------------------------------------------------------------------
+
+WWINLINE float WWMath::Tan(float val)
+{
+	return tanf(val);
+}
+
+WWINLINE double WWMath::Tan(double val)
+{
+	return tan(val);
 }
 
 // ----------------------------------------------------------------------------
@@ -485,7 +521,12 @@ WWINLINE float WWMath::Asin(float val)
 
 WWINLINE float WWMath::Sqrt(float val)
 {
-	return (float)sqrt(val);
+	return sqrtf(val);
+}
+
+WWINLINE double WWMath::Sqrt(double val)
+{
+	return sqrt(val);
 }
 
 WWINLINE int WWMath::Float_To_Int_Chop(const float& f)

--- a/Code/WWOnline/PingProfile.cpp
+++ b/Code/WWOnline/PingProfile.cpp
@@ -92,7 +92,7 @@ bool RecalculatePingProfile(const RefPtr<Session>& session)
 				pingTime = std::min<int>(pingTime, 1000);
 
 				// Scale ping time to from 0-1000 to 0-255
-				gPingProfile.Pings[index] = (((unsigned int)pingTime * 255) / 1000);
+				gPingProfile.Pings[index] = static_cast<unsigned char>(((unsigned int)pingTime * 255) / 1000);
 				}
 
 			return true;
@@ -223,14 +223,14 @@ void DecodePingProfile(const char* buffer, PingProfile& pings)
 		sscanf(buffer, "%02X%02X%02X%02X%02X%02X%02X%02X",
 			&ping[0], &ping[1], &ping[2], &ping[3], &ping[4], &ping[5], &ping[6], &ping[7]);
 
-		pings.Pings[0] = ping[0];
-		pings.Pings[1] = ping[1];
-		pings.Pings[2] = ping[2];
-		pings.Pings[3] = ping[3];
-		pings.Pings[4] = ping[4];
-		pings.Pings[5] = ping[5];
-		pings.Pings[6] = ping[6];
-		pings.Pings[7] = ping[7];
+		pings.Pings[0] = static_cast<unsigned char>(ping[0]);
+		pings.Pings[1] = static_cast<unsigned char>(ping[1]);
+		pings.Pings[2] = static_cast<unsigned char>(ping[2]);
+		pings.Pings[3] = static_cast<unsigned char>(ping[3]);
+		pings.Pings[4] = static_cast<unsigned char>(ping[4]);
+		pings.Pings[5] = static_cast<unsigned char>(ping[5]);
+		pings.Pings[6] = static_cast<unsigned char>(ping[6]);
+		pings.Pings[7] = static_cast<unsigned char>(ping[7]);
 		}
 	else
 		{

--- a/Code/ww3d2/animatedsoundmgr.cpp
+++ b/Code/ww3d2/animatedsoundmgr.cpp
@@ -410,7 +410,7 @@ AnimatedSoundMgrClass::Trigger_Sound
 					int def_id = (*sound_list)[index].SoundDefinitionID;
 					WWAudioClass::Get_Instance ()->Create_Instant_Sound (def_id, tm);
 					WWDEBUG_SAY (("Triggering Sound %d\n", TIMEGETTIME ()));
-					retval = frame;
+					retval = float(frame);
 				}
 			}
 		}

--- a/Code/ww3d2/animobj.cpp
+++ b/Code/ww3d2/animobj.cpp
@@ -917,7 +917,7 @@ float Animatable3DObjClass::Compute_Current_Frame() const
 			//	Compute the current frame based on elapsed time.
 			//
 			if (ModeAnim.AnimMode != ANIM_MODE_MANUAL) {
-				float sync_time_diff = WW3D::Get_Sync_Time() - ModeAnim.LastSyncTime;
+				float sync_time_diff = float(WW3D::Get_Sync_Time() - ModeAnim.LastSyncTime);
 				frame += ModeAnim.Motion->Get_Frame_Rate() * sync_time_diff * 0.001f;
 
 				//
@@ -927,7 +927,7 @@ float Animatable3DObjClass::Compute_Current_Frame() const
 				{
 					case ANIM_MODE_ONCE:
 						if (frame >= ModeAnim.Motion->Get_Num_Frames() - 1) {
-							frame = ModeAnim.Motion->Get_Num_Frames() - 1;
+							frame = float(ModeAnim.Motion->Get_Num_Frames() - 1);
 						}
 						break;
 

--- a/Code/ww3d2/bitmaphandler.h
+++ b/Code/ww3d2/bitmaphandler.h
@@ -149,10 +149,10 @@ WWINLINE void BitmapHandlerClass::Read_B8G8R8A8(
 		{
 			unsigned short tmp;
 			tmp=*(unsigned short*)src_ptr;
-			*argb++=((tmp&0x000f)<<4);
-			*argb++=((tmp&0x00f0));
-			*argb++=((tmp&0x0f00)>>4);
-			*argb++=((tmp&0xf000)>>8);
+			*argb++=static_cast<unsigned char>((tmp&0x000f)<<4);
+			*argb++=static_cast<unsigned char>((tmp&0x00f0));
+			*argb++=static_cast<unsigned char>((tmp&0x0f00)>>4);
+			*argb++=static_cast<unsigned char>((tmp&0xf000)>>8);
 		}
 		break;
 	case WW3D_FORMAT_A1R5G5B5:

--- a/Code/ww3d2/boxrobj.cpp
+++ b/Code/ww3d2/boxrobj.cpp
@@ -490,7 +490,7 @@ void BoxRenderObjClass::render_box(RenderInfoClass & /*rinfo*/,const Vector3 & c
 		/*
 		** Dump the faces into the sorting dynamic index buffer.
 		*/
-		DynamicIBAccessClass ibaccess(buffer_type,NUM_BOX_FACES*3);
+		DynamicIBAccessClass ibaccess(static_cast<unsigned short>(buffer_type),NUM_BOX_FACES*3);
 		{
 			DynamicIBAccessClass::WriteLockClass lock(&ibaccess);
 			unsigned short * indices = lock.Get_Index_Array();

--- a/Code/ww3d2/camera.cpp
+++ b/Code/ww3d2/camera.cpp
@@ -72,6 +72,7 @@
 #include "ww3d.h"
 #include "matrix4.h"
 #include "dx8wrapper.h"
+#include "wwmath.h"
 
 
 /***********************************************************************************************
@@ -324,13 +325,13 @@ void CameraClass::Set_View_Plane(const Vector2 & vmin,const Vector2 & vmax)
 void CameraClass::Set_View_Plane(float hfov,float vfov)
 {
 
-	float width_half = tan(hfov/2.0);
+	float width_half = WWMath::Tan(hfov/2.0f);
 	float height_half = 0.0f;
 
 	if (vfov == -1) {
 		height_half = (1.0f / AspectRatio) * width_half;		// use the aspect ratio
 	} else {
-		height_half = tan(vfov/2.0);
+		height_half = WWMath::Tan(vfov/2.0f);
 		AspectRatio = width_half / height_half;					// or, initialize the aspect ratio
 	}
 
@@ -748,13 +749,13 @@ void CameraClass::Get_Clip_Planes(float & znear,float & zfar) const
 float CameraClass::Get_Horizontal_FOV(void) const
 {
 	float width = ViewPlane.Max.X - ViewPlane.Min.X;
-	return 2*WWMath::Atan2(width,2.0);
+	return 2*WWMath::Atan2(width,2.0f);
 }
 
 float CameraClass::Get_Vertical_FOV(void) const
 {
 	float height = ViewPlane.Max.Y - ViewPlane.Min.Y;
-	return 2*WWMath::Atan2(height,2.0);
+	return 2*WWMath::Atan2(height,2.0f);
 }
 
 float CameraClass::Get_Aspect_Ratio(void) const
@@ -780,7 +781,7 @@ void CameraClass::Get_D3D_Projection_Matrix(Matrix4 * set_tm)
 	** We need to flip the handed-ness of the projection matrix and
 	** move the z-range to 0<z<1 rather than -1<z<1
 	*/
-	float oozdiff = 1.0 / (ZFar - ZNear);
+	float oozdiff = 1.0f / (ZFar - ZNear);
 	if (Projection == PERSPECTIVE) {
 		(*set_tm)[2][2] = -(ZFar) * oozdiff;
 		(*set_tm)[2][3] = -(ZFar*ZNear) * oozdiff;

--- a/Code/ww3d2/colorspace.h
+++ b/Code/ww3d2/colorspace.h
@@ -99,7 +99,7 @@ inline void HSV_To_RGB(Vector3 &rgb, const Vector3 &hsv)
 		if (h==360.0f) h=0.0f;
 
 		h/=60.0f;
-		i=WWMath::Floor(h);
+		i=int(WWMath::Floor(h));
 		f=h-i;
 		p=v*(1.0f-s);
 		q=v*(1.0f-(s*f));

--- a/Code/ww3d2/dazzle.cpp
+++ b/Code/ww3d2/dazzle.cpp
@@ -956,7 +956,7 @@ void DazzleRenderObjClass::Render(RenderInfoClass & rinfo)
 
 			unsigned time_ms=WW3D::Get_Frame_Time();
 			if (time_ms==0) time_ms=1;
-			float weight=pow(params->ic.history_weight,time_ms);
+			float weight=WWMath::Pow(params->ic.history_weight,float(time_ms));
 
 			if (dazzle_intensity>0.0f) {
 				visibility = _VisibilityHandler->Compute_Dazzle_Visibility(rinfo,this,loc);
@@ -1052,7 +1052,7 @@ void DazzleRenderObjClass::Render_Dazzle(CameraClass* camera)
 		lens_max_verts=4*lensflare->lic.flare_count;
 	}
 
-	DynamicVBAccessClass vb_access(BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,vertex_count*2+lens_max_verts);
+	DynamicVBAccessClass vb_access(BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,static_cast<unsigned short>(vertex_count*2+lens_max_verts));
 	{
 		DynamicVBAccessClass::WriteLockClass lock(&vb_access);
 		VertexFormatXYZNDUV2* verts=lock.Get_Formatted_Vertex_Array();
@@ -1179,7 +1179,7 @@ void DazzleRenderObjClass::Render_Dazzle(CameraClass* camera)
 
 	DX8Wrapper::Set_Vertex_Buffer(vb_access);
 
-	DynamicIBAccessClass ib_access(BUFFER_TYPE_DYNAMIC_DX8,poly_count*3);
+	DynamicIBAccessClass ib_access(BUFFER_TYPE_DYNAMIC_DX8,static_cast<unsigned short>(poly_count*3));
 	{
 		DynamicIBAccessClass::WriteLockClass lock(&ib_access);
 		unsigned short* inds=lock.Get_Index_Array();
@@ -1200,12 +1200,12 @@ void DazzleRenderObjClass::Render_Dazzle(CameraClass* camera)
 	DX8Wrapper::Set_Transform(D3DTS_PROJECTION,Matrix4(true));
 
 	if (halo_poly_count) {
-		DX8Wrapper::Set_Index_Buffer(ib_access,dazzle_vertex_count);
+		DX8Wrapper::Set_Index_Buffer(ib_access,static_cast<unsigned short>(dazzle_vertex_count));
 		DX8Wrapper::Set_Shader(default_halo_shader);
 		DX8Wrapper::Set_Texture(0,types[type]->Get_Halo_Texture());
 		SphereClass sphere(Get_Position(),0.1f);
 
-		DX8Wrapper::Draw_Triangles(0,halo_poly_count,0,vertex_count);
+		DX8Wrapper::Draw_Triangles(0,static_cast<unsigned short>(halo_poly_count),0,static_cast<unsigned short>(vertex_count));
 	}
 
 	if (dazzle_poly_count) {
@@ -1213,15 +1213,15 @@ void DazzleRenderObjClass::Render_Dazzle(CameraClass* camera)
 		DX8Wrapper::Set_Shader(default_dazzle_shader);
 		DX8Wrapper::Set_Texture(0,types[type]->Get_Dazzle_Texture());
 		SphereClass sphere(Vector3(0.0f,0.0f,0.0f),0.0f);
-		DX8Wrapper::Draw_Triangles(0,dazzle_poly_count,0,vertex_count);
+		DX8Wrapper::Draw_Triangles(0,static_cast<unsigned short>(dazzle_poly_count),0,static_cast<unsigned short>(vertex_count));
 	}
 
 	if (lensflare_poly_count) {
-		DX8Wrapper::Set_Index_Buffer(ib_access,dazzle_vertex_count+halo_vertex_count);
+		DX8Wrapper::Set_Index_Buffer(ib_access,static_cast<unsigned short>(dazzle_vertex_count+halo_vertex_count));
 		DX8Wrapper::Set_Shader(default_dazzle_shader);
 		DX8Wrapper::Set_Texture(0,lensflare->Get_Texture());
 		SphereClass sphere(Vector3(0.0f,0.0f,0.0f),0.0f);
-		DX8Wrapper::Draw_Triangles(0,lensflare_poly_count,0,vertex_count);
+		DX8Wrapper::Draw_Triangles(0,static_cast<unsigned short>(lensflare_poly_count),0,static_cast<unsigned short>(vertex_count));
 	}
 
 	DX8Wrapper::Set_Transform(D3DTS_PROJECTION,old_projection_transform);

--- a/Code/ww3d2/decalmsh.cpp
+++ b/Code/ww3d2/decalmsh.cpp
@@ -303,7 +303,7 @@ void RigidDecalMeshClass::Render(void)
 	/*
 	** Copy the vertices into the dynamic vb
 	*/
-	DynamicVBAccessClass dynamic_vb(BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,Verts.Count());
+	DynamicVBAccessClass dynamic_vb(BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,static_cast<unsigned short>(Verts.Count()));
 	{
 		DynamicVBAccessClass::WriteLockClass lock(&dynamic_vb);
 		VertexFormatXYZNDUV2 * vertex = lock.Get_Formatted_Vertex_Array();
@@ -333,7 +333,7 @@ void RigidDecalMeshClass::Render(void)
 	/*
 	** Copy the indices into the dynamic ib
 	*/
-	DynamicIBAccessClass dynamic_ib(BUFFER_TYPE_DYNAMIC_DX8,Polys.Count() * 3);
+	DynamicIBAccessClass dynamic_ib(BUFFER_TYPE_DYNAMIC_DX8,static_cast<unsigned short>(Polys.Count() * 3));
 	{
 		DynamicIBAccessClass::WriteLockClass lock(&dynamic_ib);
 		unsigned short * indices = lock.Get_Index_Array();
@@ -356,8 +356,8 @@ void RigidDecalMeshClass::Render(void)
 
 		DX8Wrapper::Set_Index_Buffer(dynamic_ib,0);
 		DX8Wrapper::Set_Vertex_Buffer(dynamic_vb);
-		DX8Wrapper::Draw_Triangles(	3*cur_poly_index,
-												(next_poly_index - cur_poly_index), // poly count
+		DX8Wrapper::Draw_Triangles(	static_cast<unsigned short>(3*cur_poly_index),
+												static_cast<unsigned short>(next_poly_index - cur_poly_index), // poly count
 												Polys[cur_poly_index].I,
 												1 + Polys[next_poly_index-1].K - Polys[cur_poly_index].I);
 		cur_poly_index = next_poly_index;
@@ -442,9 +442,9 @@ bool RigidDecalMeshClass::Create_Decal
 
 	DecalStruct newdecal;
 	newdecal.DecalID = generator->Get_Decal_ID();
-	newdecal.FaceStartIndex = Polys.Count();		// start faces at the end of the current array
+	newdecal.FaceStartIndex = uint16(Polys.Count());		// start faces at the end of the current array
 	newdecal.FaceCount = 0;								// init facecount to zero
-	newdecal.VertexStartIndex = Verts.Count();	// start vertices at the end of the current array
+	newdecal.VertexStartIndex = uint16(Verts.Count());	// start vertices at the end of the current array
 	newdecal.VertexCount = 0;							// init vertcount to zero
 
 	/*
@@ -537,7 +537,10 @@ bool RigidDecalMeshClass::Create_Decal
 					** Add the triangle, its plane equation, and the per-tri materials
 					*/
 					added_polys = true;
-					Polys.Add(TriIndex(first_vert,first_vert + j,first_vert + j + 1));
+					Polys.Add(TriIndex(
+						static_cast<unsigned short>(first_vert),
+						static_cast<unsigned short>(first_vert + j),
+						static_cast<unsigned short>(first_vert + j + 1)));
 					Shaders.Add(material->Peek_Shader());
 					Textures.Add(material->Get_Texture());					// Get_Texture gives us a reference...
 				}
@@ -564,8 +567,8 @@ bool RigidDecalMeshClass::Create_Decal
 	}
 
 	if (added_polys) {
-		newdecal.FaceCount = Polys.Count() - newdecal.FaceStartIndex;
-		newdecal.VertexCount = Verts.Count() - newdecal.VertexStartIndex;
+		newdecal.FaceCount = uint16(Polys.Count() - newdecal.FaceStartIndex);
+		newdecal.VertexCount = uint16(Verts.Count() - newdecal.VertexStartIndex);
 		Decals.Add(newdecal);
 
 		/*
@@ -795,7 +798,7 @@ void SkinDecalMeshClass::Render(void)
 	/*
 	** Copy the vertices into the dynamic vb
 	*/
-	DynamicVBAccessClass dynamic_vb(BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,ParentVertexIndices.Count());
+	DynamicVBAccessClass dynamic_vb(BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,static_cast<unsigned short>(ParentVertexIndices.Count()));
 	{
 		DynamicVBAccessClass::WriteLockClass lock(&dynamic_vb);
 		VertexFormatXYZNDUV2 * vertex = lock.Get_Formatted_Vertex_Array();
@@ -829,7 +832,7 @@ void SkinDecalMeshClass::Render(void)
 	/*
 	** Copy the indices into the dynamic ib
 	*/
-	DynamicIBAccessClass dynamic_ib(BUFFER_TYPE_DYNAMIC_DX8,Polys.Count() * 3);
+	DynamicIBAccessClass dynamic_ib(BUFFER_TYPE_DYNAMIC_DX8,static_cast<unsigned short>(Polys.Count() * 3));
 	{
 		DynamicIBAccessClass::WriteLockClass lock(&dynamic_ib);
 		unsigned short * indices = lock.Get_Index_Array();
@@ -852,8 +855,8 @@ void SkinDecalMeshClass::Render(void)
 
 		DX8Wrapper::Set_Index_Buffer(dynamic_ib,0);
 		DX8Wrapper::Set_Vertex_Buffer(dynamic_vb);
-		DX8Wrapper::Draw_Triangles(3*cur_poly_index,
-											(next_poly_index - cur_poly_index), // poly count
+		DX8Wrapper::Draw_Triangles(static_cast<unsigned short>(3*cur_poly_index),
+											static_cast<unsigned short>(next_poly_index - cur_poly_index), // poly count
 											Polys[cur_poly_index].I,
 											1 + Polys[next_poly_index-1].K - Polys[cur_poly_index].I);
 
@@ -927,9 +930,9 @@ bool SkinDecalMeshClass::Create_Decal(DecalGeneratorClass * generator,
 
 	DecalStruct newdecal;
 	newdecal.DecalID = generator->Get_Decal_ID();
-	newdecal.FaceStartIndex = Polys.Count();						// start faces at the end of the current array
+	newdecal.FaceStartIndex = uint16(Polys.Count());						// start faces at the end of the current array
 	newdecal.FaceCount = 0;												// init facecount to zero
-	newdecal.VertexStartIndex = ParentVertexIndices.Count();	// start vertices at the end of the current array
+	newdecal.VertexStartIndex = uint16(ParentVertexIndices.Count());	// start vertices at the end of the current array
 	newdecal.VertexCount = 0;											// init vertcount to zero
 
 	/*
@@ -956,7 +959,10 @@ bool SkinDecalMeshClass::Create_Decal(DecalGeneratorClass * generator,
 	int first_vert = ParentVertexIndices.Count();
 	for (i = 0; i < apt.Count(); i++) {
 		int offset = first_vert + i * 3;
-		Polys.Add(TriIndex(offset, offset + 1, offset + 2), face_size_hint);
+		Polys.Add(TriIndex(
+			static_cast<unsigned short>(offset),
+			static_cast<unsigned short>(offset + 1),
+			static_cast<unsigned short>(offset + 2)), face_size_hint);
 
 		Shaders.Add(material->Peek_Shader(), face_size_hint);
 		Textures.Add(material->Get_Texture(), face_size_hint);		// Get_Texture gives us a reference...
@@ -988,8 +994,8 @@ bool SkinDecalMeshClass::Create_Decal(DecalGeneratorClass * generator,
 		}
 	}
 
-	newdecal.FaceCount = Polys.Count() - newdecal.FaceStartIndex;
-	newdecal.VertexCount = ParentVertexIndices.Count() - newdecal.VertexStartIndex;
+	newdecal.FaceCount = uint16(Polys.Count() - newdecal.FaceStartIndex);
+	newdecal.VertexCount = uint16(ParentVertexIndices.Count() - newdecal.VertexStartIndex);
 	Decals.Add(newdecal);
 
 	material->Release_Ref();

--- a/Code/ww3d2/decalsys.cpp
+++ b/Code/ww3d2/decalsys.cpp
@@ -280,7 +280,7 @@ void DecalGeneratorClass::Set_Mesh_Transform(const Matrix3D & mesh_transform)
 //			SurfaceClass::SurfaceDescription surface_desc;
 //			tex->Get_Level_Description(surface_desc);
 //			texsize = surface_desc.Width;
-			texsize = tex->Get_Width();
+			texsize = float(tex->Get_Width());
 		}
 
 		Mapper->Set_Texture_Transform(mesh_to_texture,texsize);

--- a/Code/ww3d2/dx8indexbuffer.cpp
+++ b/Code/ww3d2/dx8indexbuffer.cpp
@@ -517,7 +517,7 @@ void DynamicIBAccessClass::Allocate_Sorting_Dynamic_Buffer()
 	WWASSERT(new_index_count<65536);
 	if (new_index_count>_DynamicSortingIndexArraySize) {
 		REF_PTR_RELEASE(_DynamicSortingIndexArray);
-		_DynamicSortingIndexArraySize=new_index_count;
+		_DynamicSortingIndexArraySize=static_cast<unsigned short>(new_index_count);
 		if (_DynamicSortingIndexArraySize<DEFAULT_IB_SIZE) _DynamicSortingIndexArraySize=DEFAULT_IB_SIZE;
 	}
 

--- a/Code/ww3d2/dx8polygonrenderer.h
+++ b/Code/ww3d2/dx8polygonrenderer.h
@@ -124,18 +124,18 @@ inline void DX8PolygonRendererClass::Render(/*const Matrix3D & tm,*/int base_ver
 	if (strip) {
 		SNAPSHOT_SAY(("Draw_Strip(%d,%d,%d,%d)\n",index_offset,index_count-2,min_vertex_index,vertex_index_range));
 		DX8Wrapper::Draw_Strip(
-			index_offset,
-			index_count-2,
-			min_vertex_index,
-			vertex_index_range);
+			static_cast<unsigned short>(index_offset),
+			static_cast<unsigned short>(index_count-2),
+			static_cast<unsigned short>(min_vertex_index),
+			static_cast<unsigned short>(vertex_index_range));
 	}
 	else {
 		SNAPSHOT_SAY(("Draw_Triangles(%d,%d,%d,%d)\n",index_offset,index_count-2,min_vertex_index,vertex_index_range));
 		DX8Wrapper::Draw_Triangles(
-			index_offset,
-			index_count/3,
-			min_vertex_index,
-			vertex_index_range);
+			static_cast<unsigned short>(index_offset),
+			static_cast<unsigned short>(index_count/3),
+			static_cast<unsigned short>(min_vertex_index),
+			static_cast<unsigned short>(vertex_index_range));
 	}
 }
 
@@ -150,10 +150,10 @@ inline void DX8PolygonRendererClass::Render_Sorted(/*const Matrix3D & tm,*/int b
 	DX8Wrapper::Set_Index_Buffer_Index_Offset(base_vertex_offset);
 	SortingRendererClass::Insert_Triangles(
 		bounding_sphere,
-		index_offset,
-		index_count/3,
-		min_vertex_index,
-		vertex_index_range);
+		static_cast<unsigned short>(index_offset),
+		static_cast<unsigned short>(index_count/3),
+		static_cast<unsigned short>(min_vertex_index),
+		static_cast<unsigned short>(vertex_index_range));
 
 }
 

--- a/Code/ww3d2/dx8renderer.cpp
+++ b/Code/ww3d2/dx8renderer.cpp
@@ -1002,13 +1002,13 @@ void DX8RigidFVFCategoryContainer::Add_Mesh(MeshClass* mesh_)
 		int vb_size=4000;
 		if (vb_size<needed_vertices) vb_size=needed_vertices;
 		if (sorting) {
-			vertex_buffer=NEW_REF(SortingVertexBufferClass,(vb_size));
+			vertex_buffer=NEW_REF(SortingVertexBufferClass,(static_cast<unsigned short>(vb_size)));
 			WWASSERT(vertex_buffer->FVF_Info().Get_FVF()==FVF);	// Only one sorting FVF type!
 		}
 		else {
 			vertex_buffer=NEW_REF(DX8VertexBufferClass,(
 				FVF,
-				vb_size,
+				static_cast<unsigned short>(vb_size),
 				(DX8Wrapper::Get_Current_Caps()->Support_NPatches() && WW3D::Get_NPatches_Level()>1) ? DX8VertexBufferClass::USAGE_NPATCHES : DX8VertexBufferClass::USAGE_DEFAULT));
 		}
 	}
@@ -1202,11 +1202,11 @@ void DX8FVFCategoryContainer::Generate_Texture_Categories(Vertex_Split_Table& sp
 		int ib_size=12000;
 		if (ib_size<index_count) ib_size=index_count;
 		if (sorting) {
-			index_buffer=NEW_REF(SortingIndexBufferClass,(ib_size));
+			index_buffer=NEW_REF(SortingIndexBufferClass,(static_cast<unsigned short>(ib_size)));
 		}
 		else {
 			index_buffer=NEW_REF(DX8IndexBufferClass,(
-				ib_size,
+				static_cast<unsigned short>(ib_size),
 				(DX8Wrapper::Get_Current_Caps()->Support_NPatches() && WW3D::Get_NPatches_Level()>1) ? DX8IndexBufferClass::USAGE_NPATCHES : DX8IndexBufferClass::USAGE_DEFAULT));
 		}
 	}
@@ -1294,7 +1294,7 @@ void DX8SkinFVFCategoryContainer::Render(void)
 	DynamicVBAccessClass vb(
 		sorting ? BUFFER_TYPE_DYNAMIC_SORTING : BUFFER_TYPE_DYNAMIC_DX8,
 		dynamic_fvf_type,
-		VisibleVertexCount);
+		static_cast<unsigned short>(VisibleVertexCount));
 	SNAPSHOT_SAY(("DynamicVBAccess - %s - %d vertices\n",sorting ? "sorting" : "non-sorting",VisibleVertexCount));
 
 	unsigned vertex_offset=0;

--- a/Code/ww3d2/dx8vertexbuffer.cpp
+++ b/Code/ww3d2/dx8vertexbuffer.cpp
@@ -797,7 +797,7 @@ void DynamicVBAccessClass::Allocate_Sorting_Dynamic_Buffer()
 	WWASSERT(new_vertex_count<65536);
 	if (new_vertex_count>_DynamicSortingVertexArraySize) {
 		REF_PTR_RELEASE(_DynamicSortingVertexArray);
-		_DynamicSortingVertexArraySize=new_vertex_count;
+		_DynamicSortingVertexArraySize=static_cast<unsigned short>(new_vertex_count);
 		if (_DynamicSortingVertexArraySize<DEFAULT_VB_SIZE) _DynamicSortingVertexArraySize=DEFAULT_VB_SIZE;
 	}
 

--- a/Code/ww3d2/dx8wrapper.cpp
+++ b/Code/ww3d2/dx8wrapper.cpp
@@ -230,7 +230,7 @@ bool DX8Wrapper::Init(void * hwnd, bool lite)
 	ResolutionWidth = DEFAULT_RESOLUTION_WIDTH;
 	ResolutionHeight = DEFAULT_RESOLUTION_HEIGHT;
 	// Initialize Render2DClass Screen Resolution
-	Render2DClass::Set_Screen_Resolution( RectClass( 0, 0, ResolutionWidth, ResolutionHeight ) );
+	Render2DClass::Set_Screen_Resolution( RectClass( 0, 0, float(ResolutionWidth), float(ResolutionHeight) ) );
 	BitDepth = DEFAULT_BIT_DEPTH;
 	IsWindowed = false;
 
@@ -724,7 +724,7 @@ bool DX8Wrapper::Set_Render_Device(int dev, int width, int height, int bits, int
 	if (height != -1)		ResolutionHeight = height;
 
 	// Initialize Render2DClass Screen Resolution
-	Render2DClass::Set_Screen_Resolution( RectClass( 0, 0, ResolutionWidth, ResolutionHeight ) );
+	Render2DClass::Set_Screen_Resolution( RectClass( 0, 0, float(ResolutionWidth), float(ResolutionHeight) ) );
 
 	if (bits != -1)		BitDepth = bits;
 	if (windowed != -1)	IsWindowed = (windowed != 0);
@@ -1743,7 +1743,7 @@ void DX8Wrapper::Draw_Sorting_IB_VB(
 	}
 
 	// Fill dynamic index buffer with sorting index buffer vertices
-	DynamicIBAccessClass dyn_ib_access(BUFFER_TYPE_DYNAMIC_DX8,index_count);
+	DynamicIBAccessClass dyn_ib_access(BUFFER_TYPE_DYNAMIC_DX8,static_cast<unsigned short>(index_count));
 	{
 		DynamicIBAccessClass::WriteLockClass lock(&dyn_ib_access);
 		unsigned short* dest=lock.Get_Index_Array();
@@ -2407,7 +2407,7 @@ void DX8Wrapper::Set_Light(unsigned index,const LightClass &light)
 	dlight.Phi=light.Get_Spot_Angle();
 
 	// Inverse linear light 1/(1+D)
-	double a,b;
+	float a,b;
 	light.Get_Far_Attenuation_Range(a,b);
 	dlight.Attenuation0=1.0f;
 	if (fabs(a-b)<1e-5)
@@ -2415,7 +2415,7 @@ void DX8Wrapper::Set_Light(unsigned index,const LightClass &light)
 		dlight.Attenuation1=0.0f;
 	else
 		// this will cause the light to drop to half intensity at the first far attenuation
-		dlight.Attenuation1=(float) 1.0/a;
+		dlight.Attenuation1=1.0f/a;
 	dlight.Attenuation2=0.0f;
 
 	Set_Light(index,&dlight);
@@ -2515,20 +2515,20 @@ DX8Wrapper::Create_Render_Target (int width, int height, WW3DFormat format)
 	//	Note: We're going to force the width and height to be powers of two and equal
 	//
 	const D3DCAPS9& dx8caps=Get_Current_Caps()->Get_DX8_Caps();
-	float poweroftwosize = width;
+	float poweroftwosize = float(width);
 	if (height > 0 && height < width) {
-		poweroftwosize = height;
+		poweroftwosize = float(height);
 	}
-	poweroftwosize = ::Find_POT (poweroftwosize);
+	poweroftwosize = float(::Find_POT (int(poweroftwosize)));
 
 	if (poweroftwosize>dx8caps.MaxTextureWidth) {
-		poweroftwosize=dx8caps.MaxTextureWidth;
+		poweroftwosize=float(dx8caps.MaxTextureWidth);
 	}
 	if (poweroftwosize>dx8caps.MaxTextureHeight) {
-		poweroftwosize=dx8caps.MaxTextureHeight;
+		poweroftwosize=float(dx8caps.MaxTextureHeight);
 	}
 
-	width = height = poweroftwosize;
+	width = height = int(poweroftwosize);
 
 	//
 	//	Attempt to create the render target
@@ -3406,7 +3406,7 @@ void DX8Wrapper::Set_DX8_ZBias(int zbias)
 
 	if (!Get_Current_Caps()->Support_ZBias() && ZNear!=ZFar) {
 		Matrix4 tmp=ProjectionMatrix;
-		float tmp_zbias=ZBias;
+		float tmp_zbias=float(ZBias);
 		tmp_zbias*=(1.0f/16.0f);
 		tmp_zbias*=1.0f / (ZFar - ZNear);
 		tmp[2][2]-=tmp_zbias*tmp[3][2];

--- a/Code/ww3d2/dx8wrapper.h
+++ b/Code/ww3d2/dx8wrapper.h
@@ -601,7 +601,7 @@ WWINLINE void DX8Wrapper::_Get_DX8_Transform(D3DTRANSFORMSTATETYPE transform, Ma
 WWINLINE void DX8Wrapper::Set_Index_Buffer_Index_Offset(unsigned offset)
 {
 	if (render_state.index_base_offset==offset) return;
-	render_state.index_base_offset=offset;
+	render_state.index_base_offset=static_cast<unsigned short>(offset);
 	render_state_changed|=INDEX_BUFFER_CHANGED;
 }
 
@@ -849,7 +849,7 @@ WWINLINE void DX8Wrapper::Set_Alpha (const float alpha, unsigned int &color)
 {
 	unsigned char *component = (unsigned char*) &color;
 
-	component [3] = 255.0f * alpha;
+	component [3] = static_cast<unsigned char>(255.0f * alpha);
 }
 
 WWINLINE void DX8Wrapper::Get_Render_State(RenderStateStruct& state)
@@ -892,7 +892,7 @@ WWINLINE void DX8Wrapper::Set_Projection_Transform_With_Z_Bias(const Matrix4& ma
 
 	if (!Get_Current_Caps()->Support_ZBias() && ZNear!=ZFar) {
 		Matrix4 tmp=ProjectionMatrix;
-		float tmp_zbias=ZBias;
+		float tmp_zbias=float(ZBias);
 		tmp_zbias*=(1.0f/16.0f);
 		tmp_zbias*=1.0f / (ZFar - ZNear);
 		tmp[2][2]-=tmp_zbias*tmp[3][2];
@@ -911,7 +911,7 @@ WWINLINE void DX8Wrapper::Set_Pseudo_ZBias(int zbias)
 	ZBias=zbias;
 
 	Matrix4 tmp=ProjectionMatrix;
-	float tmp_zbias=ZBias;
+	float tmp_zbias=float(ZBias);
 	tmp_zbias*=(1.0f/64.0f);
 	tmp_zbias*=1.0f / (ZFar - ZNear);
 	tmp[2][2]-=tmp_zbias*tmp[3][2];

--- a/Code/ww3d2/dynamesh.cpp
+++ b/Code/ww3d2/dynamesh.cpp
@@ -184,7 +184,7 @@ void DynamicMeshModel::Render(RenderInfoClass & /*rinfo*/)
 	** one texture channel, and the diffuse color channel (color0). If it does not contain all
 	** these components, the code will fail.
 	*/
-	DynamicVBAccessClass dynamic_vb(buffer_type,dynamic_fvf_type,DynamicMeshVNum);
+	DynamicVBAccessClass dynamic_vb(buffer_type,dynamic_fvf_type,static_cast<unsigned short>(DynamicMeshVNum));
 	const FVFInfoClass &fvf_info = dynamic_vb.FVF_Info();
 
 	{ // scope for lock
@@ -227,7 +227,7 @@ void DynamicMeshModel::Render(RenderInfoClass & /*rinfo*/)
 	/*
 	** Write index data to index buffers
 	*/
-	DynamicIBAccessClass dynamic_ib(buffer_type,DynamicMeshPNum * 3);
+	DynamicIBAccessClass dynamic_ib(static_cast<unsigned short>(buffer_type),static_cast<unsigned short>(DynamicMeshPNum * 3));
 	const TriIndex *tris = Get_Polygon_Array();
 
 	{ // scope for lock
@@ -261,7 +261,7 @@ void DynamicMeshModel::Render(RenderInfoClass & /*rinfo*/)
 		*/
 
 		// The vertex index range used
-		unsigned short min_vert_idx = DynamicMeshVNum - 1;
+		unsigned short min_vert_idx = static_cast<unsigned short>(DynamicMeshVNum - 1);
 		unsigned short max_vert_idx = 0;
 		unsigned short start_tri_idx = 0;
 		unsigned short cur_tri_idx = 0;
@@ -327,10 +327,10 @@ void DynamicMeshModel::Render(RenderInfoClass & /*rinfo*/)
 		// If no texture, shader or material arrays for this pass just draw and go to next pass
 		if (!texture_array0 && !texture_array1 && !material_array && !shader_array) {
 			if (buffer_type==BUFFER_TYPE_DYNAMIC_SORTING) {
-				SortingRendererClass::Insert_Triangles(sphere,0, DynamicMeshPNum, 0, DynamicMeshVNum);
+				SortingRendererClass::Insert_Triangles(sphere,0, static_cast<unsigned short>(DynamicMeshPNum), 0, static_cast<unsigned short>(DynamicMeshVNum));
 			}
 			else {
-				DX8Wrapper::Draw_Triangles(0, DynamicMeshPNum, 0, DynamicMeshVNum);
+				DX8Wrapper::Draw_Triangles(0, static_cast<unsigned short>(DynamicMeshPNum), 0, static_cast<unsigned short>(DynamicMeshVNum));
 			}
 			continue;
 		}
@@ -377,7 +377,7 @@ void DynamicMeshModel::Render(RenderInfoClass & /*rinfo*/)
 						1 + max_vert_idx - min_vert_idx);
 				}
 				start_tri_idx = next_tri_idx;
-				min_vert_idx = DynamicMeshVNum - 1;
+				min_vert_idx = static_cast<unsigned short>(DynamicMeshVNum - 1);
 				max_vert_idx = 0;
 				if (texture_changed) DX8Wrapper::Set_Texture(0,texture_array0[next_tri_idx]);
 				if (texture1_changed) DX8Wrapper::Set_Texture(1,texture_array1[next_tri_idx]);
@@ -476,19 +476,19 @@ bool DynamicMeshClass::End_Vertex()
 		// set vertex indices
 		TriIndex *poly = &(Model->Get_Non_Const_Polygon_Array())[PolyCount];
 		if (TriMode == TRI_MODE_STRIPS) {
-			(*poly)[0] = VertCount-3;
-			(*poly)[1] = VertCount-2;
-			(*poly)[2] = VertCount-1;
+			(*poly)[0] = static_cast<unsigned short>(VertCount-3);
+			(*poly)[1] = static_cast<unsigned short>(VertCount-2);
+			(*poly)[2] = static_cast<unsigned short>(VertCount-1);
 
 			// for every other tri, reverse vertex order
 			if (Flip_Face()) {
-				(*poly)[1] = VertCount-1;
-				(*poly)[2] = VertCount-2;
+				(*poly)[1] = static_cast<unsigned short>(VertCount-1);
+				(*poly)[2] = static_cast<unsigned short>(VertCount-2);
 			}
 		} else {
-			(*poly)[0] = FanVertex;
-			(*poly)[1] = VertCount-2;
-			(*poly)[2] = VertCount-1;
+			(*poly)[0] = static_cast<unsigned short>(FanVertex);
+			(*poly)[1] = static_cast<unsigned short>(VertCount-2);
+			(*poly)[2] = static_cast<unsigned short>(VertCount-1);
 		}
 
 		// check each pass

--- a/Code/ww3d2/dynamesh.h
+++ b/Code/ww3d2/dynamesh.h
@@ -160,7 +160,7 @@ public:
 
 	// Get and set static sort level
    virtual int		Get_Sort_Level(void) const override		{ return SortLevel; }
-  	virtual void	Set_Sort_Level(int level) override		{ SortLevel = level; if(level != SORT_LEVEL_NONE) Disable_Sort();}
+  	virtual void	Set_Sort_Level(int level) override		{ SortLevel = char(level); if(level != SORT_LEVEL_NONE) Disable_Sort();}
 
 	// object space bounding volumes
 	virtual inline void Get_Obj_Space_Bounding_Sphere(SphereClass & sphere) const override;

--- a/Code/ww3d2/font3d.cpp
+++ b/Code/ww3d2/font3d.cpp
@@ -93,8 +93,8 @@ SurfaceClass *Font3DDataClass::Minimize_Font_Image( SurfaceClass *surface )
 
 	surface->Get_Description(sd);
 
-	float current_width = sd.Width;
-	float current_height = sd.Height;
+	float current_width = float(sd.Width);
+	float current_height = float(sd.Height);
 
 	// determine new width make the size of the new image either 128x128 or 256x256,
 	// dependant on the width of the original image
@@ -190,8 +190,8 @@ SurfaceClass *Font3DDataClass::Make_Proportional( SurfaceClass	*surface )
 {
 	SurfaceClass::SurfaceDescription sd;
 	surface->Get_Description(sd);
-	float width  =	sd.Width;
-	float height =	sd.Height;
+	float width  =	float(sd.Width);
+	float height =	float(sd.Height);
 
 	// for each character in the font...
 	for (int char_index = 0; char_index < 256; char_index++) {
@@ -226,7 +226,7 @@ SurfaceClass *Font3DDataClass::Make_Proportional( SurfaceClass	*surface )
 		// update the U and width tables
 		UOffsetTable[ char_index ] = (float)x0 / width;
 		UWidthTable[ char_index ] = (float)( x1 - x0 ) / width;
-		CharWidthTable[ char_index ] = x1 - x0;
+		CharWidthTable[ char_index ] = static_cast<unsigned char>(x1 - x0);
 	}
 
 	// now shink the image given the minimum char sizes
@@ -258,7 +258,7 @@ bool	Font3DDataClass::Load_Font_Image( const char *filename )
 
  		// the height of the strike is the height of the characters
 		VHeight = 1;
-		CharHeight = sd.Height;
+		CharHeight = static_cast<unsigned char>(sd.Height);
 
 		int	column = 0;
 		int	width = sd.Width;
@@ -294,7 +294,7 @@ bool	Font3DDataClass::Load_Font_Image( const char *filename )
 				UOffsetTable[ char_index ] = (float)start / width;
 				VOffsetTable[ char_index ] = 0;
 				UWidthTable[ char_index ] = (float)(end - start) / width;
-				CharWidthTable[ char_index ] = end - start;
+				CharWidthTable[ char_index ] = static_cast<unsigned char>(end - start);
 			}
 
 		}
@@ -309,8 +309,8 @@ bool	Font3DDataClass::Load_Font_Image( const char *filename )
 
 		// Determine the width and height of each mono spaced character in pixels
 		// (assumes 16x16 array of chars)
-		float	font_width = sd.Width;
-		float	font_height = sd.Height;
+		float	font_width = float(sd.Width);
+		float	font_height = float(sd.Height);
 		float	mono_pixel_width = (font_width / 16);
 		float	mono_pixel_height = (font_height / 16);
 
@@ -320,10 +320,10 @@ bool	Font3DDataClass::Load_Font_Image( const char *filename )
 			UOffsetTable[ char_index ] = (float)((char_index % 16) * mono_pixel_width) / font_width;
 			VOffsetTable[ char_index ] = (float)((char_index / 16) * mono_pixel_height) / font_height;
 			UWidthTable[ char_index ] = mono_pixel_width / font_width;
-			CharWidthTable[ char_index ] = mono_pixel_width;
+			CharWidthTable[ char_index ] = static_cast<unsigned char>(mono_pixel_width);
 		}
 		VHeight = mono_pixel_height / font_height;
-		CharHeight = mono_pixel_height;
+		CharHeight = static_cast<unsigned char>(mono_pixel_height);
 
 		// convert the just created mon-spaced font to proportional (optional)
 
@@ -355,7 +355,7 @@ Font3DInstanceClass::Font3DInstanceClass( const char *filename )
 	FontData = WW3DAssetManager::Get_Instance()->Get_Font3DData( filename);
 	MonoSpacing = 0.0f;
 	Scale = 1.0f;
-	SpaceSpacing = (int)(FontData->Char_Width('H') / 2.0f);
+	SpaceSpacing = FontData->Char_Width('H') / 2.0f;
 	InterCharSpacing = 1;
 	Build_Cached_Tables();
 }
@@ -375,7 +375,7 @@ Font3DInstanceClass::~Font3DInstanceClass(void)
 */
 void	Font3DInstanceClass::Set_Mono_Spaced( void )
 {
-	MonoSpacing = FontData->Char_Width('W') + 1;
+	MonoSpacing = float(FontData->Char_Width('W') + 1);
 	Build_Cached_Tables();
 }
 
@@ -383,7 +383,7 @@ void	Font3DInstanceClass::Build_Cached_Tables()
 {
 	// Rebuild the cached tables
 	for (int a=0;a<256;++a) {
-		float width = (float)FontData->Char_Width(a);
+		float width = (float)FontData->Char_Width(unichar_t(a));
 		if ( a == ' ' ) {
 			width = SpaceSpacing;
 		}
@@ -395,7 +395,7 @@ void	Font3DInstanceClass::Build_Cached_Tables()
 			ScaledSpacingTable[a] = Scale * (width + InterCharSpacing);
 		}
 	}
-	ScaledHeight = floor(Scale * (float)FontData->Char_Height('A'));
+	ScaledHeight = WWMath::Floor(Scale * (float)FontData->Char_Height('A'));
 }
 
 /***********************************************************************************************

--- a/Code/ww3d2/hanim.cpp
+++ b/Code/ww3d2/hanim.cpp
@@ -305,7 +305,7 @@ bool	HAnimComboClass::Normalize_Weights(void)
 		}
 
 		// weight_total should be very close to 1. If not, normalize this pivot's weights
-		if (weight_total != 0.0 && WWMath::Fabs( weight_total - 1.0 ) > WWMATH_EPSILON) {
+		if (weight_total != 0.0f && WWMath::Fabs( weight_total - 1.0f ) > WWMATH_EPSILON) {
 			float oo_total = 1.0f / weight_total;
 			for (anim_idx = 0; anim_idx < anim_count; anim_idx++ ) {
 				if (Peek_Motion(anim_idx) != NULL ) {
@@ -330,7 +330,7 @@ bool	HAnimComboClass::Normalize_Weights(void)
 				}
 
 				// weight_total should be very close to 1. If not, normalize this pivot's weights
-				if (weight_total != 0.0 && WWMath::Fabs( weight_total - 1.0 ) > WWMATH_EPSILON) {
+				if (weight_total != 0.0f && WWMath::Fabs( weight_total - 1.0f ) > WWMATH_EPSILON) {
 					float oo_total = 1.0f / weight_total;
 					for (anim_idx = 0; anim_idx < anim_count; anim_idx++ ) {
 						if (Peek_Motion(anim_idx) != NULL ) {

--- a/Code/ww3d2/hmorphanim.cpp
+++ b/Code/ww3d2/hmorphanim.cpp
@@ -120,7 +120,7 @@ uint32 TimeCodedMorphKeysClass::get_index(float frame)
 {
 	assert(CachedIdx <= (uint32)Keys.Count ()-1);
 
-	float	cached_frame = Keys[CachedIdx].MorphFrame;
+	float	cached_frame = float(Keys[CachedIdx].MorphFrame);
 
 	// check if the requested time is in the cached interval or the following one
 	if (frame >= cached_frame) {
@@ -680,9 +680,9 @@ void HMorphAnimClass::Get_Translation(Vector3& trans,int pividx,float frame) con
 	MorphKeyData[channel].Get_Morph_Info(frame,&pose_frame0,&pose_frame1,&fraction);
 
 	Vector3 t0;
-	PoseData[channel]->Get_Translation(t0,pividx,pose_frame0);
+	PoseData[channel]->Get_Translation(t0,pividx,float(pose_frame0));
 	Vector3 t1;
-	PoseData[channel]->Get_Translation(t1,pividx,pose_frame1);
+	PoseData[channel]->Get_Translation(t1,pividx,float(pose_frame1));
 	Vector3::Lerp(t0,t1,fraction,&trans);
 }
 
@@ -694,9 +694,9 @@ void HMorphAnimClass::Get_Orientation(Quaternion& q, int pividx,float frame) con
 	MorphKeyData[channel].Get_Morph_Info(frame,&pose_frame0,&pose_frame1,&fraction);
 
 	Quaternion q0;
-	PoseData[channel]->Get_Orientation(q0,pividx,pose_frame0);
+	PoseData[channel]->Get_Orientation(q0,pividx,float(pose_frame0));
 	Quaternion q1;
-	PoseData[channel]->Get_Orientation(q1,pividx,pose_frame1);
+	PoseData[channel]->Get_Orientation(q1,pividx,float(pose_frame1));
 	::Fast_Slerp(q,q0,q1,fraction);
 }
 
@@ -708,16 +708,16 @@ void HMorphAnimClass::Get_Transform(Matrix3D& mtx,int pividx,float frame) const
 	MorphKeyData[channel].Get_Morph_Info(frame,&pose_frame0,&pose_frame1,&fraction);
 
 	Quaternion q0;
-	PoseData[channel]->Get_Orientation(q0,pividx,pose_frame0);
+	PoseData[channel]->Get_Orientation(q0,pividx,float(pose_frame0));
 	Quaternion q1;
-	PoseData[channel]->Get_Orientation(q1,pividx,pose_frame1);
+	PoseData[channel]->Get_Orientation(q1,pividx,float(pose_frame1));
 	Quaternion q;
 	::Fast_Slerp(q,q0,q1,fraction);
 	mtx=::Build_Matrix3D(q);
 	Vector3 t0;
-	PoseData[channel]->Get_Translation(t0,pividx,pose_frame0);
+	PoseData[channel]->Get_Translation(t0,pividx,float(pose_frame0));
 	Vector3 t1;
-	PoseData[channel]->Get_Translation(t1,pividx,pose_frame1);
+	PoseData[channel]->Get_Translation(t1,pividx,float(pose_frame1));
 	Vector3 trans;
 	Vector3::Lerp(t0,t1,fraction,&trans);
 	mtx.Set_Translation(trans);
@@ -730,7 +730,7 @@ void HMorphAnimClass::Insert_Morph_Key(const int channel, uint32 morph_frame, ui
 	MorphKeyData[channel].Add_Key(morph_frame,pose_frame);
 
 	// update the framecount to reflect the newly added key
-	FrameCount = WWMath::Max(morph_frame,FrameCount);
+	FrameCount = std::max(int(morph_frame),FrameCount);
 }
 
 void HMorphAnimClass::Release_Keys(void)

--- a/Code/ww3d2/hrawanim.cpp
+++ b/Code/ww3d2/hrawanim.cpp
@@ -262,7 +262,7 @@ int HRawAnimClass::Load_W3D(ChunkLoadClass & cload)
 	NumNodes = base_pose->Num_Pivots();
 
 	NumFrames = aheader.NumFrames;
-	FrameRate = aheader.FrameRate;
+	FrameRate = float(aheader.FrameRate);
 
 	NodeMotion = new NodeMotionStruct[ NumNodes ];
 	if (NodeMotion == NULL) {

--- a/Code/ww3d2/htree.cpp
+++ b/Code/ww3d2/htree.cpp
@@ -613,7 +613,7 @@ void HTreeClass::Blend_Update
 			motion0->Get_Translation(trans0,piv_idx,frame0);
 			Vector3 trans1;
 			motion1->Get_Translation(trans1,piv_idx,frame1);
-			Vector3 lerped = (1.0 - percentage) * trans0 + (percentage) * trans1;
+			Vector3 lerped = (1.0f - percentage) * trans0 + (percentage) * trans1;
 			pivot->Transform.Translate(lerped * ScaleFactor);
 
 			// interpolated rotation

--- a/Code/ww3d2/intersec.inl
+++ b/Code/ww3d2/intersec.inl
@@ -112,9 +112,9 @@ inline void IntersectionClass::Get_Screen_Ray(float screen_x, float screen_y, co
 	float xscale = (max.X - min.X);
 	float yscale = (max.Y - min.Y);
 
-	float zmod = -1.0; // Scene->vpd; // Note: view plane distance is now always 1.0 from the camera
-	float xmod = (-ScreenX + 0.5 + viewport.Min.X) * zmod * xscale;// / aspect;
-	float ymod = (ScreenY - 0.5 - viewport.Min.Y) * zmod * yscale;// * aspect;
+	float zmod = -1.0f; // Scene->vpd; // Note: view plane distance is now always 1.0 from the camera
+	float xmod = (-ScreenX + 0.5f + viewport.Min.X) * zmod * xscale;// / aspect;
+	float ymod = (ScreenY - 0.5f - viewport.Min.Y) * zmod * yscale;// * aspect;
 
 //	float xmod = (ScreenX - 0.5 - viewport.Min.X) * zmod / Scene->axratio;
 //	float ymod = (ScreenY - 0.5 - viewport.Min.Y) * zmod / Scene->ayratio;
@@ -171,9 +171,9 @@ inline bool IntersectionClass::_Point_In_Polygon_Z(
 	// calculate alpha and beta as normalized (0..1) percentages across the 2d projected triangle
 	// and do bounds checking (sum <= 1)  to determine whether or not the triangle intersection occurs.
 
-	if (u1 == 0.0f)    {
+	if (u1 == 0.0)    {
 	  beta = u0 / u2;			// beta is the percentage down the edge Corner1->Corner3
-	  if ((beta >= 0.0f) && (beta <= 1.0f)) {		// make sure it's within the edge segment
+	  if ((beta >= 0.0) && (beta <= 1.0)) {		// make sure it's within the edge segment
 			alpha = (v0 - beta * v2) / v1;	 // alpha is the percentage down the edge Corner1->Corner2
 
 			// if alpha is valid & the sum of alpha & beta is <= 1 then it's within the triangle
@@ -194,7 +194,7 @@ inline bool IntersectionClass::_Point_In_Polygon_Z(
 		float u3 = Corner2[AXIS_3] - Corner1[AXIS_3];
 		float v3 = Corner3[AXIS_3] - Corner1[AXIS_3];
 
-		Point[AXIS_3] = u3 * alpha + v3 * beta + Corner1[AXIS_3];
+		Point[AXIS_3] = float(u3 * alpha + v3 * beta + Corner1[AXIS_3]);
 	}
 
 	return intersect;
@@ -250,19 +250,22 @@ inline bool IntersectionClass::_Point_In_Polygon(
 #endif
 
 	if (u1 == 0.0f)    {
-	  Beta = beta = u0 / u2;			// beta is the percentage down the edge loc1->loc3
+	  beta = u0 / u2;			// beta is the percentage down the edge loc1->loc3
+		Beta = float(beta);
 	  if ((beta >= 0.0f) && (beta <= 1.0f)) {		// make sure it's within the edge segment
-			Alpha = alpha = (v0 - beta * v2) / v1;	 // alpha is the percentage down the edge loc1->loc2
-
+			alpha = (v0 - beta * v2) / v1;	 // alpha is the percentage down the edge loc1->loc2
+			Alpha = float(alpha);
 			// if alpha is valid & the sum of alpha & beta is <= 1 then it's within the triangle
 			// note:       0.00001 added after testing an intersection of a square in the middle indicated
 			// an error of 0.0000001350, apparently due to roundoff.
 			intersect = ((alpha >= 0.0) && ((alpha + beta) <= 1.0)); 
 	  }
 	} else {
-	  Beta = beta = (v0 * u1 - u0 * v1) / (v2 * u1 - u2 * v1);
+	  beta = (v0 * u1 - u0 * v1) / (v2 * u1 - u2 * v1);
+		Beta = float(beta);
 	  if ((beta >= 0.0) && (beta <= 1.0)) {
-			Alpha = alpha = (u0 - beta * u2) / u1;
+			alpha = (u0 - beta * u2) / u1;
+			Alpha = float(alpha);
 			intersect = ((alpha >= 0.0) && ((alpha + beta) <= 1.0));
 	  }
 	}
@@ -337,7 +340,7 @@ inline float IntersectionClass::Plane_Z_Distance(Vector3 &PlaneNormal, Vector3 &
 	// determine distance to plane
 	double d = - (PlanePoint[0] * PlaneNormal[0] + PlanePoint[1] * PlaneNormal[1] + PlanePoint[2] * PlaneNormal[2]);
 
-	float value = - (d + PlaneNormal[0] * (*RayLocation)[0] + PlaneNormal[1] *  (*RayLocation)[1] + PlaneNormal[2] * (*RayLocation)[2]) / divisor;
+	float value = float(- (d + PlaneNormal[0] * (*RayLocation)[0] + PlaneNormal[1] *  (*RayLocation)[1] + PlaneNormal[2] * (*RayLocation)[2]) / divisor);
 
 	return value;
 }
@@ -358,7 +361,7 @@ inline float IntersectionClass::_Get_Z_Elevation(
 	// determine distance to plane
 	double d = - (PlanePoint[0] * PlaneNormal[0] + PlanePoint[1] * PlaneNormal[1] + PlanePoint[2] * PlaneNormal[2]);
 
-	float value = - (d + PlaneNormal[0] * Point[0] + PlaneNormal[1] *  Point[1] ) / PlaneNormal[2];
+	float value = float(- (d + PlaneNormal[0] * Point[0] + PlaneNormal[1] *  Point[1] ) / PlaneNormal[2]);
 
 	return value;
 }

--- a/Code/ww3d2/light.cpp
+++ b/Code/ww3d2/light.cpp
@@ -556,7 +556,7 @@ WW3DErrorType LightClass::Save_W3D(ChunkSaveClass & csave)
 	if (Get_Flag(NEAR_ATTENUATION)) {
 		csave.Begin_Chunk(W3D_CHUNK_NEAR_ATTENUATION);
 
-		double start,end;
+		float start,end;
 		Get_Near_Attenuation_Range(start,end);
 
 		W3dLightAttenuationStruct atten;
@@ -571,7 +571,7 @@ WW3DErrorType LightClass::Save_W3D(ChunkSaveClass & csave)
 	if (Get_Flag(FAR_ATTENUATION)) {
 		csave.Begin_Chunk(W3D_CHUNK_FAR_ATTENUATION);
 
-		double start,end;
+		float start,end;
 		Get_Far_Attenuation_Range(start,end);
 
 		W3dLightAttenuationStruct atten;

--- a/Code/ww3d2/light.h
+++ b/Code/ww3d2/light.h
@@ -116,10 +116,10 @@ public:
 	void						Set_Specular(const Vector3 & color) { Specular = color; }
 	void						Get_Specular(Vector3 * set_c) const { if (set_c) { *set_c = Specular; } }
 
-	void						Set_Far_Attenuation_Range(double fStart, double fEnd)				{ FarAttenStart = fStart; FarAttenEnd = fEnd; }
-	void						Get_Far_Attenuation_Range(double& fStart, double& fEnd) const	{ fStart = FarAttenStart; fEnd = FarAttenEnd; }
-	void						Set_Near_Attenuation_Range(double nStart, double nEnd)			{ NearAttenStart = nStart; NearAttenEnd = nEnd; }
-	void						Get_Near_Attenuation_Range(double& nStart, double& nEnd)	const	{ nStart = NearAttenStart; nEnd = NearAttenEnd; }
+	void						Set_Far_Attenuation_Range(float fStart, float fEnd)				{ FarAttenStart = fStart; FarAttenEnd = fEnd; }
+	void						Get_Far_Attenuation_Range(float& fStart, float& fEnd) const	{ fStart = FarAttenStart; fEnd = FarAttenEnd; }
+	void						Set_Near_Attenuation_Range(float nStart, float nEnd)			{ NearAttenStart = nStart; NearAttenEnd = nEnd; }
+	void						Get_Near_Attenuation_Range(float& nStart, float& nEnd)	const	{ nStart = NearAttenStart; nEnd = NearAttenEnd; }
 	float						Get_Attenuation_Range(void) const										{ return FarAttenEnd; }
 
 	/////////////////////////////////////////////////////////////////////////////

--- a/Code/ww3d2/lightenvironment.cpp
+++ b/Code/ww3d2/lightenvironment.cpp
@@ -101,7 +101,7 @@ void LightEnvironmentClass::InputLightStruct::Init_From_Point_Or_Spot_Light
 	/*
 	** Compute the attenuation factor
 	*/
-	double atten_start,atten_end;
+	float atten_start,atten_end;
 	light.Get_Far_Attenuation_Range(atten_start,atten_end);
 
 	float atten = 1.0f - (dist - atten_start) / (atten_end - atten_start);

--- a/Code/ww3d2/linegrp.cpp
+++ b/Code/ww3d2/linegrp.cpp
@@ -318,7 +318,7 @@ void	LineGroupClass::Render(RenderInfoClass &rinfo)
 	// construct the tetrahedra in the index buffers
 	// assume first vertex is the apex, followed by offset[0-3]
 
-	DynamicIBAccessClass iba(sort?BUFFER_TYPE_DYNAMIC_SORTING:BUFFER_TYPE_DYNAMIC_DX8,num_indices);
+	DynamicIBAccessClass iba(static_cast<unsigned short>(sort?BUFFER_TYPE_DYNAMIC_SORTING:BUFFER_TYPE_DYNAMIC_DX8),static_cast<unsigned short>(num_indices));
 
 	{
 		DynamicIBAccessClass::WriteLockClass lock(&iba);
@@ -386,7 +386,7 @@ void	LineGroupClass::Render(RenderInfoClass &rinfo)
 
 	// make the vertex buffers
 
-	DynamicVBAccessClass vba(sort ? BUFFER_TYPE_DYNAMIC_SORTING : BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,num_vertices);
+	DynamicVBAccessClass vba(sort ? BUFFER_TYPE_DYNAMIC_SORTING : BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,static_cast<unsigned short>(num_vertices));
 
 	{
 		DynamicVBAccessClass::WriteLockClass lock(&vba);
@@ -469,9 +469,9 @@ void	LineGroupClass::Render(RenderInfoClass &rinfo)
 	DX8Wrapper::Set_Vertex_Buffer(vba);
 
 	if (sort) {
-		SortingRendererClass::Insert_Triangles(0, num_tris, 0, num_vertices);
+		SortingRendererClass::Insert_Triangles(0, static_cast<unsigned short>(num_tris), 0, static_cast<unsigned short>(num_vertices));
 	} else {
-		DX8Wrapper::Draw_Triangles(0, num_tris, 0, num_vertices);
+		DX8Wrapper::Draw_Triangles(0, static_cast<unsigned short>(num_tris), 0, static_cast<unsigned short>(num_vertices));
 	}
 
 	// restore the matrices

--- a/Code/ww3d2/mapper.cpp
+++ b/Code/ww3d2/mapper.cpp
@@ -394,8 +394,8 @@ void SineLinearOffsetTextureMapperClass::Apply(int uv_array_index)
 
 	CurrentAngle+=delta*ms_to_radians;
 
-	float offset_u=UAFP.X*sin(UAFP.Y*CurrentAngle+UAFP.Z*WWMATH_PI);
-	float offset_v=VAFP.X*sin(VAFP.Y*CurrentAngle+VAFP.Z*WWMATH_PI);
+	float offset_u=UAFP.X*WWMath::Sin(UAFP.Y*CurrentAngle+UAFP.Z*WWMATH_PI);
+	float offset_v=VAFP.X*WWMath::Sin(VAFP.Y*CurrentAngle+VAFP.Z*WWMATH_PI);
 
 	// ensure both coordinates of offset are in [0, 1] range:
 	offset_u = offset_u - WWMath::Floor(offset_u);
@@ -462,7 +462,7 @@ void StepLinearOffsetTextureMapperClass::Apply(int uv_array_index)
 
 	if (num_steps!=0)
 	{
-		CurrentStep+=Step*num_steps;
+		CurrentStep+=Step*float(num_steps);
 		Remainder-=num_steps/(float)StepsPerMilliSec;
 	}
 

--- a/Code/ww3d2/matrixmapper.cpp
+++ b/Code/ww3d2/matrixmapper.cpp
@@ -147,7 +147,7 @@ void MatrixMapperClass::Update_View_To_Pixel_Transform(float tex_size)
 	** In addition, the z-coordinate is modified so that it goes from 0 to 1 rather than -1 to +1.
 	** It can also be flipped if the INVERT_DEPTH_GRADIENT flag is on.
 	*/
-	float k = 0.5 * (tex_size - 2.0f) / tex_size;
+	float k = 0.5f * (tex_size - 2.0f) / tex_size;
 
 	ViewToPixel[0][0] = k * ViewToTexture[0][0] + k * ViewToTexture[3][0];
 	ViewToPixel[0][1] = k * ViewToTexture[0][1] + k * ViewToTexture[3][1];

--- a/Code/ww3d2/mesh.cpp
+++ b/Code/ww3d2/mesh.cpp
@@ -893,7 +893,7 @@ void MeshClass::Render_Material_Pass(MaterialPassClass * pass,IndexBufferClass *
 			int min_v = Model->Get_Vertex_Count();
 			int max_v = 0;
 
-			DynamicIBAccessClass dynamic_ib(buftype,temp_apt.Count() * 3);
+			DynamicIBAccessClass dynamic_ib(static_cast<unsigned short>(buftype),static_cast<unsigned short>(temp_apt.Count() * 3));
 			{
 				DynamicIBAccessClass::WriteLockClass lock(&dynamic_ib);
 				unsigned short * indices = lock.Get_Index_Array();
@@ -901,21 +901,21 @@ void MeshClass::Render_Material_Pass(MaterialPassClass * pass,IndexBufferClass *
 
 				for (int i=0; i < temp_apt.Count(); i++)
 				{
-					unsigned v0 = polys[temp_apt[i]].I;
-					unsigned v1 = polys[temp_apt[i]].J;
-					unsigned v2 = polys[temp_apt[i]].K;
+					int v0 = polys[temp_apt[i]].I;
+					int v1 = polys[temp_apt[i]].J;
+					int v2 = polys[temp_apt[i]].K;
 
 					indices[i*3 + 0] = (unsigned short)v0;
 					indices[i*3 + 1] = (unsigned short)v1;
 					indices[i*3 + 2] = (unsigned short)v2;
 
-					min_v = WWMath::Min(v0,min_v);
-					min_v = WWMath::Min(v1,min_v);
-					min_v = WWMath::Min(v2,min_v);
+					min_v = std::min(v0,min_v);
+					min_v = std::min(v1,min_v);
+					min_v = std::min(v2,min_v);
 
-					max_v = WWMath::Max(v0,max_v);
-					max_v = WWMath::Max(v1,max_v);
-					max_v = WWMath::Max(v2,max_v);
+					max_v = std::max(v0,max_v);
+					max_v = std::max(v1,max_v);
+					max_v = std::max(v2,max_v);
 				}
 			}
 
@@ -926,13 +926,13 @@ void MeshClass::Render_Material_Pass(MaterialPassClass * pass,IndexBufferClass *
 			pass->Install_Materials();
 
 			DX8Wrapper::Set_Transform(D3DTS_WORLD,Get_Transform());
-			DX8Wrapper::Set_Index_Buffer(dynamic_ib,vertex_offset);
+			DX8Wrapper::Set_Index_Buffer(dynamic_ib,static_cast<unsigned short>(vertex_offset));
 
 			DX8Wrapper::Draw_Triangles(
 				0,
-				temp_apt.Count(),
-				min_v,
-				max_v-min_v+1);
+				static_cast<unsigned short>(temp_apt.Count()),
+				static_cast<unsigned short>(min_v),
+				static_cast<unsigned short>(max_v-min_v+1));
 		}
 	} else {
 

--- a/Code/ww3d2/meshbuild.cpp
+++ b/Code/ww3d2/meshbuild.cpp
@@ -1152,14 +1152,14 @@ void MeshBuilderClass::Compute_Bounding_Sphere(Vector3 * set_center,float * set_
 			radsqr = radius * radius;
 
 			double oldtonew = testrad - radius;
-			center.X = (radius * center.X + oldtonew * Verts[i].Position.X) / testrad;
-			center.Y = (radius * center.Y + oldtonew * Verts[i].Position.Y) / testrad;
-			center.Z = (radius * center.Z + oldtonew * Verts[i].Position.Z) / testrad;
+			center.X = float((radius * center.X + oldtonew * Verts[i].Position.X) / testrad);
+			center.Y = float((radius * center.Y + oldtonew * Verts[i].Position.Y) / testrad);
+			center.Z = float((radius * center.Z + oldtonew * Verts[i].Position.Z) / testrad);
 		}
 	}
 
 	*set_center = center;
-	*set_radius = radius;
+	*set_radius = float(radius);
 }
 
 /***********************************************************************************************

--- a/Code/ww3d2/meshgeometry.cpp
+++ b/Code/ww3d2/meshgeometry.cpp
@@ -1606,7 +1606,7 @@ WW3DErrorType MeshGeometryClass::Load_W3D(ChunkLoadClass & cload)
 	namelen += strlen(header.MeshName);
 	namelen += 2;
 	W3dAttributes = header.Attributes;
-	SortLevel = header.SortLevel;
+	SortLevel = char(header.SortLevel);
 	tmpname = new char[namelen];
 	memset(tmpname,0,namelen);
 
@@ -1861,9 +1861,9 @@ WW3DErrorType MeshGeometryClass::read_triangles(ChunkLoadClass & cload)
 		}
 
 		// set the vertex indices
-		vi[i].I = tri.Vindex[0];
-		vi[i].J = tri.Vindex[1];
-		vi[i].K = tri.Vindex[2];
+		vi[i].I = static_cast<unsigned short>(tri.Vindex[0]);
+		vi[i].J = static_cast<unsigned short>(tri.Vindex[1]);
+		vi[i].K = static_cast<unsigned short>(tri.Vindex[2]);
 
 		// set the normal
 		peq[i].X = tri.Normal.X;

--- a/Code/ww3d2/meshgeometry.h
+++ b/Code/ww3d2/meshgeometry.h
@@ -128,7 +128,7 @@ public:
 	void							Set_Flag(FlagsType flag,bool onoff)						{ if (onoff) {	Flags |= flag;	} else {	Flags &= ~flag; } }
 	int							Get_Flag(FlagsType flag)									{ return Flags & flag; }
 
-	void							Set_Sort_Level(int level)									{ SortLevel = level; }
+	void							Set_Sort_Level(int level)									{ SortLevel = char(level); }
 	int							Get_Sort_Level(void) const									{ return SortLevel; }
 
 	int							Get_Polygon_Count(void) const								{ return PolyCount; }

--- a/Code/ww3d2/meshmdl.cpp
+++ b/Code/ww3d2/meshmdl.cpp
@@ -676,7 +676,7 @@ WWASSERT(loc1==loc2 || loc1==loc3 || loc2==loc3);
 //vidx2=mmc->Get_Polygon_Array()[polygon_index][1];
 //vidx3=mmc->Get_Polygon_Array()[polygon_index][2];
 
-	PolygonArray[PolygonCount]=TriIndex(vidx1,vidx2,vidx3);
+	PolygonArray[PolygonCount]=TriIndex(static_cast<unsigned short>(vidx1),static_cast<unsigned short>(vidx2),static_cast<unsigned short>(vidx3));
 	for (int pass=0;pass<mmc->Get_Pass_Count();++pass) {
 		if (mmc->Has_Shader_Array(pass)) {
 			ShaderArray[pass][PolygonCount]=mmc->Get_Shader(polygon_index,pass);

--- a/Code/ww3d2/meshmdlio.cpp
+++ b/Code/ww3d2/meshmdlio.cpp
@@ -266,7 +266,7 @@ WW3DErrorType MeshModelClass::Load_W3D(ChunkLoadClass & cload)
 	namelen += strlen(context->Header.MeshName);
 	namelen += 2;
 	W3dAttributes = context->Header.Attributes;
-	SortLevel = context->Header.SortLevel;
+	SortLevel = char(context->Header.SortLevel);
 	tmpname = new char[namelen];
 	memset(tmpname,0,namelen);
 

--- a/Code/ww3d2/metalmap.cpp
+++ b/Code/ww3d2/metalmap.cpp
@@ -372,8 +372,8 @@ void MetalMapManagerClass::initialize_normal_table(void)
 			// Set vector to point to surface of unit sphere
 			normal.Set((step * (float)x) - 1.0f, (step * (float)y) - 1.0f, 0.0f);
 			float z2 = 1 - ((normal.X * normal.X) + (normal.Y * normal.Y));
-			z2 = MAX(z2, 0.0f);	// If outside the sphere, treat as if on its edge
-			normal.Z = sqrt(z2);
+			z2 = std::max(z2, 0.0f);	// If outside the sphere, treat as if on its edge
+			normal.Z = sqrtf(z2);
 			normal.Normalize();	// Needed for "outside sphere" case and for safety's sake
 
 			idx++;

--- a/Code/ww3d2/motchan.cpp
+++ b/Code/ww3d2/motchan.cpp
@@ -431,7 +431,7 @@ void	TimeCodedMotionChannelClass::Get_Vector(float32 frame,float * setvec)
 
   uint32	tc0;
 
-  tc0 = frame;
+  tc0 = uint32(frame);
 
   uint32 pidx = get_index( tc0 );
   uint32 p2idx;
@@ -463,8 +463,8 @@ void	TimeCodedMotionChannelClass::Get_Vector(float32 frame,float * setvec)
 		return;
    }
 
-  float32 time1 = (Data[pidx]  & ~W3D_TIMECODED_BINARY_MOVEMENT_FLAG);
-  float32 time2 = (time & ~W3D_TIMECODED_BINARY_MOVEMENT_FLAG);
+  float32 time1 = float32(Data[pidx]  & ~W3D_TIMECODED_BINARY_MOVEMENT_FLAG);
+  float32 time2 = float32(time & ~W3D_TIMECODED_BINARY_MOVEMENT_FLAG);
 
   float32 ratio = (frame - time1) / (time2 - time1);
 
@@ -489,7 +489,7 @@ Quaternion TimeCodedMotionChannelClass::Get_QuatVector(float32 frame)
 
 	uint32	tc0;
 
-	tc0 = frame;
+	tc0 = uint32(frame);
 
 	uint32 pidx = get_index( tc0 );
 	uint32 p2idx;
@@ -518,8 +518,8 @@ Quaternion TimeCodedMotionChannelClass::Get_QuatVector(float32 frame)
 		return( q );
 	}
 
-	float32 time1 = (Data[pidx]  & ~W3D_TIMECODED_BINARY_MOVEMENT_FLAG);
-	float32 time2 = (time & ~W3D_TIMECODED_BINARY_MOVEMENT_FLAG);
+	float32 time1 = float32(Data[pidx]  & ~W3D_TIMECODED_BINARY_MOVEMENT_FLAG);
+	float32 time2 = float32(time & ~W3D_TIMECODED_BINARY_MOVEMENT_FLAG);
 
 	float32 ratio = (frame - time1) / (time2 - time1);
 
@@ -867,12 +867,12 @@ AdaptiveDeltaMotionChannelClass::AdaptiveDeltaMotionChannelClass(void) :
 
 		for (int i=0; i<FILTER_TABLE_GEN_SIZE; i++)
 		{
-			float ratio = i;
+			float ratio = float(i);
 
 			//ratio = ((ratio + 1.0f) / 128.0f);
 			ratio/=((float) FILTER_TABLE_GEN_SIZE);
 
-			filtertable[i + FILTER_TABLE_GEN_START] = 1.0f - WWMath::Sin( DEG_TO_RAD(90.0f * ratio));
+			filtertable[i + FILTER_TABLE_GEN_START] = 1.0f - WWMath::Sin( DEG_TO_RADF(90.0f * ratio));
 		}
 
 		table_valid = true;
@@ -1027,7 +1027,7 @@ void AdaptiveDeltaMotionChannelClass::decompress(uint32 frame_idx, float *outdat
 
 				// Convert to Floating Point
 
-				float ffactor = factor;
+				float ffactor = float(factor);
 
 				float delta = ffactor * filter;
 
@@ -1107,7 +1107,7 @@ void AdaptiveDeltaMotionChannelClass::decompress(uint32 src_idx, float *srcdata,
 
 				// Convert to Floating Point
 
-				float ffactor = factor;
+				float ffactor = float(factor);
 
 				float delta = ffactor * filter;
 
@@ -1226,7 +1226,7 @@ float AdaptiveDeltaMotionChannelClass::getframe(uint32 frame_idx, uint32 vector_
 void	AdaptiveDeltaMotionChannelClass::Get_Vector(float32 frame,float * setvec)
 {
 
-	uint32 frame1 = frame;
+	uint32 frame1 = uint32(frame);
 
 	float ratio = frame - frame1;
 
@@ -1245,7 +1245,7 @@ void	AdaptiveDeltaMotionChannelClass::Get_Vector(float32 frame,float * setvec)
 Quaternion AdaptiveDeltaMotionChannelClass::Get_QuatVector(float32 frame)
 {
 
-	uint32 frame1 = frame;
+	uint32 frame1 = uint32(frame);
 	uint32 frame2 = frame1+1;
 	float ratio = frame - frame1;
 
@@ -1294,7 +1294,7 @@ Get_Vector(int frame,float * setvec) const{
 			WWASSERT(CompressedData);
 			float scale=ValueScale/65535.0f;
 			for (int i=0; i<VectorLen; i++) {
-				float value=int(CompressedData[vframe * VectorLen + i]);
+				float value=float(CompressedData[vframe * VectorLen + i]);
 				setvec[i] = value*scale+ValueOffset;
 			}
 		}

--- a/Code/ww3d2/part_buf.cpp
+++ b/Code/ww3d2/part_buf.cpp
@@ -107,7 +107,7 @@ ParticleBufferClass::ParticleBufferClass
 	NewParticleQueueCount(0U),
 	RenderMode(render_mode),
 	FrameMode(frame_mode),
-	MaxAge(1000.0f * max_age),
+	MaxAge(int(1000.0f * max_age)),
 	LastUpdateTime(WW3D::Get_Sync_Time()),
 	IsEmitterDead(false),
 	MaxSize(0.0f),
@@ -229,7 +229,7 @@ ParticleBufferClass::ParticleBufferClass
 			PointGroup->Set_Flag(PointGroupClass::TRANSFORM, true);
 			PointGroup->Set_Texture(tex);
 			PointGroup->Set_Shader(shader);
-			PointGroup->Set_Frame_Row_Column_Count_Log2(frame_mode);
+			PointGroup->Set_Frame_Row_Column_Count_Log2(static_cast<unsigned char>(frame_mode));
 			PointGroup->Set_Point_Mode(PointGroupClass::TRIS);
 		}
 		break;
@@ -240,7 +240,7 @@ ParticleBufferClass::ParticleBufferClass
 			PointGroup->Set_Flag(PointGroupClass::TRANSFORM, true);
 			PointGroup->Set_Texture(tex);
 			PointGroup->Set_Shader(shader);
-			PointGroup->Set_Frame_Row_Column_Count_Log2(frame_mode);
+			PointGroup->Set_Frame_Row_Column_Count_Log2(static_cast<unsigned char>(frame_mode));
 			PointGroup->Set_Point_Mode(PointGroupClass::QUADS);
 		}
 		break;
@@ -1772,7 +1772,7 @@ void ParticleBufferClass::Reset_Size(ParticlePropertyStruct<float> &new_props)
 		float last_size = SizeKeyFrameValues[NumSizeKeyFrames - 1] + SizeKeyFrameDeltas[NumSizeKeyFrames - 1] *
 			(float)(MaxAge - SizeKeyFrameTimes[NumSizeKeyFrames - 1]);
 		MaxSize = MAX(MaxSize, last_size);
-		MaxSize += fabs(new_props.Rand);
+		MaxSize += WWMath::Fabs(new_props.Rand);
 
 		// Set up size randomizer table
 
@@ -2992,7 +2992,7 @@ void ParticleBufferClass::Get_Color_Key_Frames (ParticlePropertyStruct<Vector3> 
 			//
 			Vector3 start_color = ColorKeyFrameValues[index - 1];
 			Vector3 &delta = ColorKeyFrameDeltas[NumColorKeyFrames - 1];
-			float time_delta = MaxAge - ColorKeyFrameTimes[index - 1];
+			float time_delta = float(MaxAge - ColorKeyFrameTimes[index - 1]);
 			colors.Values[index - 1] = start_color + (delta * time_delta);
 		}
 	}
@@ -3048,7 +3048,7 @@ void ParticleBufferClass::Get_Opacity_Key_Frames (ParticlePropertyStruct<float> 
 			//
 			float start_alpha = AlphaKeyFrameValues[index - 1];
 			float &delta = AlphaKeyFrameDeltas[NumAlphaKeyFrames - 1];
-			float time_delta = MaxAge - AlphaKeyFrameTimes[index - 1];
+			float time_delta = float(MaxAge - AlphaKeyFrameTimes[index - 1]);
 			opacities.Values[index - 1] = start_alpha + (delta * time_delta);
 		}
 	}
@@ -3105,7 +3105,7 @@ void ParticleBufferClass::Get_Size_Key_Frames (ParticlePropertyStruct<float> &si
 			//
 			float start_size			= SizeKeyFrameValues[index - 1];
 			float &delta				= SizeKeyFrameDeltas[NumSizeKeyFrames - 1];
-			float time_delta			= MaxAge - SizeKeyFrameTimes[index - 1];
+			float time_delta			= float(MaxAge - SizeKeyFrameTimes[index - 1]);
 			sizes.Values[index - 1]	= start_size + (delta * time_delta);
 		}
 	}
@@ -3167,7 +3167,7 @@ void ParticleBufferClass::Get_Rotation_Key_Frames (ParticlePropertyStruct<float>
 			//
 			float start_rotation				= RotationKeyFrameValues[index - 1];
 			float delta							= 2.0f * HalfRotationKeyFrameDeltas[NumRotationKeyFrames - 1];
-			float time_delta					= MaxAge - RotationKeyFrameTimes[index - 1];
+			float time_delta					= float(MaxAge - RotationKeyFrameTimes[index - 1]);
 			rotations.Values[index - 1]	= (start_rotation + (delta * time_delta)) * 1000.0f;
 		}
 	}
@@ -3224,7 +3224,7 @@ void ParticleBufferClass::Get_Frame_Key_Frames (ParticlePropertyStruct<float> &f
 			//
 			float start_frame			= FrameKeyFrameValues[index - 1];
 			float &delta				= FrameKeyFrameDeltas[NumFrameKeyFrames - 1];
-			float time_delta			= MaxAge - FrameKeyFrameTimes[index - 1];
+			float time_delta			= float(MaxAge - FrameKeyFrameTimes[index - 1]);
 			frames.Values[index - 1]	= start_frame + (delta * time_delta);
 		}
 	}
@@ -3280,7 +3280,7 @@ void ParticleBufferClass::Get_Blur_Time_Key_Frames (ParticlePropertyStruct<float
 			//
 			float start_blurtime		= BlurTimeKeyFrameValues[index - 1];
 			float &delta				= BlurTimeKeyFrameDeltas[NumBlurTimeKeyFrames - 1];
-			float time_delta			= MaxAge - BlurTimeKeyFrameTimes[index - 1];
+			float time_delta			= float(MaxAge - BlurTimeKeyFrameTimes[index - 1]);
 			blurtimes.Values[index - 1]	= start_blurtime + (delta * time_delta);
 		}
 	}

--- a/Code/ww3d2/part_emt.cpp
+++ b/Code/ww3d2/part_emt.cpp
@@ -106,10 +106,10 @@ ParticleEmitterClass::ParticleEmitterClass(float emit_rate, unsigned int burst_s
 	// The maximum number of particles is determined by the emission rate, burst size and lifetime.
 	// However, it is capped both by the particle cap and by the maximum buffer size, if these are
 	// active.
-	int max_num = BurstSize * emit_rate * (max_age + 1);
+	int max_num = int(BurstSize * emit_rate * (max_age + 1));
 	if (max_particles > 0) max_num = MIN(max_num, max_particles);
 	if (max_buffer_size > 0) max_num = MIN(max_num, max_buffer_size);
-	max_num = MAX(max_num, 2);	// max_num of 1 causes problems
+	max_num = std::max(max_num, 2);	// max_num of 1 causes problems
 
 	Buffer = new ParticleBufferClass(this, max_num, color, opacity, size, rotation, orient_rnd,
 		frames, blur_times, accel/1000000.0f,max_age, tex, shader, pingpong, render_mode, frame_mode,
@@ -268,7 +268,7 @@ ParticleEmitterClass::Create_From_Definition (const ParticleEmitterDefClass &def
 																definition.Get_Lifetime (),
 																ptexture,
 																shader,
-																definition.Get_Max_Emissions (),
+																int(definition.Get_Max_Emissions ()),
 																0,
 																false,
 																definition.Get_Render_Mode (),
@@ -713,7 +713,7 @@ ParticleEmitterClass::Build_Definition (void) const
 		pdefinition->Set_Name (Get_Name ());
 		pdefinition->Set_Lifetime (Get_Lifetime ());
 		pdefinition->Set_Emission_Rate (Get_Emission_Rate ());
-		pdefinition->Set_Max_Emissions (Get_Max_Particles ());
+		pdefinition->Set_Max_Emissions (float(Get_Max_Particles ()));
 		pdefinition->Set_Fade_Time (Get_Fade_Time ());
 		pdefinition->Set_Gravity (0);
 		pdefinition->Set_Elasticity (0);

--- a/Code/ww3d2/pointgr.cpp
+++ b/Code/ww3d2/pointgr.cpp
@@ -892,7 +892,7 @@ void PointGroupClass::Render(RenderInfoClass &/*rinfo*/)
 	while (current<vnum)
 	{
 		delta=MIN(vnum-current,MAX_VB_SIZE);
-		DynamicVBAccessClass PointVerts (sort ? BUFFER_TYPE_DYNAMIC_SORTING : BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, delta);
+		DynamicVBAccessClass PointVerts (sort ? BUFFER_TYPE_DYNAMIC_SORTING : BUFFER_TYPE_DYNAMIC_DX8, dynamic_fvf_type, static_cast<unsigned short>(delta));
 
 		// Copy in the data to the VB
 		{
@@ -920,9 +920,9 @@ void PointGroupClass::Render(RenderInfoClass &/*rinfo*/)
 		DX8Wrapper::Set_Index_Buffer (indexbuffer, 0);
 		DX8Wrapper::Set_Vertex_Buffer (PointVerts);
 		if (sort) {
-			SortingRendererClass::Insert_Triangles (0, delta / verticesperprimitive, 0, delta);
+			SortingRendererClass::Insert_Triangles (0, static_cast<unsigned short>(delta / verticesperprimitive), 0, static_cast<unsigned short>(delta));
 		} else {
-			DX8Wrapper::Draw_Triangles (0, delta / verticesperprimitive, 0, delta);
+			DX8Wrapper::Draw_Triangles (0, static_cast<unsigned short>(delta / verticesperprimitive), 0, static_cast<unsigned short>(delta));
 		}
 
 		current+=delta;

--- a/Code/ww3d2/projector.cpp
+++ b/Code/ww3d2/projector.cpp
@@ -150,8 +150,8 @@ void ProjectorClass::Set_Perspective_Projection(float hfov,float vfov,float znea
 	Mapper->Set_Type(MatrixMapperClass::PERSPECTIVE_PROJECTION);
 	Projection.Init_Perspective(hfov,vfov,0.1f,zfar);					// don't use znear for the projection matrix
 
-	float tan_hfov2 = tan(hfov) * 0.5f;
-	float tan_vfov2 = tan(vfov) * 0.5f;
+	float tan_hfov2 = WWMath::Tan(hfov) * 0.5f;
+	float tan_vfov2 = WWMath::Tan(vfov) * 0.5f;
 
 	LocalBoundingVolume.Center.Set(0.0f,0.0f,-(zfar+znear)*0.5f);	// note, zcenter is negative
 	LocalBoundingVolume.Extent.X = zfar * tan_hfov2;

--- a/Code/ww3d2/render2d.cpp
+++ b/Code/ww3d2/render2d.cpp
@@ -359,32 +359,32 @@ void	Render2DClass::Internal_Add_Quad_Indicies( int start_vert_index, bool backf
 
 	if (backfaced ^ (CoordinateScale.X * CoordinateScale.Y > 0)) {
 		indices=Indices.Uninitialized_Add();
-		*indices = start_vert_index + 1;
+		*indices = static_cast<unsigned short>(start_vert_index + 1);
 		indices=Indices.Uninitialized_Add();
-		*indices = start_vert_index + 0;
+		*indices = static_cast<unsigned short>(start_vert_index + 0);
 		indices=Indices.Uninitialized_Add();
-		*indices = start_vert_index + 2;
+		*indices = static_cast<unsigned short>(start_vert_index + 2);
 
 		indices=Indices.Uninitialized_Add();
-		*indices = start_vert_index + 1;
+		*indices = static_cast<unsigned short>(start_vert_index + 1);
 		indices=Indices.Uninitialized_Add();
-		*indices = start_vert_index + 2;
+		*indices = static_cast<unsigned short>(start_vert_index + 2);
 		indices=Indices.Uninitialized_Add();
-		*indices = start_vert_index + 3;
+		*indices = static_cast<unsigned short>(start_vert_index + 3);
 	} else {
 		indices=Indices.Uninitialized_Add();
-		*indices = start_vert_index + 0;
+		*indices = static_cast<unsigned short>(start_vert_index + 0);
 		indices=Indices.Uninitialized_Add();
-		*indices = start_vert_index + 1;
+		*indices = static_cast<unsigned short>(start_vert_index + 1);
 		indices=Indices.Uninitialized_Add();
-		*indices = start_vert_index + 2;
+		*indices = static_cast<unsigned short>(start_vert_index + 2);
 
 		indices=Indices.Uninitialized_Add();
-		*indices = start_vert_index + 2;
+		*indices = static_cast<unsigned short>(start_vert_index + 2);
 		indices=Indices.Uninitialized_Add();
-		*indices = start_vert_index + 1;
+		*indices = static_cast<unsigned short>(start_vert_index + 1);
 		indices=Indices.Uninitialized_Add();
-		*indices = start_vert_index + 3;
+		*indices = static_cast<unsigned short>(start_vert_index + 3);
 	}
 
 }
@@ -478,9 +478,9 @@ void	Render2DClass::Add_Tri( const Vector2 & v0, const Vector2 & v1, const Vecto
 	*Colors.Uninitialized_Add()=color;
 
 	// Add the faces
-	*Indices.Uninitialized_Add()=old_vert_count + 0;
-	*Indices.Uninitialized_Add()=old_vert_count + 1;
-	*Indices.Uninitialized_Add()=old_vert_count + 2;
+	*Indices.Uninitialized_Add()=static_cast<unsigned short>(old_vert_count + 0);
+	*Indices.Uninitialized_Add()=static_cast<unsigned short>(old_vert_count + 1);
+	*Indices.Uninitialized_Add()=static_cast<unsigned short>(old_vert_count + 2);
 
 }
 
@@ -576,7 +576,7 @@ void Render2DClass::Render(void)
 	DX8Wrapper::Set_View_Identity();
 	DX8Wrapper::Set_Transform(D3DTS_PROJECTION,identity);
 
-	DynamicVBAccessClass vb(BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,Vertices.Count());
+	DynamicVBAccessClass vb(BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,static_cast<unsigned short>(Vertices.Count()));
 	{
 		DynamicVBAccessClass::WriteLockClass Lock(&vb);
 		const FVFInfoClass &fi=vb.FVF_Info();
@@ -593,7 +593,7 @@ void Render2DClass::Render(void)
 		}
 	}
 
-	DynamicIBAccessClass ib(BUFFER_TYPE_DYNAMIC_DX8,Indices.Count());
+	DynamicIBAccessClass ib(BUFFER_TYPE_DYNAMIC_DX8,static_cast<unsigned short>(Indices.Count()));
 	{
 		DynamicIBAccessClass::WriteLockClass Lock(&ib);
 		unsigned short *mem=Lock.Get_Index_Array();
@@ -603,7 +603,7 @@ void Render2DClass::Render(void)
 
 	DX8Wrapper::Set_Vertex_Buffer(vb);
 	DX8Wrapper::Set_Index_Buffer(ib,0);
-	DX8Wrapper::Draw_Triangles(0,Indices.Count()/3,0,Vertices.Count());
+	DX8Wrapper::Draw_Triangles(0,static_cast<unsigned short>(Indices.Count()/3),0,static_cast<unsigned short>(Vertices.Count()));
 
 	DX8Wrapper::Set_Transform(D3DTS_VIEW,view);
 	DX8Wrapper::Set_Transform(D3DTS_PROJECTION,proj);

--- a/Code/ww3d2/render2dsentence.cpp
+++ b/Code/ww3d2/render2dsentence.cpp
@@ -302,7 +302,7 @@ Render2DSentenceClass::Get_Text_Extents (const unichar_t *text)
 		return(temp);
 	}
 
-	Vector2 extent (0, Font->Get_Char_Height());
+	Vector2 extent (0, float(Font->Get_Char_Height()));
 
 	while (*text) {
 		unichar_t ch = *text++;
@@ -336,7 +336,7 @@ Render2DSentenceClass::Find_Row_Start( const unichar_t * text, int row_index )
 
 	float max_x_pos	= 0;
 	float x_pos			= 0;
-	float y_pos			= Font->Get_Char_Height ();
+	float y_pos			= float(Font->Get_Char_Height ());
 
 	int row_counter = 0;
 
@@ -354,7 +354,7 @@ Render2DSentenceClass::Find_Row_Start( const unichar_t * text, int row_index )
 			//	Find the width of the next word
 			//
 			const unichar_t *word	= text;
-			float word_width = Font->Get_Char_Spacing (ch);
+			float word_width = float(Font->Get_Char_Spacing (ch));
 			while ((*word != 0) && ((*word > U_CHAR(' ')) && !IS_BREAK_CHAR (*word))) {
 				word_width += Font->Get_Char_Spacing (*word++);
 			}
@@ -412,7 +412,7 @@ Render2DSentenceClass::Get_Formatted_Text_Extents (const unichar_t *text, int *r
 
 	float max_x_pos	= 0;
 	float x_pos			= 0;
-	float y_pos			= Font->Get_Char_Height ();
+	float y_pos			= float(Font->Get_Char_Height ());
 
 	int row_counter = 0;
 
@@ -430,7 +430,7 @@ Render2DSentenceClass::Get_Formatted_Text_Extents (const unichar_t *text, int *r
 			//	Find the width of the next word
 			//
 			const unichar_t *word	= text;
-			float word_width = Font->Get_Char_Spacing (ch);
+			float word_width = float(Font->Get_Char_Spacing (ch));
 			while ((*word != 0) && ((*word > U_CHAR(' ')) && !IS_BREAK_CHAR (*word))) {
 				word_width += Font->Get_Char_Spacing (*word++);
 			}
@@ -760,7 +760,7 @@ Render2DSentenceClass::Record_Sentence_Chunk (void)
 	//
 	int width = TextureOffset.I - TextureStartX;
 	if (width > 0) {
-		float char_height = Font->Get_Char_Height ();
+		float char_height = float(Font->Get_Char_Height ());
 
 		//
 		//	Build a structure that contains enough information
@@ -773,9 +773,9 @@ Render2DSentenceClass::Record_Sentence_Chunk (void)
 		sentence_data.ScreenRect.Right	= Cursor.X + width;
 		sentence_data.ScreenRect.Top		= Cursor.Y;
 		sentence_data.ScreenRect.Bottom	= Cursor.Y + char_height;
-		sentence_data.UVRect.Left			= TextureStartX;
-		sentence_data.UVRect.Top			= TextureOffset.J;
-		sentence_data.UVRect.Right			= TextureOffset.I;
+		sentence_data.UVRect.Left			= float(TextureStartX);
+		sentence_data.UVRect.Top			= float(TextureOffset.J);
+		sentence_data.UVRect.Right			= float(TextureOffset.I);
 		sentence_data.UVRect.Bottom		= TextureOffset.J + char_height;
 
 		//
@@ -910,7 +910,7 @@ Render2DSentenceClass::Build_Sentence (const unichar_t *text)
 		Allocate_New_Surface (text);
 	}
 
-	float char_height = Font->Get_Char_Height ();
+	float char_height = float(Font->Get_Char_Height ());
 
 	//
 	//	Loop over all the characters in the string
@@ -921,7 +921,7 @@ Render2DSentenceClass::Build_Sentence (const unichar_t *text)
 		//
 		//	Determine how much horizontal space this character requires
 		//
-		float char_spacing = Font->Get_Char_Spacing (ch);
+		float char_spacing = float(Font->Get_Char_Spacing (ch));
 
 		bool exceeded_texture_width	= ((TextureOffset.I + char_spacing) >= CurrTextureSize);
 		bool encountered_break_char	= (IS_BREAK_CHAR (ch) || ch == U_CHAR('\n') || ch == 0 || ch == U_CHAR('\t'));
@@ -977,7 +977,7 @@ Render2DSentenceClass::Build_Sentence (const unichar_t *text)
 				break;
 			} else if (ch == U_CHAR('\t')) {
 				float tab_spacing = (char_spacing * TabStop);
-				float tab_pos = (floor(Cursor.X / tab_spacing) * tab_spacing);
+				float tab_pos = (WWMath::Floor(Cursor.X / tab_spacing) * tab_spacing);
 				Cursor.X = (tab_pos + tab_spacing);
 			}
 
@@ -987,7 +987,7 @@ Render2DSentenceClass::Build_Sentence (const unichar_t *text)
 			if (exceeded_texture_width) {
 				TextureStartX		= 0;
 				TextureOffset.I	= TextureStartX;
-				TextureOffset.J	+= char_height;
+				TextureOffset.J	+= int(char_height);
 
 				//
 				//	Did the text extent completely off the texture?
@@ -1017,7 +1017,7 @@ Render2DSentenceClass::Build_Sentence (const unichar_t *text)
 			//	Blit the character to the surface
 			//
 			Font->Blit_Char (ch, LockedPtr, LockedStride, TextureOffset.I, TextureOffset.J);
-			TextureOffset.I += char_spacing;
+			TextureOffset.I += int(char_spacing);
 		}
 	}
 
@@ -1354,7 +1354,7 @@ FontCharsClass::Store_GDI_Char (unichar_t ch)
 	//
 	CharDataStruct *char_data	= new CharDataStruct;
 	char_data->Value				= ch;
-	char_data->Width				= char_size.cx;
+	char_data->Width				= short(char_size.cx);
 	char_data->Buffer				= BufferList[BufferList.Count () - 1] + CurrPixelOffset;
 
 	//

--- a/Code/ww3d2/ringobj.cpp
+++ b/Code/ww3d2/ringobj.cpp
@@ -375,7 +375,7 @@ void RingRenderObjClass::Generate_Shared_Mesh_Arrays (void)
 
 		for(int i=0; i < RING_NUM_LOD; i++) {
 
-			RingMeshArray[i].Generate(1.0f, size);
+			RingMeshArray[i].Generate(1.0f, int(size));
 
 			size+=step;
 		}
@@ -514,7 +514,7 @@ void RingRenderObjClass::render_ring(RenderInfoClass & /*rinfo*/,const Vector3 &
 	DX8Wrapper::Set_Texture(0,RingTexture);
 	DX8Wrapper::Set_Material(RingMaterial);
 
-	DynamicVBAccessClass vb(BUFFER_TYPE_DYNAMIC_SORTING,dynamic_fvf_type,ring.Vertex_ct);
+	DynamicVBAccessClass vb(BUFFER_TYPE_DYNAMIC_SORTING,dynamic_fvf_type,static_cast<unsigned short>(ring.Vertex_ct));
 	{
 		DynamicVBAccessClass::WriteLockClass Lock(&vb);
 		VertexFormatXYZNDUV2 *fva = Lock.Get_Formatted_Vertex_Array();
@@ -549,7 +549,7 @@ void RingRenderObjClass::render_ring(RenderInfoClass & /*rinfo*/,const Vector3 &
 		}
 	}
 
-	DynamicIBAccessClass ib(BUFFER_TYPE_DYNAMIC_SORTING,ring.face_ct*3);
+	DynamicIBAccessClass ib(BUFFER_TYPE_DYNAMIC_SORTING,static_cast<unsigned short>(ring.face_ct*3));
 	{
 		DynamicIBAccessClass::WriteLockClass Lock(&ib);
 		unsigned short *mem=Lock.Get_Index_Array();
@@ -565,7 +565,7 @@ void RingRenderObjClass::render_ring(RenderInfoClass & /*rinfo*/,const Vector3 &
 	DX8Wrapper::Set_Index_Buffer(ib,0);
 
 #if (STATIC_SORT_RINGS)
-	DX8Wrapper::Draw_Triangles(0,ring.face_ct,0,ring.Vertex_ct);
+	DX8Wrapper::Draw_Triangles(0,static_cast<unsigned short>(ring.face_ct),0,static_cast<unsigned short>(ring.Vertex_ct));
 #else
 	SortingRendererClass::Insert_Triangles(
 		Get_Bounding_Sphere(),
@@ -677,7 +677,7 @@ void RingRenderObjClass::Render(RenderInfoClass & rinfo)
 		screen_size = sqrtf(screen_size);
 
 		float lod     = screen_size * ((float) RING_NUM_LOD);
-		int	lod_int = lod;
+		int	lod_int = int(lod);
 		lod-=lod_int;
 
 		if (lod >= 0.5f) lod_int++;
@@ -1017,7 +1017,7 @@ void RingRenderObjClass::animate()
 			// Convert from milliseconds to seconds and normalize the time
 			//
 			if (AnimDuration > 0) {
-				float	frametime = WW3D::Get_Frame_Time();
+				float	frametime = float(WW3D::Get_Frame_Time());
 				frametime = (frametime * 0.001F) / AnimDuration;
 				anim_time += frametime;
 			} else {
@@ -1459,9 +1459,9 @@ void RingMeshClass::Generate(float radius, int slices)
 	//	Make the triangle strip...
 	//
 	for (index = 0; index < face_ct; index ++) {
-		tri_poly[index].I = index;
-		tri_poly[index].J = index+1;
-		tri_poly[index].K = index+2;
+		tri_poly[index].I = static_cast<unsigned short>(index);
+		tri_poly[index].J = static_cast<unsigned short>(index+1);
+		tri_poly[index].K = static_cast<unsigned short>(index+2);
 	}
 
 	return ;

--- a/Code/ww3d2/segline.cpp
+++ b/Code/ww3d2/segline.cpp
@@ -465,7 +465,7 @@ void SegmentedLineClass::Decrement_LOD(void)
 
 float SegmentedLineClass::Get_Cost(void) const
 {
-	return Get_Num_Polys();
+	return float(Get_Num_Polys());
 }
 
 float SegmentedLineClass::Get_Value(void) const

--- a/Code/ww3d2/seglinerenderer.cpp
+++ b/Code/ww3d2/seglinerenderer.cpp
@@ -184,7 +184,7 @@ void SegLineRendererClass::Set_Texture_Tile_Factor(float factor)
 		factor = 8.0f;
 		WWDEBUG_SAY(("Texture Tile Factor too large in SegLineRendererClass!\r\n"));
 	} else {
-		factor = MAX(factor, 0.0f);
+		factor = std::max(factor, 0.0f);
 	}
 	TextureTileFactor = factor;
 }
@@ -221,8 +221,8 @@ void SegLineRendererClass::Render
 	Vector2 uv_offset = CurrentUVOffset + UVOffsetDeltaPerMS * del;
 
 	// ensure offsets are in [0, 1] range:
-	uv_offset.X = uv_offset.X - floor(uv_offset.X);
-	uv_offset.Y = uv_offset.Y - floor(uv_offset.Y);
+	uv_offset.X = uv_offset.X - WWMath::Floor(uv_offset.X);
+	uv_offset.Y = uv_offset.Y - WWMath::Floor(uv_offset.Y);
 
 	// Update state
 	CurrentUVOffset = uv_offset;
@@ -251,7 +251,7 @@ void SegLineRendererClass::Render
 	// iteration so we don't need another one).
 	for (unsigned int chidx = 0; chidx < num_points - 1; chidx += (chunk_size - 1)) {
 		unsigned int point_cnt = num_points - chidx;
-		point_cnt = MIN(point_cnt, chunk_size);
+		point_cnt = std::min(point_cnt, chunk_size);
 
 		// We use these different loop indices (which loop INSIDE a chunk) to improve readability:
 		unsigned int pidx;	// Point index
@@ -925,7 +925,7 @@ void SegLineRendererClass::Render
 		unsigned int residual_bottom_points = intersection[1][BOTTOM_EDGE].PointCount;
 
 		// Reduce both pointcounts by the same amount so the smaller one is 1 (skip points)
-		unsigned int residual_delta = MIN(residual_top_points, residual_bottom_points) - 1;
+		unsigned int residual_delta = std::min(residual_top_points, residual_bottom_points) - 1;
 		residual_top_points -= residual_delta;
 		residual_bottom_points -= residual_delta;
 		pidx += residual_delta;
@@ -934,13 +934,13 @@ void SegLineRendererClass::Render
 
 			if (residual_top_points == 1 && residual_bottom_points == 1) {
 				// Advance both intersections, creating a tristrip segment
-				v_index_array[tidx].I = last_top_vidx;
-				v_index_array[tidx].J = last_bottom_vidx;
-				v_index_array[tidx].K = vidx;
+				v_index_array[tidx].I = static_cast<unsigned short>(last_top_vidx);
+				v_index_array[tidx].J = static_cast<unsigned short>(last_bottom_vidx);
+				v_index_array[tidx].K = static_cast<unsigned short>(vidx);
 				tidx++;
-				v_index_array[tidx].I = last_bottom_vidx;
-				v_index_array[tidx].J = vidx + 1;
-				v_index_array[tidx].K = vidx;
+				v_index_array[tidx].I = static_cast<unsigned short>(last_bottom_vidx);
+				v_index_array[tidx].J = static_cast<unsigned short>(vidx + 1);
+				v_index_array[tidx].K = static_cast<unsigned short>(vidx);
 				tidx++;
 				last_top_vidx = vidx;
 				last_bottom_vidx = vidx + 1;
@@ -976,9 +976,9 @@ void SegLineRendererClass::Render
 				// Exactly one of the pointcounts is greater than one - advance it and draw one triangle
 				if (residual_top_points > 1) {
 					// Draw one triangle (fan segment)
-					v_index_array[tidx].I = last_top_vidx;
-					v_index_array[tidx].J = last_bottom_vidx;
-					v_index_array[tidx].K = vidx;
+					v_index_array[tidx].I = static_cast<unsigned short>(last_top_vidx);
+					v_index_array[tidx].J = static_cast<unsigned short>(last_bottom_vidx);
+					v_index_array[tidx].K = static_cast<unsigned short>(vidx);
 					tidx++;
 					last_bottom_vidx = vidx;
 
@@ -1005,9 +1005,9 @@ void SegLineRendererClass::Render
 					// residual_bottom_points > 1
 
 					// Draw one triangle (fan segment)
-					v_index_array[tidx].I = last_top_vidx;
-					v_index_array[tidx].J = last_bottom_vidx;
-					v_index_array[tidx].K = vidx;
+					v_index_array[tidx].I = static_cast<unsigned short>(last_top_vidx);
+					v_index_array[tidx].J = static_cast<unsigned short>(last_bottom_vidx);
+					v_index_array[tidx].K = static_cast<unsigned short>(vidx);
 					tidx++;
 					last_top_vidx = vidx;
 
@@ -1032,7 +1032,7 @@ void SegLineRendererClass::Render
 			}
 
 			// Reduce both pointcounts by the same amount so the smaller one is 1 (skip points)
-			residual_delta = MIN(residual_top_points, residual_bottom_points) - 1;
+			residual_delta = std::min(residual_top_points, residual_bottom_points) - 1;
 			residual_top_points -= residual_delta;
 			residual_bottom_points -= residual_delta;
 			pidx += residual_delta;
@@ -1087,7 +1087,7 @@ void SegLineRendererClass::Render
 		** Render
 		*/
 
-		DynamicVBAccessClass Verts((sorting?BUFFER_TYPE_DYNAMIC_SORTING:BUFFER_TYPE_DYNAMIC_DX8),dynamic_fvf_type,vnum);
+		DynamicVBAccessClass Verts((sorting?BUFFER_TYPE_DYNAMIC_SORTING:BUFFER_TYPE_DYNAMIC_DX8),dynamic_fvf_type,static_cast<unsigned short>(vnum));
 		// Copy in the data to the  VB
 		{
 			DynamicVBAccessClass::WriteLockClass Lock(&Verts);
@@ -1108,7 +1108,7 @@ void SegLineRendererClass::Render
 			}
 		} // copy
 
-		DynamicIBAccessClass ib_access((sorting?BUFFER_TYPE_DYNAMIC_SORTING:BUFFER_TYPE_DYNAMIC_DX8),tidx*3);
+		DynamicIBAccessClass ib_access(static_cast<unsigned short>(sorting?BUFFER_TYPE_DYNAMIC_SORTING:BUFFER_TYPE_DYNAMIC_DX8),static_cast<unsigned short>(tidx*3));
 		{
 			unsigned int i;
 			DynamicIBAccessClass::WriteLockClass lock(&ib_access);
@@ -1129,9 +1129,9 @@ void SegLineRendererClass::Render
 		DX8Wrapper::Set_Shader(shader);
 
 		if (sorting) {
-			SortingRendererClass::Insert_Triangles(obj_sphere,0,tidx,0,vnum);
+			SortingRendererClass::Insert_Triangles(obj_sphere,0,static_cast<unsigned short>(tidx),0,static_cast<unsigned short>(vnum));
 		} else {
-			DX8Wrapper::Draw_Triangles(0,tidx,0,vnum);
+			DX8Wrapper::Draw_Triangles(0,static_cast<unsigned short>(tidx),0,static_cast<unsigned short>(vnum));
 		}
 
 		REF_PTR_RELEASE(mat);

--- a/Code/ww3d2/shattersystem.cpp
+++ b/Code/ww3d2/shattersystem.cpp
@@ -335,8 +335,8 @@ void VertexClass::Lerp
 		Vector4 dcg_v1=DX8Wrapper::Convert_Color(v1.DCG[ipass]);
 		Vector4 dig_v0=DX8Wrapper::Convert_Color(v0.DIG[ipass]);
 		Vector4 dig_v1=DX8Wrapper::Convert_Color(v1.DIG[ipass]);
-		Vector4::Lerp(dcg_v0,dcg_v1,res->DCG[ipass]);
-		Vector4::Lerp(dig_v0,dig_v1,res->DIG[ipass]);
+		Vector4::Lerp(dcg_v0,dcg_v1,float(res->DCG[ipass]));
+		Vector4::Lerp(dig_v0,dig_v1,float(res->DIG[ipass]));
 //		Vector4::Lerp(v0.DCG[ipass],v1.DCG[ipass],lerp,&(res->DCG[ipass]));
 //		Vector4::Lerp(v0.DIG[ipass],v1.DIG[ipass],lerp,&(res->DIG[ipass]));
 		for (int istage=0; istage<MeshMatDescClass::MAX_TEX_STAGES; istage++) {
@@ -447,7 +447,7 @@ void PolygonClass::Compute_Plane(void)
 	ny /= len;
 	nz /= len;
 
-	Plane.Set(Vector3(nx,ny,nz),Vector3(ax,ay,az));
+	Plane.Set(Vector3(float(nx),float(ny),float(nz)),Vector3(float(ax),float(ay),float(az)));
 }
 
 int PolygonClass::Which_Side(const PlaneClass & plane) const

--- a/Code/ww3d2/sortingrenderer.cpp
+++ b/Code/ww3d2/sortingrenderer.cpp
@@ -487,7 +487,7 @@ void SortingRendererClass::Flush_Sorting_Pool()
 	float* polygon_z_array_ptr=Get_Polygon_Z_Array(overlapping_polygon_count);
 	ShortVectorIStruct* polygon_idx_array=(ShortVectorIStruct*)Get_Polygon_Index_Array(overlapping_polygon_count);
 
-	DynamicVBAccessClass dyn_vb_access(BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,overlapping_vertex_count);
+	DynamicVBAccessClass dyn_vb_access(BUFFER_TYPE_DYNAMIC_DX8,dynamic_fvf_type,static_cast<unsigned short>(overlapping_vertex_count));
 	{
 		DynamicVBAccessClass::WriteLockClass lock(&dyn_vb_access);
 		VertexFormatXYZNDUV2* dest_verts=lock.Get_Formatted_Vertex_Array();
@@ -546,12 +546,12 @@ void SortingRendererClass::Flush_Sorting_Pool()
 				polygon_z_array_ptr[array_index]=z;
 				node_id_array_ptr[array_index]=node_id;
 				polygon_idx_array[array_index]=ShortVectorIStruct(
-					idx1+vertex_array_offset,
-					idx2+vertex_array_offset,
-					idx3+vertex_array_offset);
+					static_cast<unsigned short>(idx1+vertex_array_offset),
+					static_cast<unsigned short>(idx2+vertex_array_offset),
+					static_cast<unsigned short>(idx3+vertex_array_offset));
 			}
 
-			state->min_vertex_index=vertex_array_offset;
+			state->min_vertex_index=static_cast<unsigned short>(vertex_array_offset);
 
 			polygon_array_offset+=state->polygon_count;
 			vertex_array_offset+=state->vertex_count;
@@ -562,11 +562,11 @@ void SortingRendererClass::Flush_Sorting_Pool()
 	TempIndexStruct* tis=Get_Temp_Index_Array(overlapping_polygon_count);
 	unsigned a;
 	for (a=0;a<overlapping_polygon_count;++a) {
-		tis[a]=TempIndexStruct(polygon_idx_array[a],node_id_array_ptr[a]);
+		tis[a]=TempIndexStruct(polygon_idx_array[a],static_cast<unsigned short>(node_id_array_ptr[a]));
 	}
 	Sort<TempIndexStruct,float>(tis,polygon_z_array_ptr,overlapping_polygon_count);
 
-	DynamicIBAccessClass dyn_ib_access(BUFFER_TYPE_DYNAMIC_DX8,overlapping_polygon_count*3);
+	DynamicIBAccessClass dyn_ib_access(BUFFER_TYPE_DYNAMIC_DX8,static_cast<unsigned short>(overlapping_polygon_count*3));
 	{
 		DynamicIBAccessClass::WriteLockClass lock(&dyn_ib_access);
 		ShortVectorIStruct* sorted_polygon_index_array=(ShortVectorIStruct*)lock.Get_Index_Array();
@@ -595,8 +595,8 @@ void SortingRendererClass::Flush_Sorting_Pool()
 			Apply_Render_State(state->sorting_state);
 
 			DX8Wrapper::Draw_Triangles(
-				start_index*3,
-				count_to_render,
+				static_cast<unsigned short>(start_index*3),
+				static_cast<unsigned short>(count_to_render),
 				state->min_vertex_index,
 				state->vertex_count);
 
@@ -613,8 +613,8 @@ void SortingRendererClass::Flush_Sorting_Pool()
 		Apply_Render_State(state->sorting_state);
 
 		DX8Wrapper::Draw_Triangles(
-			start_index*3,
-			count_to_render,
+			static_cast<unsigned short>(start_index*3),
+			static_cast<unsigned short>(count_to_render),
 			state->min_vertex_index,
 			state->vertex_count);
 	}

--- a/Code/ww3d2/sphereobj.cpp
+++ b/Code/ww3d2/sphereobj.cpp
@@ -296,7 +296,7 @@ void SphereRenderObjClass::Generate_Shared_Mesh_Arrays (const AlphaVectorStruct 
 
 		for(int i=0; i < SPHERE_NUM_LOD; i++) {
 
-			SphereMeshArray[i].Generate(1.0f, size, size);
+			SphereMeshArray[i].Generate(1.0f, int(size), int(size));
 
 			size+=step;
 
@@ -441,7 +441,7 @@ void SphereRenderObjClass::render_sphere()
 	DX8Wrapper::Set_Texture(0,SphereTexture);
 	DX8Wrapper::Set_Material(SphereMaterial);
 
-	DynamicVBAccessClass vb(BUFFER_TYPE_DYNAMIC_SORTING,dynamic_fvf_type,mesh.Vertex_ct);
+	DynamicVBAccessClass vb(BUFFER_TYPE_DYNAMIC_SORTING,dynamic_fvf_type,static_cast<unsigned short>(mesh.Vertex_ct));
 	{
 		DynamicVBAccessClass::WriteLockClass Lock(&vb);
 		VertexFormatXYZNDUV2 *fva = Lock.Get_Formatted_Vertex_Array();
@@ -470,7 +470,7 @@ void SphereRenderObjClass::render_sphere()
 		}
 	}
 
-	DynamicIBAccessClass ib(BUFFER_TYPE_DYNAMIC_SORTING,mesh.face_ct*3);
+	DynamicIBAccessClass ib(BUFFER_TYPE_DYNAMIC_SORTING,static_cast<unsigned short>(mesh.face_ct*3));
 	{
 		DynamicIBAccessClass::WriteLockClass Lock(&ib);
 		unsigned short *mem=Lock.Get_Index_Array();
@@ -486,7 +486,7 @@ void SphereRenderObjClass::render_sphere()
 	DX8Wrapper::Set_Index_Buffer(ib,0);
 
 #if (STATIC_SORT_SPHERES)
-	DX8Wrapper::Draw_Triangles(0,mesh.face_ct,0,mesh.Vertex_ct);
+	DX8Wrapper::Draw_Triangles(0,static_cast<unsigned short>(mesh.face_ct),0,static_cast<unsigned short>(mesh.Vertex_ct));
 #else
 	SortingRendererClass::Insert_Triangles(
 		Get_Bounding_Sphere(),
@@ -597,7 +597,7 @@ void SphereRenderObjClass::Render(RenderInfoClass & rinfo)
 		screen_size = sqrtf(screen_size);
 
 		float lod     = screen_size * ((float) SPHERE_NUM_LOD);
-		int	lod_int = lod;
+		int	lod_int = int(lod);
 		lod-=lod_int;
 
 		if (lod >= 0.5f) lod_int++;
@@ -971,7 +971,7 @@ void SphereRenderObjClass::animate (void)
 			// Convert from milliseconds to seconds and normalize the time
 			//
 			if (AnimDuration > 0) {
-				float	frametime = WW3D::Get_Frame_Time();
+				float	frametime = float(WW3D::Get_Frame_Time());
 				frametime = (frametime * 0.001F) / AnimDuration;
 				anim_time += frametime;
 			} else {
@@ -1323,7 +1323,7 @@ void	SphereMeshClass::Set_Alpha_Vector (const AlphaVectorStruct &v, bool inverse
 			temp = vec * vtx_normal[idx];
 			temp*= Intensity;
 
-			temp = fabs(temp);
+			temp = WWMath::Fabs(temp);
 
 			if (temp > 1.0f) temp = 1.0f;
 
@@ -1338,7 +1338,7 @@ void	SphereMeshClass::Set_Alpha_Vector (const AlphaVectorStruct &v, bool inverse
 			temp = vec * vtx_normal[idx];
 			temp*= Intensity;
 
-			temp = fabs(temp);
+			temp = WWMath::Fabs(temp);
 
 			if (temp > 1.0f) temp = 1.0f;
 
@@ -1511,9 +1511,9 @@ void SphereMeshClass::Generate(float radius, int slices, int stacks)
 		// IJK
 		for(int fidx=0; fidx < (strip_size - 2); fidx++) {
 
-			out->I = in[0];
-			out->J = in[1];
-			out->K = in[2];
+			out->I = static_cast<unsigned short>(in[0]);
+			out->J = static_cast<unsigned short>(in[1]);
+			out->K = static_cast<unsigned short>(in[2]);
 
 			out++;
 			in++;
@@ -1521,9 +1521,9 @@ void SphereMeshClass::Generate(float radius, int slices, int stacks)
 			fidx++;
 			if (fidx >= (strip_size-2)) break;
 
-			out->I = in[0];
-			out->J = in[2];
-			out->K = in[1];
+			out->I = static_cast<unsigned short>(in[0]);
+			out->J = static_cast<unsigned short>(in[2]);
+			out->K = static_cast<unsigned short>(in[1]);
 			out++;
 			in++;
 
@@ -1542,9 +1542,9 @@ void SphereMeshClass::Generate(float radius, int slices, int stacks)
 
 		for (int fidx=0; fidx < (fan_size - 2); fidx++) {
 
-			out->I = base_idx[0];
-			out->J = in[2];
-			out->K = in[1];
+			out->I = static_cast<unsigned short>(base_idx[0]);
+			out->J = static_cast<unsigned short>(in[2]);
+			out->K = static_cast<unsigned short>(in[1]);
 
 			in++;
 			out++;

--- a/Code/ww3d2/surfaceclass.cpp
+++ b/Code/ww3d2/surfaceclass.cpp
@@ -129,27 +129,27 @@ void SurfaceClass::Convert_Pixel(Vector3 &rgb, const SurfaceClass::SurfaceDescri
 		{
 			unsigned short tmp;
 			tmp=*(unsigned short*)&pixel[0];
-			rgb.X=((tmp&0x0f00)>>4);   // R
-			rgb.Y=((tmp&0x00f0));		// G
-			rgb.Z=((tmp&0x000f)<<4);	// B
+			rgb.X=float((tmp&0x0f00)>>4);   // R
+			rgb.Y=float((tmp&0x00f0));		// G
+			rgb.Z=float((tmp&0x000f)<<4);	// B
 		}
 		break;
 	case WW3D_FORMAT_A1R5G5B5:
 		{
 			unsigned short tmp;
 			tmp=*(unsigned short*)&pixel[0];
-			rgb.X=(tmp>>7)&0xf8; // R
-			rgb.Y=(tmp>>2)&0xf8; // G
-			rgb.Z=(tmp<<3)&0xf8; // B
+			rgb.X=float((tmp>>7)&0xf8); // R
+			rgb.Y=float((tmp>>2)&0xf8); // G
+			rgb.Z=float((tmp<<3)&0xf8); // B
 		}
 		break;
 	case WW3D_FORMAT_R5G6B5:
 		{
 			unsigned short tmp;
 			tmp=*(unsigned short*)&pixel[0];
-			rgb.X=(tmp>>8)&0xf8;
-			rgb.Y=(tmp>>3)&0xfc;
-			rgb.Z=(tmp<<3)&0xf8;
+			rgb.X=float((tmp>>8)&0xf8);
+			rgb.Y=float((tmp>>3)&0xfc);
+			rgb.Z=float((tmp<<3)&0xf8);
 		}
 		break;
 

--- a/Code/ww3d2/texproject.cpp
+++ b/Code/ww3d2/texproject.cpp
@@ -1238,7 +1238,7 @@ void TexProjectClass::Configure_Camera(CameraClass & camera)
 	}
 
 	// Set one-pixel borders to the texture to avoid "flooding" shadows...
-	float size=Get_Texture_Size();
+	float size=float(Get_Texture_Size());
 	float inv_size=1.0f/size;
 	Vector2 vmin(1.0f*inv_size,1.0f*inv_size);
 	Vector2 vmax((size-1.0f)*inv_size,(size-1.0f)*inv_size);
@@ -1314,9 +1314,9 @@ void TexProjectClass::Pre_Render_Update(const Matrix3D & camera)
 		WWASSERT(Get_Texture_Size() != 0);
 	}
 
-	Mapper->Set_Texture_Transform(view_to_texture,Get_Texture_Size());
+	Mapper->Set_Texture_Transform(view_to_texture,float(Get_Texture_Size()));
 	if (Mapper1) {
-		Mapper1->Set_Texture_Transform(view_to_texture,Get_Texture_Size());
+		Mapper1->Set_Texture_Transform(view_to_texture,float(Get_Texture_Size()));
 	}
 }
 

--- a/Code/ww3d2/visrasterizer.cpp
+++ b/Code/ww3d2/visrasterizer.cpp
@@ -474,8 +474,8 @@ struct EdgeStruct
 {
 	EdgeStruct(const GradientsStruct & grad,const Vector3 * verts,int top,int bottom)
 	{
-		Y = WWMath::Ceil(verts[top].Y);
-		Height = WWMath::Ceil(verts[bottom].Y) - Y;
+		Y = int(WWMath::Ceil(verts[top].Y));
+		Height = int(WWMath::Ceil(verts[bottom].Y) - Y);
 
 		float y_prestep = Y - verts[top].Y;
 		float real_height = verts[bottom].Y - verts[top].Y;

--- a/Code/ww3d2/w3d_file.h
+++ b/Code/ww3d2/w3d_file.h
@@ -907,26 +907,26 @@ inline void W3d_Shader_Reset(W3dShaderStruct* s) {
 	s->pad[0] = 0;
 }
 
-inline void W3d_Shader_Set_Depth_Compare(W3dShaderStruct* s, int val) { s->DepthCompare = val; }
-inline void W3d_Shader_Set_Depth_Mask(W3dShaderStruct* s, int val) { s->DepthMask = val; }
-inline void W3d_Shader_Set_Dest_Blend_Func(W3dShaderStruct* s, int val) { s->DestBlend = val; }
-inline void W3d_Shader_Set_Pri_Gradient(W3dShaderStruct* s, int val) { s->PriGradient = val; }
-inline void W3d_Shader_Set_Sec_Gradient(W3dShaderStruct* s, int val) { s->SecGradient = val; }
-inline void W3d_Shader_Set_Src_Blend_Func(W3dShaderStruct* s, int val) { s->SrcBlend = val; }
-inline void W3d_Shader_Set_Texturing(W3dShaderStruct* s, int val) { s->Texturing = val; }
-inline void W3d_Shader_Set_Detail_Color_Func(W3dShaderStruct* s, int val) { s->DetailColorFunc = val; }
-inline void W3d_Shader_Set_Detail_Alpha_Func(W3dShaderStruct* s, int val) { s->DetailAlphaFunc = val; }
-inline void W3d_Shader_Set_Alpha_Test(W3dShaderStruct* s, int val) { s->AlphaTest = val; }
-inline void W3d_Shader_Set_Post_Detail_Color_Func(W3dShaderStruct* s, int val) { s->PostDetailColorFunc = val; }
-inline void W3d_Shader_Set_Post_Detail_Alpha_Func(W3dShaderStruct* s, int val) { s->PostDetailAlphaFunc = val; }
+inline void W3d_Shader_Set_Depth_Compare(W3dShaderStruct* s, int val) { s->DepthCompare = uint8(val); }
+inline void W3d_Shader_Set_Depth_Mask(W3dShaderStruct* s, int val) { s->DepthMask = uint8(val); }
+inline void W3d_Shader_Set_Dest_Blend_Func(W3dShaderStruct* s, int val) { s->DestBlend = uint8(val); }
+inline void W3d_Shader_Set_Pri_Gradient(W3dShaderStruct* s, int val) { s->PriGradient = uint8(val); }
+inline void W3d_Shader_Set_Sec_Gradient(W3dShaderStruct* s, int val) { s->SecGradient = uint8(val); }
+inline void W3d_Shader_Set_Src_Blend_Func(W3dShaderStruct* s, int val) { s->SrcBlend = uint8(val); }
+inline void W3d_Shader_Set_Texturing(W3dShaderStruct* s, int val) { s->Texturing = uint8(val); }
+inline void W3d_Shader_Set_Detail_Color_Func(W3dShaderStruct* s, int val) { s->DetailColorFunc = uint8(val); }
+inline void W3d_Shader_Set_Detail_Alpha_Func(W3dShaderStruct* s, int val) { s->DetailAlphaFunc = uint8(val); }
+inline void W3d_Shader_Set_Alpha_Test(W3dShaderStruct* s, int val) { s->AlphaTest = uint8(val); }
+inline void W3d_Shader_Set_Post_Detail_Color_Func(W3dShaderStruct* s, int val) { s->PostDetailColorFunc = uint8(val); }
+inline void W3d_Shader_Set_Post_Detail_Alpha_Func(W3dShaderStruct* s, int val) { s->PostDetailAlphaFunc = uint8(val); }
 
 // These functions use the existing W3dShaderStruct unused members to store PS2 specific parameters.
 // At mesh save time, if a PS2 material was used, a separate PS2 material chunk is saved out.
 // If W3dShaderStruct is changed this should still work because it is only used for the PS2 stuff.
-inline void W3d_Shader_Set_PS2_Param_A(W3dShaderStruct* s, int val) { s->ColorMask = val; }
-inline void W3d_Shader_Set_PS2_Param_B(W3dShaderStruct* s, int val) { s->FogFunc = val; }
-inline void W3d_Shader_Set_PS2_Param_C(W3dShaderStruct* s, int val) { s->ShaderPreset = val; }
-inline void W3d_Shader_Set_PS2_Param_D(W3dShaderStruct* s, int val) { s->pad[0] = val; }
+inline void W3d_Shader_Set_PS2_Param_A(W3dShaderStruct* s, int val) { s->ColorMask = uint8(val); }
+inline void W3d_Shader_Set_PS2_Param_B(W3dShaderStruct* s, int val) { s->FogFunc = uint8(val); }
+inline void W3d_Shader_Set_PS2_Param_C(W3dShaderStruct* s, int val) { s->ShaderPreset = uint8(val); }
+inline void W3d_Shader_Set_PS2_Param_D(W3dShaderStruct* s, int val) { s->pad[0] = uint8(val); }
 
 inline int W3d_Shader_Get_PS2_Param_A(const W3dShaderStruct* s) { return (s->ColorMask); }
 inline int W3d_Shader_Get_PS2_Param_B(const W3dShaderStruct* s) { return (s->FogFunc); }

--- a/Code/ww3d2/ww3d.cpp
+++ b/Code/ww3d2/ww3d.cpp
@@ -1315,8 +1315,8 @@ void WW3D::Make_Screen_Shot( const char * filename_base )
 
 	Targa targ;
 	memset(&targ.Header,0,sizeof(targ.Header));
-	targ.Header.Width=width;
-	targ.Header.Height=height;
+	targ.Header.Width=short(width);
+	targ.Header.Height=short(height);
 	targ.Header.PixelDepth=24;
 	targ.Header.ImageType=TGA_TRUECOLOR;
 	targ.SetImage(image);

--- a/Code/wwdebug/wwprofile.cpp
+++ b/Code/wwdebug/wwprofile.cpp
@@ -518,7 +518,7 @@ void	WWProfileManager::End_Collecting(const char* filename)
 			file->Open (FileClass::WRITE);
 
 			StringClass str;
-			float avg_frame_time=TotalFrameTimes/float(ProfileCollectVector.Count());
+			float avg_frame_time=float(TotalFrameTimes/float(ProfileCollectVector.Count()));
 			str.Format(
 				"Total frames: %d, average frame time: %fms\r\n"
 				"All frames taking more than twice the average frame time are marked with keyword SPIKE.\r\n\r\n",
@@ -708,7 +708,7 @@ WWTimeItClass::~WWTimeItClass( void )
 	WWProfile_Get_Ticks( &End );
 	End -= Time;
 #ifdef WWDEBUG
-	float time = End * CPUDetectClass::Get_Inv_Processor_Ticks_Per_Second();
+	float time = float(End * CPUDetectClass::Get_Inv_Processor_Ticks_Per_Second());
 	WWDEBUG_SAY(( "*** WWTIMEIT *** %s took %1.9f\n", Name, time ));
 #endif
 }
@@ -730,7 +730,7 @@ WWMeasureItClass::~WWMeasureItClass( void )
 	WWProfile_Get_Ticks( &End );
 	End -= Time;
 	WWASSERT(PResult != NULL);
-	*PResult = End  * CPUDetectClass::Get_Inv_Processor_Ticks_Per_Second();
+	*PResult = float(End  * CPUDetectClass::Get_Inv_Processor_Ticks_Per_Second());
 }
 
 // ----------------------------------------------------------------------------

--- a/Code/wwlib/FFmpegFile.cpp
+++ b/Code/wwlib/FFmpegFile.cpp
@@ -458,8 +458,8 @@ void FFmpegFile::Seek_Frame(int frame_idx)
 {
 	// Note: not tested, since not used ingame
 	for (const auto &stream : Streams) {
-		int64_t timestamp = av_q2d(FmtCtx->streams[stream.stream_idx]->time_base) * frame_idx
-			* av_q2d(FmtCtx->streams[stream.stream_idx]->avg_frame_rate);
+		int64_t timestamp = int64_t(av_q2d(FmtCtx->streams[stream.stream_idx]->time_base) * frame_idx
+			* av_q2d(FmtCtx->streams[stream.stream_idx]->avg_frame_rate));
 		int result = av_seek_frame(FmtCtx, stream.stream_idx, timestamp, AVSEEK_FLAG_ANY);
 		if (result < 0) {
 			char error_buffer[1024];
@@ -584,7 +584,7 @@ int FFmpegFile::Get_Num_Frames() const
 		return 0;
 	}
 
-	return (FmtCtx->duration / (double)AV_TIME_BASE) * av_q2d(FmtCtx->streams[stream->stream_idx]->avg_frame_rate);
+	return int((FmtCtx->duration / (double)AV_TIME_BASE) * av_q2d(FmtCtx->streams[stream->stream_idx]->avg_frame_rate));
 }
 
 int FFmpegFile::Get_Current_Frame() const
@@ -594,7 +594,7 @@ int FFmpegFile::Get_Current_Frame() const
 		return 0;
 	}
 
-	return stream->codec_ctx->frame_num;
+	return int(stream->codec_ctx->frame_num);
 }
 
 int FFmpegFile::Get_Pixel_Format() const
@@ -614,5 +614,5 @@ unsigned FFmpegFile::Get_Frame_Time() const
 		return 0u;
 	}
 
-	return 1000u / av_q2d(FmtCtx->streams[stream->stream_idx]->avg_frame_rate);
+	return unsigned(1000u / av_q2d(FmtCtx->streams[stream->stream_idx]->avg_frame_rate));
 }

--- a/Code/wwlib/TARGA.CPP
+++ b/Code/wwlib/TARGA.CPP
@@ -1161,7 +1161,7 @@ int Targa::EncodeImage()
 			if ((count != 0) && (packet[0] == 0))
 				{
 				/* Run count */
-				packet[0] = (count | 0x80);
+				packet[0] = char(count | 0x80);
 
 				/* Run pixel */
 				for (i = 0; i < depth; i++)

--- a/Code/wwlib/chunkio.cpp
+++ b/Code/wwlib/chunkio.cpp
@@ -204,7 +204,7 @@ bool ChunkSaveClass::Begin_Micro_Chunk(uint32 id)
 
 	// Save the current file position and chunk header
 	// for the call to End_Micro_Chunk.
-	MCHeader.Set_Type(id);
+	MCHeader.Set_Type(uint8(id));
 	MCHeader.Set_Size(0);
 	MicroChunkPosition = File->Seek(0);
 

--- a/Code/wwlib/cpudetect.cpp
+++ b/Code/wwlib/cpudetect.cpp
@@ -1241,9 +1241,9 @@ void Get_OS_Info(
 				}
 			}
 
-			os_info.BuildMajor=build_major;
-			os_info.BuildMinor=build_minor;
-			os_info.BuildSub=build_sub;
+			os_info.BuildMajor=static_cast<unsigned char>(build_major);
+			os_info.BuildMinor=static_cast<unsigned char>(build_minor);
+			os_info.BuildSub=static_cast<unsigned char>(build_sub);
 			if (OSVersionNumberMajor==4) {
 //				os_info.SubCode.Format("%d",build_sub);
 				os_info.SubCode="UNKNOWN";

--- a/Code/wwlib/point.h
+++ b/Code/wwlib/point.h
@@ -168,8 +168,8 @@ class TPoint3D : public TPoint2D<T> {
 		// Vector support functions.
 		T Length(void) const {return(T(sqrt(X*X + Y*Y + Z*Z)));}
 		TPoint3D<T> const Normalize(void) const {
-			double len = sqrt(X*X + Y*Y + Z*Z);
-			if (len != 0.0) {
+			T len = T(sqrt(X*X + Y*Y + Z*Z));
+			if (len != 0) {
 				return(TPoint3D<T>(X / len, Y / len, Z / len));
 			} else {
 				return(*this);

--- a/Code/wwlib/rawfile.cpp
+++ b/Code/wwlib/rawfile.cpp
@@ -895,7 +895,7 @@ int RawFileClass::Size(void)
 				Error(GetLastError(), false, Filename);
 			}
 		#elif defined(OPENW3D_SDL3)
-			size = SDL_GetIOSize(Handle);
+			size = int(SDL_GetIOSize(Handle));
 		#else
 			#error "Not implemented"
 		#endif
@@ -1056,8 +1056,8 @@ static Uint32 Seconds_to_FatTime(time_t t)
 	SDL_DateTime datetime;
 	SDL_zero(datetime);
 	SDL_TimeToDateTime(time_ns, &datetime, true);
-	Uint16 fatDate = datetime.day | (datetime.month << 5) | SDL_max(0, datetime.year - 1980) << 9;
-	Uint16 fatTime = (datetime.second / 2) | (datetime.minute << 5) | (datetime.hour << 11);
+	Uint16 fatDate = Uint16(datetime.day | (datetime.month << 5) | SDL_max(0, datetime.year - 1980) << 9);
+	Uint16 fatTime = Uint16((datetime.second / 2) | (datetime.minute << 5) | (datetime.hour << 11));
 	return (fatDate << 16) | fatTime;
 }
 #endif
@@ -1107,7 +1107,7 @@ unsigned int RawFileClass::Get_Date_Time(void)
 		fstat(fileno(f), &statbuf);
 		return Seconds_to_FatTime(statbuf.st_mtime);
 	}
-	int fd = SDL_GetNumberProperty(SDL_GetIOProperties(Handle), SDL_PROP_IOSTREAM_FILE_DESCRIPTOR_NUMBER, 0);
+	int fd = int(SDL_GetNumberProperty(SDL_GetIOProperties(Handle), SDL_PROP_IOSTREAM_FILE_DESCRIPTOR_NUMBER, 0));
 	if (fd != 0) {
 		struct stat statbuf;
 		fstat(fd, &statbuf);
@@ -1183,7 +1183,7 @@ bool RawFileClass::Set_Date_Time(unsigned int datetime)
 #endif
 		return true;
 	}
-	int fd = SDL_GetNumberProperty(SDL_GetIOProperties(Handle), SDL_PROP_IOSTREAM_FILE_DESCRIPTOR_NUMBER, 0);
+	int fd = int(SDL_GetNumberProperty(SDL_GetIOProperties(Handle), SDL_PROP_IOSTREAM_FILE_DESCRIPTOR_NUMBER, 0));
 	if (fd != 0) {
 #ifdef _WIN32
         if (_futime(fd, &tbuf) != 0) {
@@ -1315,7 +1315,7 @@ int RawFileClass::Raw_Seek(int pos, int dir)
 		if (SDL_SeekIO(Handle, pos, whence) == -1) {
 			Error(EIO, false, Filename);
 		}
-		pos = SDL_TellIO(Handle);
+		pos = int(SDL_TellIO(Handle));
 		/*
 		**	If there was an error in the seek, then bail with an error condition.
 		*/

--- a/Code/wwlib/thread.cpp
+++ b/Code/wwlib/thread.cpp
@@ -100,8 +100,8 @@ void ThreadClass::Execute()
 	ResumeThread(mHandle);
 #elif defined(OPENW3D_SDL3)
 	mHandle = SDL_CreateThread(Internal_Thread_Function, ThreadName, this);
-
-	mThreadID = SDL_GetThreadID(mHandle);
+	// TODO OmniBlade: ThreadID probably needs changing to 64bit to handle all platforms.
+	mThreadID = unsigned(SDL_GetThreadID(mHandle));
 #else
 	assert(0);
 #endif
@@ -167,7 +167,7 @@ unsigned ThreadClass::Get_Current_Thread_ID()
 #if defined(OPENW3D_WIN32)
 	return GetCurrentThreadId();
 #elif defined(OPENW3D_SDL3)
-	return SDL_GetCurrentThreadID();
+	return unsigned(SDL_GetCurrentThreadID());
 #else
 	assert(0);
 #endif

--- a/Code/wwlib/wwstring.h
+++ b/Code/wwlib/wwstring.h
@@ -60,7 +60,7 @@ namespace openw3d{
 inline char* string_to_lower(char* str1){
     int x = 0;
     while(str1[x] != '\0'){
-        str1[x] = ::tolower(str1[x]);
+        str1[x] = char(::tolower(str1[x]));
         x++;
     }
     return str1;
@@ -69,7 +69,7 @@ inline char* string_to_lower(char* str1){
 inline char* string_to_upper(char* str1){
     int x = 0;
     while(str1[x] != '\0'){
-        str1[x] = ::toupper(str1[x]);
+        str1[x] = char(::toupper(str1[x]));
         x++;
     }
     return str1;

--- a/Code/wwnet/BWBalance.cpp
+++ b/Code/wwnet/BWBalance.cpp
@@ -318,7 +318,7 @@ unsigned int BandwidthBalancerClass::Allocate_Bandwidth(float average_priority, 
 		/*
 		** Work out the bandwidth, initially based on average priority.
 		*/
-		int client_bbo_adjust = (pri - average_priority) * bbo_per_client;
+		int client_bbo_adjust = int((pri - average_priority) * bbo_per_client);
 		if (client_bbo_adjust > 0) {
 			client_bbo_adjust = std::min(client_bbo_adjust, (int)bbo_per_client / 2);
 		} else {

--- a/Code/wwnet/connect.cpp
+++ b/Code/wwnet/connect.cpp
@@ -555,10 +555,10 @@ void cConnection::Set_Packet_Loss(double percent_lost)
 
    WWASSERT(percent_lost >= 0 && percent_lost <= 100);
 
-   SimulatedPacketLossPerRANDMAX = (UINT) cMathUtil::Round(
+   SimulatedPacketLossPerRANDMAX = (USHORT) cMathUtil::Round(
 		percent_lost / 100.0 * RAND_MAX);
 
-	WWDEBUG_SAY(("cConnection::Set_Packet_Loss: %d / %d\n", SimulatedPacketLossPerRANDMAX, RAND_MAX));
+	WWDEBUG_SAY(("cConnection::Set_Packet_Loss: %hu / %d\n", SimulatedPacketLossPerRANDMAX, RAND_MAX));
 }
 
 //------------------------------------------------------------------------------------
@@ -575,7 +575,7 @@ void cConnection::Set_Packet_Duplication(double percent_duplicated)
    //
    // Globally:
    //
-   SimulatedPacketDuplicationPerRANDMAX = (UINT) cMathUtil::Round(
+   SimulatedPacketDuplicationPerRANDMAX = (USHORT) cMathUtil::Round(
 		percent_duplicated / 100.0 * RAND_MAX);
 
 	WWDEBUG_SAY(("cConnection::Set_Packet_Duplication: %d / %d\n",  SimulatedPacketDuplicationPerRANDMAX, RAND_MAX));
@@ -745,7 +745,7 @@ bool cConnection::Receive_Packet()
    //
 	// Measurement stats
 	//
-	USHORT packet_bits = Calculate_Packet_Bits(ret_code);
+	USHORT packet_bits = Calculate_Packet_Bits(USHORT(ret_code));
 
    int addressee = Address_To_Rhostid(&packet.Get_From_Address_Wrapper()->FromAddress);
    if (addressee != INVALID_RHOST_ID) {
@@ -1527,7 +1527,7 @@ void cConnection::Send_Packet_To_Address(cPacket & packet, struct sockaddr_in* p
 			TotalCompressedBytesSent	+= packet.Get_Compressed_Size_Bytes();
 			TotalUncompressedBytesSent += packet.Get_Uncompressed_Size_Bytes();
 
-         USHORT bits_sent = Calculate_Packet_Bits(packet.Get_Compressed_Size_Bytes());
+         USHORT bits_sent = Calculate_Packet_Bits(USHORT(packet.Get_Compressed_Size_Bytes()));
 
          if (rhost_id != INVALID_RHOST_ID) {
             PRHost[rhost_id]->Get_Stats().StatSample[STAT_PktSent]++;
@@ -2448,7 +2448,7 @@ void cConnection::Service_Send(bool is_urgent)
 	//
 	// Monkey with the stats for a while
 	//
-	float sample_time_ms = ThisFrameTimeMs - CombinedStats.Get_Sample_Start_Time();
+	float sample_time_ms = float(ThisFrameTimeMs - CombinedStats.Get_Sample_Start_Time());
 
    if (IsServer && NumRHosts > 0 &&
       sample_time_ms > cNetUtil::NETSTATS_SAMPLE_TIME_MS) {

--- a/Code/wwnet/rhost.cpp
+++ b/Code/wwnet/rhost.cpp
@@ -55,7 +55,7 @@ cRemoteHost::cRemoteHost() :
    MustEvict(false),
    LastReliableSendId(-2),		// dummy value
    LastUnreliableSendId(-2),	// dummy value
-	ResendTimeoutMs(cNetUtil::Get_Default_Resend_Timeout_Ms()),
+	ResendTimeoutMs(USHORT(cNetUtil::Get_Default_Resend_Timeout_Ms())),
 	LastServiceCount(0),
 	LastContactTime(0),
 	TargetBps(0),
@@ -679,10 +679,10 @@ void cRemoteHost::Adjust_Resend_Timeout(void)
 			candidate_resend_timeout_ms = std::min(candidate_resend_timeout_ms, 3000);
 			candidate_resend_timeout_ms = std::max(candidate_resend_timeout_ms, 333);
 
-			ResendTimeoutMs = (ResendTimeoutMs + candidate_resend_timeout_ms) / 2;
+			ResendTimeoutMs = USHORT((ResendTimeoutMs + candidate_resend_timeout_ms) / 2);
 			if (candidate_resend_timeout_ms < ResendTimeoutMs) {
 				WWASSERT(candidate_resend_timeout_ms < 0xffff);
-				ResendTimeoutMs = candidate_resend_timeout_ms;
+				ResendTimeoutMs = USHORT(candidate_resend_timeout_ms);
 				//WWDEBUG_SAY((">> ResendTimeoutMs for rhost %d = %d\n", Id, ResendTimeoutMs));
 			}
 

--- a/Code/wwphys/CMakeLists.txt
+++ b/Code/wwphys/CMakeLists.txt
@@ -56,7 +56,7 @@ set(WWPHYS_SRC
     pscene_saveload.cpp
     pscene_vis.cpp
     rbody.cpp
-    rbody_obsolete.cpp
+    #rbody_obsolete.cpp
     renderobjphys.cpp
     renegadeterrainmaterialpass.cpp
     renegadeterrainpatch.cpp

--- a/Code/wwphys/Path.cpp
+++ b/Code/wwphys/Path.cpp
@@ -496,7 +496,7 @@ PathClass::Add_Waypath_Data
 	//	Loop along the waypath either forwards or backwards, depending
 	// on what the caller has requested
 	//
-	int count	= WWMath::Fabs (end_index - start_index);
+	int count	= abs (end_index - start_index);
 	int inc		= (end_index > start_index) ? 1 : -1;
 	for (int index = start_index; count >= 0; index += inc, count --) {
 

--- a/Code/wwphys/PathfindPortal.h
+++ b/Code/wwphys/PathfindPortal.h
@@ -173,9 +173,9 @@ PathfindPortalClass::Add_Dest_Sector (int sector_index)
 	WWASSERT (sector_index != -1);
 
 	if (m_DestSector1 == (uint16)-1) {
-		m_DestSector1 = sector_index;
+		m_DestSector1 = uint16(sector_index);
 	} else {
-		m_DestSector2 = sector_index;
+		m_DestSector2 = uint16(sector_index);
 	}
 
 	return ;

--- a/Code/wwphys/animcollisionmanager.cpp
+++ b/Code/wwphys/animcollisionmanager.cpp
@@ -523,7 +523,7 @@ void AnimCollisionManagerClass::Set_Animation(const char * anim_name)
 	*/
 	LoopStart = 0;
 	if (CurAnimation != NULL) {
-		LoopEnd = TargetFrame = CurAnimation->Get_Num_Frames() - 1;
+		LoopEnd = TargetFrame = float(CurAnimation->Get_Num_Frames() - 1);
 	} else {
 		LoopEnd = TargetFrame = 0;
 	}
@@ -614,7 +614,7 @@ void AnimCollisionManagerClass::Set_Target_Frame(float frame)
 void AnimCollisionManagerClass::Set_Target_Frame_End(void)
 {
 	if (CurAnimation != NULL) {
-		Set_Target_Frame(CurAnimation->Get_Num_Frames() - 1);
+		Set_Target_Frame(float(CurAnimation->Get_Num_Frames() - 1));
 	}
 }
 

--- a/Code/wwphys/dynamicaabtreecull.cpp
+++ b/Code/wwphys/dynamicaabtreecull.cpp
@@ -230,9 +230,9 @@ void DynamicAABTreeCullClass::Re_Partition
 	Vector3 worldsize = grid_max - grid_min;
 
 	Vector3i cellcount;
-	cellcount.I = worldsize.X / min_grid_cell_size.X;
-	cellcount.J = worldsize.Y / min_grid_cell_size.Y;
-	cellcount.K = worldsize.Z / min_grid_cell_size.Z;
+	cellcount.I = int(worldsize.X / min_grid_cell_size.X);
+	cellcount.J = int(worldsize.Y / min_grid_cell_size.Y);
+	cellcount.K = int(worldsize.Z / min_grid_cell_size.Z);
 
 	int total_grid_count = cellcount.I * cellcount.J * cellcount.K;
 	while (total_grid_count > max_grid_cell_count) {

--- a/Code/wwphys/floodfillgrid.cpp
+++ b/Code/wwphys/floodfillgrid.cpp
@@ -126,8 +126,8 @@ FloodfillGridClass::Initialize
 	//
 	m_CellSize.X	= box_extents.X * 32;
 	m_CellSize.Y	= box_extents.Y * 32;
-	m_CellsX	= ((m_WorldMax.X - m_WorldMin.X) / m_CellSize.X) + 1;
-	m_CellsY	= ((m_WorldMax.Y - m_WorldMin.Y) / m_CellSize.Y) + 1;
+	m_CellsX	= int((m_WorldMax.X - m_WorldMin.X) / m_CellSize.X) + 1;
+	m_CellsY	= int((m_WorldMax.Y - m_WorldMin.Y) / m_CellSize.Y) + 1;
 
 	//
 	//	Allocate the grid

--- a/Code/wwphys/heightdb.cpp
+++ b/Code/wwphys/heightdb.cpp
@@ -144,8 +144,8 @@ HeightDBClass::Get_Height (const Vector3 &pos)
 		//
 		if (percent_x >= 0 && percent_x <= 1.0F && percent_y >= 0 && percent_y <= 1.0F) {
 
-			int entry_ul_x = (m_NumPointsX - 1) * percent_x;
-			int entry_ul_y = (m_NumPointsY - 1) * percent_y;
+			int entry_ul_x = int((m_NumPointsX - 1) * percent_x);
+			int entry_ul_y = int((m_NumPointsY - 1) * percent_y);
 			int entry_ur_x = entry_ul_x + 1;
 			int entry_ur_y = entry_ul_y;
 			int entry_lr_x = entry_ul_x + 1;
@@ -204,8 +204,8 @@ HeightDBClass::Generate (void)
 	//
 	//	Determine how big a heightmap we will need to store data for this level
 	//
-	m_NumPointsX	= ((m_LevelMax.X - m_LevelMin.X) / generate_patch_size) + 1;
-	m_NumPointsY	= ((m_LevelMax.Y - m_LevelMin.Y) / generate_patch_size) + 1;
+	m_NumPointsX	= int((m_LevelMax.X - m_LevelMin.X) / generate_patch_size) + 1;
+	m_NumPointsY	= int((m_LevelMax.Y - m_LevelMin.Y) / generate_patch_size) + 1;
 	int entries		= m_NumPointsX * m_NumPointsY;
 
 	m_HeightArray	= new float[entries];
@@ -463,8 +463,8 @@ HeightDBClass::Submit_Mesh (MeshClass &mesh)
 			//
 			if (percent_x >= 0 && percent_x <= 1.0F && percent_y >= 0 && percent_y <= 1.0F) {
 
-				int entry_ul_x = (m_NumPointsX - 1) * percent_x;
-				int entry_ul_y = (m_NumPointsY - 1) * percent_y;
+				int entry_ul_x = int((m_NumPointsX - 1) * percent_x);
+				int entry_ul_y = int((m_NumPointsY - 1) * percent_y);
 				int entry_ur_x = entry_ul_x + 1;
 				int entry_ur_y = entry_ul_y;
 				int entry_lr_x = entry_ul_x + 1;

--- a/Code/wwphys/projectile.cpp
+++ b/Code/wwphys/projectile.cpp
@@ -347,7 +347,7 @@ void ProjectileClass::Timestep(float dt)
 						** We were requested to fly through.  Mark the current blocker as ignore
 						** so we collide with him no more this pass
 						*/
-						Integrate(0.02*timestep);
+						Integrate(0.02f*timestep);
 
 						if ( blocker ) {	 // Stop ignoring the last blocker
 							blocker->Dec_Ignore_Counter();

--- a/Code/wwphys/projectormanager.cpp
+++ b/Code/wwphys/projectormanager.cpp
@@ -161,7 +161,7 @@ void ProjectorManagerClass::Init(const ProjectorManagerDefClass & def,RenderObjC
 			/*
 			** Find the bone
 			*/
-			ProjectorBoneIndex = model->Get_Bone_Index(def.BoneName);
+			ProjectorBoneIndex = uint16(model->Get_Bone_Index(def.BoneName));
 			if (ProjectorBoneIndex == 0xFFFF) {
 				ProjectorBoneIndex = 0;
 			}

--- a/Code/wwphys/pscene.cpp
+++ b/Code/wwphys/pscene.cpp
@@ -1215,7 +1215,7 @@ void PhysicsSceneClass::Optimize_LODs
 		it.Peek_Obj()->Peek_Model()->Prepare_LOD(camera);
 		it.Peek_Obj()->Set_Last_Visible_Frame(CurrentFrameNumber);
 	}
-	PredictiveLODOptimizerClass::Optimize_LODs(DynamicPolyBudget);
+	PredictiveLODOptimizerClass::Optimize_LODs(float(DynamicPolyBudget));
 
 	// process the static objects
 	PredictiveLODOptimizerClass::Clear();
@@ -1227,7 +1227,7 @@ void PhysicsSceneClass::Optimize_LODs
 		it.Peek_Obj()->Peek_Model()->Prepare_LOD(camera);
 		it.Peek_Obj()->Set_Last_Visible_Frame(CurrentFrameNumber);
 	}
-	PredictiveLODOptimizerClass::Optimize_LODs(StaticPolyBudget);
+	PredictiveLODOptimizerClass::Optimize_LODs(float(StaticPolyBudget));
 }
 
 

--- a/Code/wwphys/rbody.cpp
+++ b/Code/wwphys/rbody.cpp
@@ -1766,7 +1766,7 @@ Vector3 avel0 = AngularVelocity;
 					** centroid.  (of course, this is all "ad-hoc", not true rigid-body dynamics...)
 					*/
 					Vector3 impulse = 0.3f * (State.LMomentum - oldstate.LMomentum);
-					contact_centroid /= ContactBox->Get_Contact_Count();
+					contact_centroid /= float(ContactBox->Get_Contact_Count());
 
 					Vector3 r = contact_centroid - State.Position;
 					Vector3 a_impulse;

--- a/Code/wwphys/renegadeterrainpatch.cpp
+++ b/Code/wwphys/renegadeterrainpatch.cpp
@@ -503,7 +503,7 @@ RenegadeTerrainPatchClass::Render_Procedural_Material_Pass(MaterialPassClass * m
 			//
 			//	Draw the mesh!
 			//
-			DX8Wrapper::Draw_Triangles (BUFFER_TYPE_DYNAMIC_DX8, 0, poly_count, 0, vert_count);
+			DX8Wrapper::Draw_Triangles (BUFFER_TYPE_DYNAMIC_DX8, 0, static_cast<unsigned short>(poly_count), 0, static_cast<unsigned short>(vert_count));
 		}
 //	}
 }
@@ -590,7 +590,7 @@ RenegadeTerrainPatchClass::Render_By_Texture (int texture_index, int pass_type)
 	//
 	//	Draw the mesh!
 	//
-	DX8Wrapper::Draw_Triangles (BUFFER_TYPE_DYNAMIC_DX8, 0, poly_count, 0, vert_count);
+	DX8Wrapper::Draw_Triangles (BUFFER_TYPE_DYNAMIC_DX8, 0, static_cast<unsigned short>(poly_count), 0, static_cast<unsigned short>(vert_count));
 	return ;
 }
 
@@ -672,8 +672,8 @@ RenegadeTerrainPatchClass::Build_Rendering_Buffers (int texture_index, int pass_
 	//
 	//	Allocate the vertex and index buffers
 	//
-	material_pass->IndexBuffers[pass_type]		= new DX8IndexBufferClass (poly_count * 3);
-	material_pass->VertexBuffers[pass_type]	= new DX8VertexBufferClass (DX8_FVF_XYZNDUV1, vert_count);
+	material_pass->IndexBuffers[pass_type]		= new DX8IndexBufferClass (static_cast<unsigned short>(poly_count * 3));
+	material_pass->VertexBuffers[pass_type]	= new DX8VertexBufferClass (DX8_FVF_XYZNDUV1, static_cast<unsigned short>(vert_count));
 
 	//
 	// Write index data to index buffers

--- a/Code/wwphys/shakeablestaticphys.cpp
+++ b/Code/wwphys/shakeablestaticphys.cpp
@@ -182,7 +182,7 @@ void ShakeableStaticPhysClass::Play_Animation(void)
 	if (anim != NULL) {
 		anim_mgr.Set_Current_Frame(0);
 		anim_mgr.Set_Animation_Mode(AnimCollisionManagerClass::ANIMATE_TARGET);
-		anim_mgr.Set_Target_Frame(anim->Get_Num_Frames()-1);
+		anim_mgr.Set_Target_Frame(float(anim->Get_Num_Frames()-1));
 	}
 }
 

--- a/Code/wwphys/visrendercontext.cpp
+++ b/Code/wwphys/visrendercontext.cpp
@@ -213,10 +213,10 @@ void VisRenderContextClass::Scan_Frame_Buffer
 	int width,height;
 	VisRasterizer->Get_Resolution(&width,&height);
 
-	int minx = MAX(min.X * width , 1);		// ignore the far left column
-	int miny = MAX(min.Y * height , 1);		// ignore the top row
-	int maxx = MIN(max.X * width , width-1);
-	int maxy = MIN(max.Y * height , height-1);
+	int minx = std::max(int(min.X * width) , 1);		// ignore the far left column
+	int miny = std::max(int(min.Y * height) , 1);		// ignore the top row
+	int maxx = std::min(int(max.X * width) , width-1);
+	int maxy = std::min(int(max.Y * height) , height-1);
 	int backface_count = 0;
 
 	const uint32 * pixel_row = NULL;

--- a/Code/wwphys/vistable.cpp
+++ b/Code/wwphys/vistable.cpp
@@ -218,7 +218,7 @@ void VisTableClass::Delete_Bit(int delete_index)
 	** first handle the int that the deleted bit is in
 	*/
 	int first_long = delete_index >> 5;
-	int start_bits = WWMath::Min((first_long + 1)<<5,BitCount-1);
+	int start_bits = std::min((first_long + 1)<<5,BitCount-1);
 
 	for (i=delete_index; i<start_bits; i++) {
 		Set_Bit(i,(Get_Bit(i+1) != 0));

--- a/Code/wwphys/wheel.cpp
+++ b/Code/wwphys/wheel.cpp
@@ -730,7 +730,7 @@ void WheelClass::Compute_Force_And_Torque(Vector3 * force,Vector3 * torque)
 	// the wheel can attempt to cancel them.
 	// TODO: load distribution?
 	Vector3 gravity(0.0f,0.0f,-Parent->Get_Weight());
-	gravity /= Parent->Get_Real_Wheel_Count();
+	gravity /= float(Parent->Get_Real_Wheel_Count());
 	Vector3 local_gravity;
 	Matrix3D::Inverse_Rotate_Vector(WheelTM,gravity,&local_gravity);
 
@@ -799,7 +799,7 @@ void WheelClass::Compute_Suspension_Force(const Vector3 & pdot,const Vector3 & /
 	float sforce = - SpringConstant*dx - DampingCoefficient*dv;
 
 	// Clamp the suspension force to produce at most an acceleration of MAX_SUSPENSION_ACCEL
-	float max_sforce = MAX_SUSPENSION_ACCEL * Parent->Get_Mass() / WWMath::Max(Parent->Get_Real_Wheel_Count(),1.0f);
+	float max_sforce = MAX_SUSPENSION_ACCEL * Parent->Get_Mass() / WWMath::Max(float(Parent->Get_Real_Wheel_Count()),1.0f);
 	sforce = WWMath::Clamp(sforce,-max_sforce,max_sforce);
 
 	*suspension_force = Normal;

--- a/Code/wwui/ProgressCtrl.cpp
+++ b/Code/wwui/ProgressCtrl.cpp
@@ -255,8 +255,8 @@ void ProgressCtrlClass::Set_Range(unsigned int min, unsigned int max)
 	// Scale current position to new range
 	if (mPosition > mMinLimit)
 		{
-		float oldDelta = (mMaxLimit - mMinLimit);
-		float newDelta = (max - min);
+		float oldDelta = float(mMaxLimit - mMinLimit);
+		float newDelta = float(max - min);
 		float scaler = (oldDelta / newDelta);
 
 		unsigned int position = (unsigned int)((float)mPosition * scaler);
@@ -412,6 +412,6 @@ void ProgressCtrlClass::Set_Step(unsigned int step)
 void ProgressCtrlClass::Step_Position(void)
 	{
 	float stepping = ((float)(mMaxLimit - mMinLimit) / (float)mStep);
-	float stepPos = (floor((float)mPosition / stepping) * stepping);
-	Set_Position(stepPos + mStep);
+	float stepPos = (WWMath::Floor((float)mPosition / stepping) * stepping);
+	Set_Position(unsigned(stepPos + mStep));
 	}

--- a/Code/wwui/buttonctrl.cpp
+++ b/Code/wwui/buttonctrl.cpp
@@ -729,7 +729,7 @@ ButtonCtrlClass::Update_Pulse (bool is_mouse_over)
 			//
 			//	Map the percent onto a circle to give us a pulse
 			//
-			float value	= ::cos (DEG_TO_RADF (360.0F) * percent);
+			float value	= WWMath::Cos (DEG_TO_RADF (360.0F) * percent);
 			value			= 0.8F + (value * 0.2F);
 
 			//

--- a/Code/wwui/checkboxctrl.cpp
+++ b/Code/wwui/checkboxctrl.cpp
@@ -238,21 +238,21 @@ CheckBoxCtrlClass::Update_Client_Rect (void)
 	//
 	//	Determine what size the button should be
 	//
-	float button_width	= int(char_size.X * 1.5F);
+	float button_width	= WWMath::Trunc(char_size.X * 1.5F);
 	float button_height	= button_width;
 
 	//
 	//	Calculate the button rectangle
 	//
 	ButtonRect.Left	= ClientRect.Left;
-	ButtonRect.Top		= ClientRect.Top + int((ClientRect.Height () / 2.0F) - (button_height / 2.0F));
+	ButtonRect.Top		= ClientRect.Top + WWMath::Trunc((ClientRect.Height () / 2.0F) - (button_height / 2.0F));
 	ButtonRect.Right	= ButtonRect.Left + button_width;
-	ButtonRect.Bottom	= ClientRect.Top + int((ClientRect.Height () / 2.0F) + (button_height / 2.0F));
+	ButtonRect.Bottom	= ClientRect.Top + WWMath::Trunc((ClientRect.Height () / 2.0F) + (button_height / 2.0F));
 
 	//
 	//	Calculate the text rectangle
 	//
-	TextRect.Left		= int(ButtonRect.Right + (char_size.X * 0.5F));
+	TextRect.Left		= WWMath::Trunc(ButtonRect.Right + (char_size.X * 0.5F));
 	TextRect.Top		= ClientRect.Top;
 	TextRect.Right		= ClientRect.Right;
 	TextRect.Bottom	= ClientRect.Bottom;

--- a/Code/wwui/comboboxctrl.cpp
+++ b/Code/wwui/comboboxctrl.cpp
@@ -197,10 +197,10 @@ ComboBoxCtrlClass::Create_Control_Renderers (void)
 	//
 	rect = ButtonRect;
 	renderer.Add_Line (Vector2 (rect.Left, rect.Bottom),	Vector2 (rect.Left, rect.Top-1),		1, color);
-	float width		= int(ButtonRect.Width () / 4);
-	float height	= int(ButtonRect.Height () / 4);
-	float center_x = int(ButtonRect.Left + (ButtonRect.Width () / 2));
-	float center_y = int(ButtonRect.Top + (ButtonRect.Height () / 2));
+	float width		= WWMath::Trunc(ButtonRect.Width () / 4);
+	float height	= WWMath::Trunc(ButtonRect.Height () / 4);
+	float center_x = WWMath::Trunc(ButtonRect.Left + (ButtonRect.Width () / 2));
+	float center_y = WWMath::Trunc(ButtonRect.Top + (ButtonRect.Height () / 2));
 	renderer.Add_Line (Vector2 (center_x - width, center_y - height),	Vector2 (center_x + width, center_y - height), 1, color);
 	renderer.Add_Line (Vector2 (center_x + width, center_y - height),	Vector2 (center_x, center_y + height), 1, color);
 	renderer.Add_Line (Vector2 (center_x, center_y + height),	Vector2 (center_x - width, center_y - height), 1, color);
@@ -241,10 +241,10 @@ ComboBoxCtrlClass::Set_Window_Pos (const Vector2 &pos)
 	//
 	//	Recalculate the window's bounding rectangle
 	//
-	FullRect.Left	= (int)pos.X;
-	FullRect.Top		= (int)pos.Y;
-	FullRect.Right	= (int)(FullRect.Left + width);
-	FullRect.Bottom	= (int)(FullRect.Top + height);
+	FullRect.Left	= WWMath::Trunc(pos.X);
+	FullRect.Top		= WWMath::Trunc(pos.Y);
+	FullRect.Right	= WWMath::Trunc(FullRect.Left + width);
+	FullRect.Bottom	= WWMath::Trunc(FullRect.Top + height);
 
 	//
 	//	Let the control recalculate anything it needs
@@ -275,7 +275,7 @@ ComboBoxCtrlClass::Update_Client_Rect (void)
 	float border_width	= char_size.X + 2;
 	float border_height	= 2;
 
-	float button_height	= int(char_size.Y * 2.0F);
+	float button_height	= WWMath::Trunc(char_size.Y * 2.0F);
 	float button_width	= button_height;
 
 	//
@@ -287,8 +287,8 @@ ComboBoxCtrlClass::Update_Client_Rect (void)
 	//
 	//	Remember how much space we have for the drop down control
 	//
-	DropDownSize.X = int(ClientRect.Width ());
-	DropDownSize.Y = int(FullRect.Bottom - ClientRect.Bottom);
+	DropDownSize.X = WWMath::Trunc(ClientRect.Width ());
+	DropDownSize.Y = WWMath::Trunc(FullRect.Bottom - ClientRect.Bottom);
 
 	//
 	//	Calculate the bounding rectangle for the drop-down control

--- a/Code/wwui/dialogbase.cpp
+++ b/Code/wwui/dialogbase.cpp
@@ -142,16 +142,16 @@ DialogBaseClass::Start_Dialog (void)
 	//	Convert the dialog's width and height from dialog units to screen units
 	//
 	const RectClass &screen_rect	= Render2DClass::Get_Screen_Resolution ();
-	int dlg_screen_width				= int(((float)DialogResource_->cx / RES_SCREEN_WIDTH) * screen_rect.Width ());
-	int dlg_screen_height			= int(((float)DialogResource_->cy / RES_SCREEN_HEIGHT) * screen_rect.Height ());
+	float dlg_screen_width				= WWMath::Trunc(((float)DialogResource_->cx / RES_SCREEN_WIDTH) * screen_rect.Width ());
+	float dlg_screen_height			= WWMath::Trunc(((float)DialogResource_->cy / RES_SCREEN_HEIGHT) * screen_rect.Height ());
 
 	//
 	//	Center the dialog on the screen
 	//
-	Rect.Left	= int(screen_rect.Center ().X - ((float)dlg_screen_width * 0.5F));
-	Rect.Top		= int(screen_rect.Center ().Y - ((float)dlg_screen_height * 0.5F));
-	Rect.Right	= int(Rect.Left + dlg_screen_width);
-	Rect.Bottom	= int(Rect.Top + dlg_screen_height);
+	Rect.Left	= WWMath::Trunc(screen_rect.Center ().X - (dlg_screen_width * 0.5F));
+	Rect.Top		= WWMath::Trunc(screen_rect.Center ().Y - (dlg_screen_height * 0.5F));
+	Rect.Right	= WWMath::Trunc(Rect.Left + dlg_screen_width);
+	Rect.Bottom	= WWMath::Trunc(Rect.Top + dlg_screen_height);
 
 	//
 	//	Now create the controls
@@ -268,17 +268,17 @@ DialogBaseClass::Start_Dialog (void)
 			control->Set_Style (info.style);
 			control->Set_ID (info.id);
 
-			int ctrl_width		= int((((float)info.cx) / RES_SCREEN_WIDTH) * screen_rect.Width ());
-			int ctrl_height	= int((((float)info.cy) / RES_SCREEN_HEIGHT) * screen_rect.Height ());
+			float ctrl_width		= WWMath::Trunc((((float)info.cx) / RES_SCREEN_WIDTH) * screen_rect.Width ());
+			float ctrl_height	= WWMath::Trunc((((float)info.cy) / RES_SCREEN_HEIGHT) * screen_rect.Height ());
 
 			//
 			//	Calculate the screen position of the control
 			//
 			RectClass rect;
-			rect.Left	= int(Rect.Left + ((((float)info.x) / RES_SCREEN_WIDTH) * screen_rect.Width ()));
-			rect.Top		= int(Rect.Top + ((((float)info.y) / RES_SCREEN_HEIGHT) * screen_rect.Height ()));
-			rect.Right	= int(rect.Left + ctrl_width);
-			rect.Bottom	= int(rect.Top + ctrl_height);
+			rect.Left	= WWMath::Trunc(Rect.Left + ((((float)info.x) / RES_SCREEN_WIDTH) * screen_rect.Width ()));
+			rect.Top		= WWMath::Trunc(Rect.Top + ((((float)info.y) / RES_SCREEN_HEIGHT) * screen_rect.Height ()));
+			rect.Right	= WWMath::Trunc(rect.Left + ctrl_width);
+			rect.Bottom	= WWMath::Trunc(rect.Top + ctrl_height);
 			control->Set_Window_Rect (rect);
 
 			//

--- a/Code/wwui/dialogcontrol.cpp
+++ b/Code/wwui/dialogcontrol.cpp
@@ -154,10 +154,10 @@ DialogControlClass::Set_Window_Pos (const Vector2 &pos)
 	//
 	//	Recalculate the window's bounding rectangle
 	//
-	Rect.Left	= (int)pos.X;
-	Rect.Top		= (int)pos.Y;
-	Rect.Right	= (int)(Rect.Left + width);
-	Rect.Bottom	= (int)(Rect.Top + height);
+	Rect.Left	= WWMath::Trunc(pos.X);
+	Rect.Top		= WWMath::Trunc(pos.Y);
+	Rect.Right	= WWMath::Trunc(Rect.Left + width);
+	Rect.Bottom	= WWMath::Trunc(Rect.Top + height);
 
 	//
 	//	Let the control recalculate anything it needs

--- a/Code/wwui/dropdownctrl.cpp
+++ b/Code/wwui/dropdownctrl.cpp
@@ -236,8 +236,8 @@ DropDownCtrlClass::Update_Client_Rect (void)
 	//
 	//	Calculate how each "text" cell should be
 	//
-	CellSize.X = int(ClientRect.Width ());
-	CellSize.Y = int(char_size.Y * 1.5F);
+	CellSize.X = WWMath::Trunc(ClientRect.Width ());
+	CellSize.Y = WWMath::Trunc(char_size.Y * 1.5F);
 
 	//
 	//	Update the number of entries we can display at one time
@@ -274,7 +274,7 @@ DropDownCtrlClass::Update_Client_Rect (void)
 		float new_width	= ScrollBarCtrl.Get_Window_Rect ().Left;
 		ClientRect.Right	= new_width;
 		Rect.Right			= new_width;
-		CellSize.X			= int(ClientRect.Width ());
+		CellSize.X			= WWMath::Trunc(ClientRect.Width ());
 	}
 
 	Set_Dirty ();

--- a/Code/wwui/editctrl.cpp
+++ b/Code/wwui/editctrl.cpp
@@ -524,10 +524,10 @@ EditCtrlClass::Create_Caret_Renderer (void)
 	//	Create a bounding rectangle for the caret
 	//
 	RectClass rect;
-	rect.Left	= int(ClientRect.Left + text_extent.X);
-	rect.Top		= int(ClientRect.Top + 1);
-	rect.Right	= int(rect.Left + std::max (space_extent, 1.0F));
-	rect.Bottom	= int(ClientRect.Bottom - 1);
+	rect.Left	= WWMath::Trunc(ClientRect.Left + text_extent.X);
+	rect.Top		= WWMath::Trunc(ClientRect.Top + 1);
+	rect.Right	= WWMath::Trunc(rect.Left + std::max (space_extent, 1.0F));
+	rect.Bottom	= WWMath::Trunc(ClientRect.Bottom - 1);
 
 	//
 	//	Draw the caret

--- a/Code/wwui/healthbarctrl.cpp
+++ b/Code/wwui/healthbarctrl.cpp
@@ -145,7 +145,7 @@ HealthBarCtrlClass::Create_Control_Renderer (void)
 	//	Calculate how long to draw the texture
 	//
 	float full_width	= Rect.Width ();
-	int	width			= (full_width * Percent);
+	float	width			= WWMath::Trunc(full_width * Percent);
 
 	Vector2 size1 (8.0F, 12.0F);
 	Vector2 size2 (7.0F, 12.0F);

--- a/Code/wwui/listctrl.cpp
+++ b/Code/wwui/listctrl.cpp
@@ -227,7 +227,7 @@ ListCtrlClass::Create_Text_Renderers (void)
 		//
 		//	Render each column header
 		//
-		int x_pos = HeaderRect.Left;
+		float x_pos = WWMath::Trunc(HeaderRect.Left);
 		for (int index = 0; index < ColList.Count (); index ++) {
 
 			//
@@ -303,7 +303,7 @@ ListCtrlClass::Create_Text_Renderers (void)
 			//
 			//	Move on to the next column
 			//
-			x_pos = rect.Right;
+			x_pos = WWMath::Trunc(rect.Right);
 		}
 	}
 
@@ -344,10 +344,10 @@ ListCtrlClass::Create_Text_Renderers (void)
 			//	Build a bounding rectangle for this entry
 			//
 			RectClass rect;
-			rect.Left	= int(x_pos);
-			rect.Right	= int(x_pos + col_width);
-			rect.Top		= int(y_pos);
-			rect.Bottom	= int(y_pos + row_height);
+			rect.Left	= WWMath::Trunc(x_pos);
+			rect.Right	= WWMath::Trunc(x_pos + col_width);
+			rect.Top		= WWMath::Trunc(y_pos);
+			rect.Bottom	= WWMath::Trunc(y_pos + row_height);
 
 			//
 			//	Render the entry
@@ -365,8 +365,8 @@ ListCtrlClass::Create_Text_Renderers (void)
 		//
 		if (Is_Entry_Selected (row_index)) {
 			RectClass row_rect	= TextRect;
-			row_rect.Top			= (int)std::max (TextRect.Top, (float)y_pos);
-			row_rect.Bottom		= (int)std::min (TextRect.Bottom, (float)(y_pos + row_height));
+			row_rect.Top			= WWMath::Trunc(std::max (TextRect.Top, y_pos));
+			row_rect.Bottom		= WWMath::Trunc(std::min (TextRect.Bottom, (y_pos + row_height)));
 			StyleMgrClass::Render_Hilight (&HilightRenderer, row_rect);
 		}
 
@@ -1660,7 +1660,7 @@ ListCtrlClass::Insert_Entry (int index, const unichar_t *text)
 void
 ListCtrlClass::Update_Row_Height (int row_index)
 {
-	int border_height		= (ROW_SPACING * StyleMgrClass::Get_Y_Scale ());
+	float border_height		= WWMath::Trunc(ROW_SPACING * StyleMgrClass::Get_Y_Scale ());
 	float height			= (TextRenderer.Get_Text_Extents (U_CHAR("W")).Y + border_height);
 
 	//
@@ -1737,7 +1737,7 @@ ListCtrlClass::Set_Icon_Size (float width, float height)
 void
 ListCtrlClass::Set_Min_Row_Height (int height)
 {
-	MinRowHeight = height;
+	MinRowHeight = float(height);
 
 	//
 	//	Update each row using this new height information
@@ -2148,10 +2148,10 @@ ListCtrlClass::Get_Entry_Rect (int index, RectClass &rect)
 		}
 	}
 
-	rect.Left	= int(TextRect.Left);
-	rect.Right	= int(TextRect.Right);
-	rect.Top		= int(y_pos);
-	rect.Bottom	= int(rect.Top + row_height);
+	rect.Left	= WWMath::Trunc(TextRect.Left);
+	rect.Right	= WWMath::Trunc(TextRect.Right);
+	rect.Top		= WWMath::Trunc(y_pos);
+	rect.Bottom	= WWMath::Trunc(rect.Top + row_height);
 	return ;
 }
 
@@ -2169,14 +2169,14 @@ ListCtrlClass::Col_From_Pos (const Vector2 &mouse_pos)
 	//
 	//	Test each column
 	//
-	int x_pos		= HeaderRect.Left;
+	float x_pos		= WWMath::Trunc(HeaderRect.Left);
 	int col_count	= ColList.Count ();
 	for (int col_index = 0; col_index < col_count; col_index ++) {
 
 		//
 		//	Determine how wide this column is
 		//
-		int col_width = (ColList[col_index]->Get_Width () * HeaderRect.Width ());
+		float col_width = WWMath::Trunc(ColList[col_index]->Get_Width () * HeaderRect.Width ());
 
 		//
 		//	Let the last column extend to the edge
@@ -2197,7 +2197,7 @@ ListCtrlClass::Col_From_Pos (const Vector2 &mouse_pos)
 		//
 		//	Move on to the next column
 		//
-		x_pos += col_width;
+		x_pos = WWMath::Trunc(x_pos + col_width);
 	}
 
 	return retval;
@@ -2220,7 +2220,7 @@ ListCtrlClass::Entry_From_Pos (const Vector2 &mouse_pos)
 	//
 	//	Test each row
 	//
-	int y_pos		= TextRect.Top;
+	float y_pos		= WWMath::Trunc(TextRect.Top);
 	int row_count	= Get_Entry_Count ();
 	for (int row_index = ScrollPos; row_index < row_count; row_index ++) {
 
@@ -2237,7 +2237,7 @@ ListCtrlClass::Entry_From_Pos (const Vector2 &mouse_pos)
 		//
 		//	Move down to the next row
 		//
-		y_pos += row_height;
+		y_pos = WWMath::Trunc(y_pos + row_height);
 
 		//
 		//	Stop searching if we've moved off the page

--- a/Code/wwui/listctrl.h
+++ b/Code/wwui/listctrl.h
@@ -138,7 +138,7 @@ public:
 	//	Row height support
 	//
 	void				Set_Min_Row_Height (int height);
-	int				Get_Min_Row_Height (void) const	{ return MinRowHeight; }
+	int				Get_Min_Row_Height (void) const	{ return int(MinRowHeight); }
 
 	//
 	//	Icon support

--- a/Code/wwui/listiconmgr.cpp
+++ b/Code/wwui/listiconmgr.cpp
@@ -171,8 +171,8 @@ ListIconMgrClass::Render_Icon (const RectClass &clip_rect, const char *texture_n
 		RectClass rect;
 		rect.Left			= clip_rect.Left;
 		rect.Right			= clip_rect.Left + icon_size_x;
-		rect.Top				= int (clip_rect.Center ().Y - (icon_size_y * 0.5F));
-		rect.Bottom			= int (clip_rect.Center ().Y + (icon_size_y * 0.5F));
+		rect.Top				= WWMath::Trunc (clip_rect.Center ().Y - (icon_size_y * 0.5F));
+		rect.Bottom			= WWMath::Trunc (clip_rect.Center ().Y + (icon_size_y * 0.5F));
 		Renderers[index]->Add_Quad (rect);
 	}
 

--- a/Code/wwui/mapctrl.cpp
+++ b/Code/wwui/mapctrl.cpp
@@ -245,10 +245,10 @@ MapCtrlClass::Create_Control_Renderers (void)
 			//	Build a screen rectangle we'll render into
 			//
 			RectClass screen_rect;
-			screen_rect.Left		= int(screen_pos.X - (marker.Get_Rect ().Width () / 2));
-			screen_rect.Top		= int(screen_pos.Y - (marker.Get_Rect ().Height () / 2));
-			screen_rect.Right		= int(screen_rect.Left + marker.Get_Rect ().Width ());
-			screen_rect.Bottom	= int(screen_rect.Top + marker.Get_Rect ().Height ());
+			screen_rect.Left		= WWMath::Trunc(screen_pos.X - (marker.Get_Rect ().Width () / 2));
+			screen_rect.Top		= WWMath::Trunc(screen_pos.Y - (marker.Get_Rect ().Height () / 2));
+			screen_rect.Right		= WWMath::Trunc(screen_rect.Left + marker.Get_Rect ().Width ());
+			screen_rect.Bottom	= WWMath::Trunc(screen_rect.Top + marker.Get_Rect ().Height ());
 
 			//
 			//	Convert the pixel coordinates into normalized UVs
@@ -300,16 +300,16 @@ MapCtrlClass::Create_Control_Renderers (void)
 	ButtonRenderer.Reset ();
 
 	RectClass temp_rect1;
-	temp_rect1.Left		= int(ZoomInButtonRect.Center ().X - (ZoomInUVRect.Width () / 2));
-	temp_rect1.Top			= int(ZoomInButtonRect.Center ().Y - (ZoomInUVRect.Height () / 2));
-	temp_rect1.Right		= int(temp_rect1.Left + ZoomInUVRect.Width ());
-	temp_rect1.Bottom		= int(temp_rect1.Top + ZoomInUVRect.Height ());
+	temp_rect1.Left		= WWMath::Trunc(ZoomInButtonRect.Center ().X - (ZoomInUVRect.Width () / 2));
+	temp_rect1.Top			= WWMath::Trunc(ZoomInButtonRect.Center ().Y - (ZoomInUVRect.Height () / 2));
+	temp_rect1.Right		= WWMath::Trunc(temp_rect1.Left + ZoomInUVRect.Width ());
+	temp_rect1.Bottom		= WWMath::Trunc(temp_rect1.Top + ZoomInUVRect.Height ());
 
 	RectClass temp_rect2;
-	temp_rect2.Left		= int(ZoomOutButtonRect.Center ().X - (ZoomInUVRect.Width () / 2));
-	temp_rect2.Top			= int(ZoomOutButtonRect.Center ().Y - (ZoomInUVRect.Height () / 2));
-	temp_rect2.Right		= int(temp_rect2.Left + ZoomInUVRect.Width ());
-	temp_rect2.Bottom		= int(temp_rect2.Top + ZoomInUVRect.Height ());
+	temp_rect2.Left		= WWMath::Trunc(ZoomOutButtonRect.Center ().X - (ZoomInUVRect.Width () / 2));
+	temp_rect2.Top			= WWMath::Trunc(ZoomOutButtonRect.Center ().Y - (ZoomInUVRect.Height () / 2));
+	temp_rect2.Right		= WWMath::Trunc(temp_rect2.Left + ZoomInUVRect.Width ());
+	temp_rect2.Bottom		= WWMath::Trunc(temp_rect2.Top + ZoomInUVRect.Height ());
 
 	RectClass temp_uv_rect1 = ZoomInUVRect;
 	RectClass temp_uv_rect2 = ZoomOutUVRect;
@@ -534,14 +534,14 @@ MapCtrlClass::Update_Client_Rect (void)
 	//
 	//	Build the zoom button rectangles
 	//
-	ZoomOutButtonRect.Left		= int(Rect.Right	- (ZoomInUVRect.Width () + 2));
-	ZoomOutButtonRect.Top		= int(Rect.Bottom	- (ZoomInUVRect.Height () + 2));
-	ZoomOutButtonRect.Right		= int(Rect.Right);
-	ZoomOutButtonRect.Bottom	= int(Rect.Bottom);
+	ZoomOutButtonRect.Left		= WWMath::Trunc(Rect.Right	- (ZoomInUVRect.Width () + 2));
+	ZoomOutButtonRect.Top		= WWMath::Trunc(Rect.Bottom	- (ZoomInUVRect.Height () + 2));
+	ZoomOutButtonRect.Right		= WWMath::Trunc(Rect.Right);
+	ZoomOutButtonRect.Bottom	= WWMath::Trunc(Rect.Bottom);
 
 	ZoomInButtonRect				= ZoomOutButtonRect;
-	ZoomInButtonRect.Left		= int(ZoomInButtonRect.Left - (ZoomInUVRect.Width () + 2));
-	ZoomInButtonRect.Right		= int(ZoomInButtonRect.Right - (ZoomInUVRect.Width () + 2));
+	ZoomInButtonRect.Left		= WWMath::Trunc(ZoomInButtonRect.Left - (ZoomInUVRect.Width () + 2));
+	ZoomInButtonRect.Right		= WWMath::Trunc(ZoomInButtonRect.Right - (ZoomInUVRect.Width () + 2));
 
 	Set_Dirty ();
 	return ;
@@ -664,8 +664,8 @@ MapCtrlClass::Set_Map_Texture (const char *filename)
 		//
 		//	Get the dimensions of the texture
 		//
-		MapSize.X = texture->Get_Width();
-		MapSize.Y = texture->Get_Height();
+		MapSize.X = float(texture->Get_Width());
+		MapSize.Y = float(texture->Get_Height());
 		texture->Set_U_Addr_Mode (TextureClass::TEXTURE_ADDRESS_CLAMP);
 		texture->Set_V_Addr_Mode (TextureClass::TEXTURE_ADDRESS_CLAMP);
 
@@ -934,8 +934,8 @@ MapCtrlClass::Set_Marker_Texture (const char *filename)
 //		texture->Get_Level_Description (surface_desc);
 //		IconTextureSize.X = surface_desc.Width;
 //		IconTextureSize.Y = surface_desc.Height;
-		IconTextureSize.X = texture->Get_Width ();
-		IconTextureSize.Y = texture->Get_Height ();
+		IconTextureSize.X = float(texture->Get_Width ());
+		IconTextureSize.Y = float(texture->Get_Height ());
 
 		//
 		//	Set the texture for the map

--- a/Code/wwui/menuentryctrl.cpp
+++ b/Code/wwui/menuentryctrl.cpp
@@ -184,7 +184,7 @@ MenuEntryCtrlClass::On_Create (void)
 	if ((Style & 0xF00) == BS_LEFT) {
 		Rect.Right = Rect.Left + extents.X + TextRenderer.Get_Text_Extents (U_CHAR("W")).X;
 	} else {
-		Rect.Left	= int(Rect.Left + (Rect.Width () / 2) - (extents.X / 2));
+		Rect.Left	= WWMath::Trunc(Rect.Left + (Rect.Width () / 2) - (extents.X / 2));
 		Rect.Right	= Rect.Left + extents.X + TextRenderer.Get_Text_Extents (U_CHAR("W")).X;
 	}
 
@@ -390,7 +390,7 @@ MenuEntryCtrlClass::Update_State (void)
 
 				if (curr_time >= (int)time2) {
 
-					Vector3 start_color (MaxHilightRedValue * 3, MaxHilightRedValue * 3.0F * 0.6F, 0);
+					Vector3 start_color (MaxHilightRedValue * 3.0F, MaxHilightRedValue * 3.0F * 0.6F, 0);
 					Vector3 end_color (0, 0, 0);
 
 					//
@@ -406,8 +406,8 @@ MenuEntryCtrlClass::Update_State (void)
 
 				} else {
 
-					Vector3 start_color (MaxHilightRedValue * 3, 0, 0);
-					Vector3 end_color (MaxHilightRedValue * 3, MaxHilightRedValue * 3.0F * 0.6F, 0);
+					Vector3 start_color (MaxHilightRedValue * 3.0F, 0, 0);
+					Vector3 end_color (MaxHilightRedValue * 3.0F, MaxHilightRedValue * 3.0F * 0.6F, 0);
 
 					uint32 start_time	= time1;
 					uint32 end_time	= time2;
@@ -424,13 +424,13 @@ MenuEntryCtrlClass::Update_State (void)
 
 			} else {
 
-				if (CurrRadiusX != 160.0F) {
+				if (CurrRadiusX != 160) {
 
 					//
 					//	Snap the glow to its max
 					//
-					CurrRadiusX	= 160.0F;
-					CurrRadiusY	= 60.0F;
+					CurrRadiusX	= 160;
+					CurrRadiusY	= 60;
 					CurrColor	= RGB_TO_INT32 (0, 0, 0);
 				}
 
@@ -466,9 +466,9 @@ MenuEntryCtrlClass::Update_State (void)
 				//	Fade out the color
 				//
 				if (curr_time > (EndTime - 500)) {
-					float start_time = EndTime - 500;
+					float start_time = float(EndTime - 500);
 					float red_percent = float(float(curr_time - start_time) / float(EndTime - start_time));
-					int red_value		= (1.0F - red_percent) * MaxHilightRedValue;
+					int red_value		= int((1.0F - red_percent) * MaxHilightRedValue);
 					CurrColor = RGB_TO_INT32 (red_value, 0, 0);
 				}
 
@@ -519,14 +519,14 @@ MenuEntryCtrlClass::Create_Text_Renderer (void)
 	//
 	//	Assume cenetered text
 	//
-	int x_pos = int(Rect.Left + (Rect.Width () / 2) - (text_extent.X / 2));
-	int y_pos = int(Rect.Top + (Rect.Height () / 2) - (text_extent.Y / 2));
+	float x_pos = WWMath::Trunc(Rect.Left + (Rect.Width () / 2) - (text_extent.X / 2));
+	float y_pos = WWMath::Trunc(Rect.Top + (Rect.Height () / 2) - (text_extent.Y / 2));
 
 	//
 	//	Should we left justify?
 	//
 	if ((Style & 0xF00) == BS_LEFT) {
-		x_pos = int(Rect.Left + 1);
+		x_pos = WWMath::Trunc(Rect.Left + 1);
 	}
 
 	if (CurrState == UP) {
@@ -763,18 +763,18 @@ MenuEntryCtrlClass::Center_Mouse (void)
 	//
 	Vector2 text_extent = TextRenderer.Get_Text_Extents (Title);
 
-	int x_pos = 0;
+	float x_pos = 0;
 
 	//
 	//	Should we left justify?
 	//
 	if ((Style & 0xF00) == BS_LEFT) {
-		x_pos = int(Rect.Left + (text_extent.X / 2));
+		x_pos = WWMath::Trunc(Rect.Left + (text_extent.X / 2));
 	} else {
-		x_pos = int(Rect.Left + (Rect.Width () / 2) - (text_extent.X / 2));
+		x_pos = WWMath::Trunc(Rect.Left + (Rect.Width () / 2) - (text_extent.X / 2));
 	}
 
-	int y_pos = int(Rect.Top + (Rect.Height () / 2));
+	float y_pos = WWMath::Trunc(Rect.Top + (Rect.Height () / 2));
 
 	//
 	//	Put the mouse cursor in the middle of this control

--- a/Code/wwui/merchandisectrl.cpp
+++ b/Code/wwui/merchandisectrl.cpp
@@ -188,14 +188,14 @@ MerchandiseCtrlClass::Update_Client_Rect (void)
 	//	Make the texture rectangle the 2/3 of the space
 	//
 	TextureRect				= Rect;
-	TextureRect.Bottom	= int(TextureRect.Top + (Rect.Height () * 0.667F));
+	TextureRect.Bottom	= WWMath::Trunc(TextureRect.Top + (Rect.Height () * 0.667F));
 
 	//
 	//	Make the cost rect use up 60% of the remaining space
 	//
 	CostRect				= Rect;
-	CostRect.Top		= int(TextureRect.Bottom + 1);
-	CostRect.Bottom	= CostRect.Top + int((Rect.Bottom - TextureRect.Bottom) * 0.6F);
+	CostRect.Top		= WWMath::Trunc(TextureRect.Bottom + 1);
+	CostRect.Bottom	= CostRect.Top + WWMath::Trunc((Rect.Bottom - TextureRect.Bottom) * 0.6F);
 
 	//
 	//	The rest of the space goes to the text rect
@@ -207,8 +207,8 @@ MerchandiseCtrlClass::Update_Client_Rect (void)
 	//	The counter lives in the upper-right corner
 	//
 	CountRect			= Rect;
-	CountRect.Left		= CountRect.Left + int(Rect.Width () * 0.75F);
-	CountRect.Bottom	= CountRect.Top + int(TextureRect.Height () * 0.25F);
+	CountRect.Left		= CountRect.Left + WWMath::Trunc(Rect.Width () * 0.75F);
+	CountRect.Bottom	= CountRect.Top + WWMath::Trunc(TextureRect.Height () * 0.25F);
 
 	Set_Dirty ();
 	return ;
@@ -277,8 +277,8 @@ MerchandiseCtrlClass::Create_Control_Renderer (void)
 		RectClass button_rect;
 		button_rect.Right		= Rect.Right - 1;
 		button_rect.Top		= Rect.Top + 2;
-		button_rect.Left		= int(button_rect.Right - (BUTTON_WIDTH * StyleMgrClass::Get_X_Scale ()));
-		button_rect.Bottom	= int(button_rect.Top + (BUTTON_HEIGHT * StyleMgrClass::Get_Y_Scale ()));
+		button_rect.Left		= WWMath::Trunc(button_rect.Right - (BUTTON_WIDTH * StyleMgrClass::Get_X_Scale ()));
+		button_rect.Bottom	= WWMath::Trunc(button_rect.Top + (BUTTON_HEIGHT * StyleMgrClass::Get_Y_Scale ()));
 
 		ButtonRenderer.Add_Quad (button_rect);
 	}
@@ -300,8 +300,8 @@ MerchandiseCtrlClass::Create_Control_Renderer (void)
 	//
 	RectClass text_rect = TextRect;
 	RectClass cost_rect = CostRect;
-	text_rect.Right = int(text_rect.Left + name_extents.X + 4.0F);
-	cost_rect.Right = int(cost_rect.Left + cost_extents.X + 4.0F);
+	text_rect.Right = WWMath::Trunc(text_rect.Left + name_extents.X + 4.0F);
+	cost_rect.Right = WWMath::Trunc(cost_rect.Left + cost_extents.X + 4.0F);
 
 	//
 	//	Clip the backdrop to the bounding rectangle
@@ -405,8 +405,8 @@ MerchandiseCtrlClass::On_LButton_Down (const Vector2 &mouse_pos)
 	RectClass button_rect;
 	button_rect.Right		= Rect.Right - 1;
 	button_rect.Top		= Rect.Top + 2;
-	button_rect.Left		= int(button_rect.Right - (BUTTON_WIDTH * StyleMgrClass::Get_X_Scale ()));
-	button_rect.Bottom	= int(button_rect.Top + (BUTTON_HEIGHT * StyleMgrClass::Get_Y_Scale ()));
+	button_rect.Left		= WWMath::Trunc(button_rect.Right - (BUTTON_WIDTH * StyleMgrClass::Get_X_Scale ()));
+	button_rect.Bottom	= WWMath::Trunc(button_rect.Top + (BUTTON_HEIGHT * StyleMgrClass::Get_Y_Scale ()));
 
 	//
 	//	Did the user click in the cycle button?
@@ -454,8 +454,8 @@ MerchandiseCtrlClass::On_LButton_DblClk (const Vector2 &mouse_pos)
 	RectClass button_rect;
 	button_rect.Right		= Rect.Right - 1;
 	button_rect.Top		= Rect.Top + 2;
-	button_rect.Left		= int(button_rect.Right - (BUTTON_WIDTH * StyleMgrClass::Get_X_Scale ()));
-	button_rect.Bottom	= int(button_rect.Top + (BUTTON_HEIGHT * StyleMgrClass::Get_Y_Scale ()));
+	button_rect.Left		= WWMath::Trunc(button_rect.Right - (BUTTON_WIDTH * StyleMgrClass::Get_X_Scale ()));
+	button_rect.Bottom	= WWMath::Trunc(button_rect.Top + (BUTTON_HEIGHT * StyleMgrClass::Get_Y_Scale ()));
 
 	//
 	//	Did the user click in the cycle button?

--- a/Code/wwui/multilinetextctrl.cpp
+++ b/Code/wwui/multilinetextctrl.cpp
@@ -166,7 +166,7 @@ MultiLineTextCtrlClass::Create_Text_Renderer (void)
 		//
 		if ((Style & ES_CENTER) == ES_CENTER) {
 
-			float char_height = TextRenderer.Peek_Font ()->Get_Char_Height ();
+			float char_height = float(TextRenderer.Peek_Font ()->Get_Char_Height ());
 			RectClass text_rect = ClientRect;
 
 			//
@@ -187,7 +187,7 @@ MultiLineTextCtrlClass::Create_Text_Renderer (void)
 				//
 				TextRenderer.Set_Wrapping_Width (0);
 				StyleMgrClass::Render_Text (text, &TextRenderer, text_rect, true, true, StyleMgrClass::CENTER_JUSTIFY, IsEnabled, false);
-				text_rect.Top = int (text_rect.Top + char_height);
+				text_rect.Top = WWMath::Trunc (text_rect.Top + char_height);
 				TextRenderer.Set_Wrapping_Width (ClientRect.Width ());
 
 				if (line_end == NULL) {
@@ -258,16 +258,16 @@ MultiLineTextCtrlClass::Update_Client_Rect (void)
 	//
 	ClientRect = Rect;
 	ClientRect.Inflate (Vector2 (-5.0F * StyleMgrClass::Get_X_Scale (), -3.75F * StyleMgrClass::Get_Y_Scale ()));
-	ClientRect.Left	= int(ClientRect.Left);
-	ClientRect.Top		= int(ClientRect.Top);
-	ClientRect.Right	= int(ClientRect.Right);
-	ClientRect.Bottom	= int(ClientRect.Bottom);
+	ClientRect.Left	= WWMath::Trunc(ClientRect.Left);
+	ClientRect.Top		= WWMath::Trunc(ClientRect.Top);
+	ClientRect.Right	= WWMath::Trunc(ClientRect.Right);
+	ClientRect.Bottom	= WWMath::Trunc(ClientRect.Bottom);
 
 	//
 	//	Determine how many rows we can fit on one page
 	//
-	float char_height = TextRenderer.Peek_Font ()->Get_Char_Height ();
-	RowsPerPage			= ClientRect.Height () / char_height;
+	float char_height = float(TextRenderer.Peek_Font ()->Get_Char_Height ());
+	RowsPerPage			= int(ClientRect.Height () / char_height);
 	IsInitialized		= true;
 
 	//
@@ -337,10 +337,10 @@ MultiLineTextCtrlClass::Update_Scroll_Bar_Visibility (void)
 		Rect.Right = new_right;
 		ClientRect = Rect;
 		ClientRect.Inflate (Vector2 (-5.0F * StyleMgrClass::Get_X_Scale (), -3.75F * StyleMgrClass::Get_Y_Scale ()));
-		ClientRect.Left	= int(ClientRect.Left);
-		ClientRect.Top		= int(ClientRect.Top);
-		ClientRect.Right	= int(ClientRect.Right);
-		ClientRect.Bottom	= int(ClientRect.Bottom);
+		ClientRect.Left	= WWMath::Trunc(ClientRect.Left);
+		ClientRect.Top		= WWMath::Trunc(ClientRect.Top);
+		ClientRect.Right	= WWMath::Trunc(ClientRect.Right);
+		ClientRect.Bottom	= WWMath::Trunc(ClientRect.Bottom);
 
 
 		Calculate_Row_Count ();
@@ -445,7 +445,7 @@ MultiLineTextCtrlClass::On_VScroll (ScrollBarCtrlClass *, int , int new_position
 void
 MultiLineTextCtrlClass::On_Mouse_Wheel (int direction)
 {
-	int lineoffset = direction * MouseWheelIncrement;
+	int lineoffset = int(direction * MouseWheelIncrement);
 
 	Set_Scroll_Pos (ScrollPos + lineoffset);
 	return ;

--- a/Code/wwui/screencursor.cpp
+++ b/Code/wwui/screencursor.cpp
@@ -125,10 +125,10 @@ ScreenCursorClass::Render (void)
 	//	Build the screen-space rectangle we'll render to
 	//
 	RectClass rect;
-	rect.Left	= (int)cursor_pos.X;
-	rect.Top		= (int)cursor_pos.Y;
-	rect.Right	= (int)cursor_pos.X + Width;
-	rect.Bottom	= (int)cursor_pos.Y + Height;
+	rect.Left	= WWMath::Trunc(cursor_pos.X);
+	rect.Top		= WWMath::Trunc(cursor_pos.Y);
+	rect.Right	= WWMath::Trunc(cursor_pos.X + Width);
+	rect.Bottom	= WWMath::Trunc(cursor_pos.Y + Height);
 
 	//
 	//	Render the mouse cursor

--- a/Code/wwui/scrollbarctrl.cpp
+++ b/Code/wwui/scrollbarctrl.cpp
@@ -323,7 +323,7 @@ ScrollBarCtrlClass::Update_Client_Rect (void)
 	//	Snap the rect to the alloted size
 	//
 	if (Rect.Right >= 0.0f) {
-		Rect.Left = int(Rect.Right - Width);
+		Rect.Left = WWMath::Trunc(Rect.Right - Width);
 	} else {
 		Rect.Right = (Rect.Left + Width);
 	}
@@ -348,18 +348,18 @@ ScrollBarCtrlClass::Update_Client_Rect (void)
 	//
 	//	Update the top button's bounding rectangle
 	//
-	TopButtonRect.Left	= int(ClientRect.Left + (ClientRect.Width () / 2) - (button_width / 2));
-	TopButtonRect.Top		= int(ClientRect.Top - (BUTTON_V_OFFSET * ScaleY));
-	TopButtonRect.Right	= int(TopButtonRect.Left + button_width);
-	TopButtonRect.Bottom	= int(TopButtonRect.Top + button_height);
+	TopButtonRect.Left	= WWMath::Trunc(ClientRect.Left + (ClientRect.Width () / 2) - (button_width / 2));
+	TopButtonRect.Top		= WWMath::Trunc(ClientRect.Top - (BUTTON_V_OFFSET * ScaleY));
+	TopButtonRect.Right	= WWMath::Trunc(TopButtonRect.Left + button_width);
+	TopButtonRect.Bottom	= WWMath::Trunc(TopButtonRect.Top + button_height);
 
 	//
 	//	Update the bottom button's bounding rectangle
 	//
-	BottomButtonRect.Left	= int(ClientRect.Left + (ClientRect.Width () / 2) - (button_width / 2));
-	BottomButtonRect.Top		= int(ClientRect.Bottom - button_height + (BUTTON_V_OFFSET * ScaleY));
-	BottomButtonRect.Right	= int(BottomButtonRect.Left + button_width);
-	BottomButtonRect.Bottom	= int(BottomButtonRect.Top + button_height);
+	BottomButtonRect.Left	= WWMath::Trunc(ClientRect.Left + (ClientRect.Width () / 2) - (button_width / 2));
+	BottomButtonRect.Top		= WWMath::Trunc(ClientRect.Bottom - button_height + (BUTTON_V_OFFSET * ScaleY));
+	BottomButtonRect.Right	= WWMath::Trunc(BottomButtonRect.Left + button_width);
+	BottomButtonRect.Bottom	= WWMath::Trunc(BottomButtonRect.Top + button_height);
 
 	//
 	//	Adjust the rectangle to include the top and bottom buttons
@@ -773,15 +773,15 @@ ScrollBarCtrlClass::Update_Thumb_Rect (void)
 	//
 
 	if (IsSmallBMPMode) {
-		ThumbRect.Left		= int(ClientRect.Left + (ClientRect.Width () / 2) - (ThumbWidth / 2));
-		ThumbRect.Right	= int(ThumbRect.Left + ThumbWidth);
+		ThumbRect.Left		= WWMath::Trunc(ClientRect.Left + (ClientRect.Width () / 2) - (ThumbWidth / 2));
+		ThumbRect.Right	= WWMath::Trunc(ThumbRect.Left + ThumbWidth);
 	} else {
 		ThumbRect.Right	= ClientRect.Right - 1;
 		ThumbRect.Left		= ThumbRect.Right - ThumbWidth;
 	}
 
-	ThumbRect.Top		= int(TopButtonRect.Bottom + (TrackRect.Height () * percent));
-	ThumbRect.Bottom	= int(ThumbRect.Top + ThumbHeight);
+	ThumbRect.Top		= WWMath::Trunc(TopButtonRect.Bottom + (TrackRect.Height () * percent));
+	ThumbRect.Bottom	= WWMath::Trunc(ThumbRect.Top + ThumbHeight);
 	return ;
 }
 

--- a/Code/wwui/shortcutbarctrl.cpp
+++ b/Code/wwui/shortcutbarctrl.cpp
@@ -259,7 +259,7 @@ ShortcutBarCtrlClass::Render_Strip (const RectClass &screen_rect, bool flip_uvs)
 	//	Render the top of the bar
 	//
 	RectClass rect	= screen_rect;
-	rect.Bottom		= int(rect.Top + BAR_TOP_UVS.Height ());
+	rect.Bottom		= WWMath::Trunc(rect.Top + BAR_TOP_UVS.Height ());
 	TexturedControlRenderer.Add_Quad (rect, bar_top_uvs);
 
 	//
@@ -275,7 +275,7 @@ ShortcutBarCtrlClass::Render_Strip (const RectClass &screen_rect, bool flip_uvs)
 		//	Render this section of the bar
 		//
 		rect.Top		= rect.Bottom;
-		rect.Bottom = int (rect.Top + tile_height);
+		rect.Bottom = WWMath::Trunc (rect.Top + tile_height);
 		TexturedControlRenderer.Add_Quad (rect, bar_tile_uvs);
 
 		//
@@ -653,10 +653,10 @@ ShortcutBarCtrlClass::Get_Entry_Rect (int index, RectClass &rect)
 	//	Simply calculate the rectangle for this entry and return it
 	// to the caller
 	//
-	rect.Left	= FullRect.Left + int(BORDER_X * StyleMgrClass::Get_X_Scale ());
-	rect.Right	= FullRect.Right - int(BORDER_X * StyleMgrClass::Get_X_Scale ());
-	rect.Top		= int(start_y_pos + (index * entry_height));
-	rect.Bottom	= int(rect.Top + entry_height);
+	rect.Left	= FullRect.Left + WWMath::Trunc(BORDER_X * StyleMgrClass::Get_X_Scale ());
+	rect.Right	= FullRect.Right - WWMath::Trunc(BORDER_X * StyleMgrClass::Get_X_Scale ());
+	rect.Top		= WWMath::Trunc(start_y_pos + (index * entry_height));
+	rect.Bottom	= WWMath::Trunc(rect.Top + entry_height);
 	return ;
 }
 

--- a/Code/wwui/sliderctrl.cpp
+++ b/Code/wwui/sliderctrl.cpp
@@ -107,17 +107,17 @@ SliderCtrlClass::Create_Control_Renderer (void)
 	//	Calculate the thumb's position
 	//
 	float percent		= float(CurrPos - MinPos) / float(MaxPos - MinPos);
-	int thumb_height	= ClientRect.Height () - 2;
+	int thumb_height	= int(ClientRect.Height () - 2);
 	int thumb_width	= thumb_height / 2;
 
 	//
 	//	Calculate the rectangle for the thumb
 	//
 	RectClass rect;
-	rect.Left	= int (ClientRect.Left + (ClientRect.Width () * percent) - (thumb_width * 0.5F));
+	rect.Left	= WWMath::Trunc (ClientRect.Left + (ClientRect.Width () * percent) - (thumb_width * 0.5F));
 	rect.Right	= rect.Left + thumb_width;
-	rect.Top		= int(ClientRect.Top + (ClientRect.Height () / 2) - (thumb_height / 2));
-	rect.Bottom	= int(ClientRect.Top + (ClientRect.Height () / 2) + (thumb_height / 2));
+	rect.Top		= WWMath::Trunc(ClientRect.Top + (ClientRect.Height () / 2) - (thumb_height / 2));
+	rect.Bottom	= WWMath::Trunc(ClientRect.Top + (ClientRect.Height () / 2) + (thumb_height / 2));
 
 
 	//
@@ -139,8 +139,8 @@ SliderCtrlClass::Create_Control_Renderer (void)
 	rect1.Right		= rect.Left;
 	rect2.Left		= rect.Right;
 	rect2.Right		= ClientRect.Right;
-	rect1.Top		= int(ClientRect.Top + (ClientRect.Height () / 2) - (bar_height / 2));
-	rect1.Bottom	= int(ClientRect.Top + (ClientRect.Height () / 2) + (bar_height / 2));
+	rect1.Top		= WWMath::Trunc(ClientRect.Top + (ClientRect.Height () / 2) - (bar_height / 2));
+	rect1.Bottom	= WWMath::Trunc(ClientRect.Top + (ClientRect.Height () / 2) + (bar_height / 2));
 	rect2.Top		= rect1.Top;
 	rect2.Bottom	= rect1.Bottom;
 
@@ -372,7 +372,7 @@ SliderCtrlClass::Slider_Pos_From_Mouse_Pos (const Vector2 &mouse_pos)
 		retval = MaxPos;
 	} else {
 
-		int thumb_height	= ClientRect.Height () - 2;
+		int thumb_height	= int(ClientRect.Height () - 2);
 		int thumb_width	= thumb_height / 2;
 
 		//

--- a/Code/wwui/stylemgr.cpp
+++ b/Code/wwui/stylemgr.cpp
@@ -152,7 +152,7 @@ StyleMgrClass::Initialize (void)
 		//	Create the font
 		//
 		Fonts[index] = WW3DAssetManager::Get_Instance()->Get_FontChars (DEFAULT_FONTS[index].name,
-								point_size, DEFAULT_FONTS[index].is_bold);
+								int(point_size), DEFAULT_FONTS[index].is_bold);
 	}
 
 	//
@@ -265,7 +265,7 @@ StyleMgrClass::Initialize_From_INI (const char *filename)
 			//	Create the font
 			//
 			Fonts[index] = WW3DAssetManager::Get_Instance()->Get_FontChars (font_name,
-									point_size, is_bold);
+									int(point_size), is_bold);
 
 		}
 
@@ -455,8 +455,8 @@ StyleMgrClass::Render_Title_Text
 	//
 	//	Center the text
 	//
-	int x_pos = int(rect.Left + (rect.Width () / 2) - (text_extent.X / 2));
-	int y_pos = int(rect.Top + (rect.Height () / 2) - (text_extent.Y / 2));
+	float x_pos = WWMath::Trunc(rect.Left + (rect.Width () / 2) - (text_extent.X / 2));
+	float y_pos = WWMath::Trunc(rect.Top + (rect.Height () / 2) - (text_extent.Y / 2));
 
 	//
 	//	Build the textures for the text we'll be drawing
@@ -551,8 +551,8 @@ StyleMgrClass::Render_Text
 	//
 	//	Assume left justification
 	//
-	int x_pos = rect.Left + 1;
-	int y_pos = int(rect.Top + (rect.Height () / 2) - (text_extent.Y / 2));
+	float x_pos = WWMath::Trunc(rect.Left + 1);
+	float y_pos = WWMath::Trunc(rect.Top + (rect.Height () / 2) - (text_extent.Y / 2));
 	if (is_vcentered == false) {
 		y_pos = rect.Top;
 	}
@@ -565,13 +565,13 @@ StyleMgrClass::Render_Text
 		//
 		//	Caclulate right justification
 		//
-		x_pos = int(rect.Right - text_extent.X);
+		x_pos = WWMath::Trunc(rect.Right - text_extent.X);
 	} else if (justify == CENTER_JUSTIFY) {
 
 		//
 		//	Calculate center justification
 		//
-		x_pos = int(rect.Left + (rect.Width () / 2) - (text_extent.X / 2));
+		x_pos = WWMath::Trunc(rect.Left + (rect.Width () / 2) - (text_extent.X / 2));
 	}
 
 	//
@@ -845,10 +845,10 @@ StyleMgrClass::Render_Wrapped_Text_Ex
 	//
 	//	Calculate where to start spitting out the text
 	//
-	float text_height		= renderer->Peek_Font ()->Get_Char_Height ();
+	float text_height		= float(renderer->Peek_Font ()->Get_Char_Height ());
 	RectClass curr_rect	= rect;
 	if (do_vcenter) {
-		curr_rect.Top = int(rect.Center ().Y - ((row_count * text_height) * 0.5F));
+		curr_rect.Top = WWMath::Trunc(rect.Center ().Y - ((row_count * text_height) * 0.5F));
 	}
 
 	//
@@ -926,8 +926,8 @@ StyleMgrClass::Render_Wrapped_Text
 	//
 	//	Assume left justification
 	//
-	int x_pos = rect.Left + 1;
-	int y_pos = rect.Top + 1;
+	float x_pos = WWMath::Trunc(rect.Left + 1);
+	float y_pos = WWMath::Trunc(rect.Top + 1);
 
 	//
 	//	Center the text vertically if necessary
@@ -1055,8 +1055,8 @@ StyleMgrClass::Render_Glow
 	//step_count			= std::max (step_count, 4);
 	float angle_inc	= DEG_TO_RADF (360) / step_count;
 
-	float x_inc = radius_x / pass_count;
-	float y_inc = radius_y / pass_count;
+	float x_inc = float(radius_x / pass_count);
+	float y_inc = float(radius_y / pass_count);
 
 	float curr_radiusx = 2.0F;
 	float curr_radiusy = 2.0F;

--- a/Code/wwui/tabctrl.cpp
+++ b/Code/wwui/tabctrl.cpp
@@ -172,10 +172,10 @@ TabCtrlClass::Create_Text_Renderer (void)
 		//	Calculate what rectangle to render to
 		//
 		RectClass text_rect;
-		text_rect.Left		= (int)(text_left + (radius + x_offset));
-		text_rect.Top		= (int)y_pos;
-		text_rect.Right	= (int)ClientRect.Right;
-		text_rect.Bottom	= int(y_pos + tab_height);
+		text_rect.Left		= WWMath::Trunc(text_left + (radius + x_offset));
+		text_rect.Top		= WWMath::Trunc(y_pos);
+		text_rect.Right	= WWMath::Trunc(ClientRect.Right);
+		text_rect.Bottom	= WWMath::Trunc(y_pos + tab_height);
 
 		//
 		//	Get the title from the child dialog
@@ -343,27 +343,27 @@ TabCtrlClass::Create_Control_Renderer (void)
 	//	Calculate the screen rectangle for the bar
 	//
 	RectClass bar_rect;
-	bar_rect.Left		= int(ClientRect.Left + x_offset + (BAR_OFFSET * ScaleX) - (bar_width / 2));
-	bar_rect.Right		= int(bar_rect.Left + bar_width);
-	bar_rect.Top		= int(ClientRect.Top - (x_offset * 1.5F));
-	bar_rect.Bottom	= int(ClientRect.Bottom + (x_offset * 1.5F));
+	bar_rect.Left		= WWMath::Trunc(ClientRect.Left + x_offset + (BAR_OFFSET * ScaleX) - (bar_width / 2));
+	bar_rect.Right		= WWMath::Trunc(bar_rect.Left + bar_width);
+	bar_rect.Top		= WWMath::Trunc(ClientRect.Top - (x_offset * 1.5F));
+	bar_rect.Bottom	= WWMath::Trunc(ClientRect.Bottom + (x_offset * 1.5F));
 
 	//
 	//	Calculate the screen rectangle for the selector
 	//
-	SelRect.Left	= int(ClientRect.Left + x_offset);
-	SelRect.Right	= int(SelRect.Left + sel_width);
-	SelRect.Top		= int(SelectorPos - (sel_height / 2));
-	SelRect.Bottom	= int(SelRect.Top + sel_height);
+	SelRect.Left	= WWMath::Trunc(ClientRect.Left + x_offset);
+	SelRect.Right	= WWMath::Trunc(SelRect.Left + sel_width);
+	SelRect.Top		= WWMath::Trunc(SelectorPos - (sel_height / 2));
+	SelRect.Bottom	= WWMath::Trunc(SelRect.Top + sel_height);
 
 	//
 	//	Calculate the screen rectangle for the bubble
 	//
 	RectClass bubble_rect;
-	bubble_rect.Left		= int(SelRect.Left + BUBBLE_OFFSET_X * ScaleX);
-	bubble_rect.Right		= int(bubble_rect.Left + bubble_width);
-	bubble_rect.Top		= int(SelRect.Top + BUBBLE_OFFSET_Y * ScaleY);
-	bubble_rect.Bottom	= int(bubble_rect.Top + bubble_height);
+	bubble_rect.Left		= WWMath::Trunc(SelRect.Left + BUBBLE_OFFSET_X * ScaleX);
+	bubble_rect.Right		= WWMath::Trunc(bubble_rect.Left + bubble_width);
+	bubble_rect.Top		= WWMath::Trunc(SelRect.Top + BUBBLE_OFFSET_Y * ScaleY);
+	bubble_rect.Bottom	= WWMath::Trunc(bubble_rect.Top + bubble_height);
 
 	//
 	//	Normalize the UVs
@@ -380,16 +380,16 @@ TabCtrlClass::Create_Control_Renderer (void)
 	//	Render the bar top and bottom
 	//
 	RectClass bar_top_rect;
-	bar_top_rect.Left		= int(bar_rect.Left);
-	bar_top_rect.Right	= int(bar_rect.Right);
-	bar_top_rect.Top		= int(bar_rect.Top);
-	bar_top_rect.Bottom	= int(bar_top_rect.Top + bar_tip_height);
+	bar_top_rect.Left		= WWMath::Trunc(bar_rect.Left);
+	bar_top_rect.Right	= WWMath::Trunc(bar_rect.Right);
+	bar_top_rect.Top		= WWMath::Trunc(bar_rect.Top);
+	bar_top_rect.Bottom	= WWMath::Trunc(bar_top_rect.Top + bar_tip_height);
 
 	RectClass bar_bottom_rect;
-	bar_bottom_rect.Left		= int(bar_rect.Left);
-	bar_bottom_rect.Right	= int(bar_rect.Right);
-	bar_bottom_rect.Top		= int(bar_rect.Bottom - bar_tip_height);
-	bar_bottom_rect.Bottom	= int(bar_rect.Bottom);
+	bar_bottom_rect.Left		= WWMath::Trunc(bar_rect.Left);
+	bar_bottom_rect.Right	= WWMath::Trunc(bar_rect.Right);
+	bar_bottom_rect.Top		= WWMath::Trunc(bar_rect.Bottom - bar_tip_height);
+	bar_bottom_rect.Bottom	= WWMath::Trunc(bar_rect.Bottom);
 
 	renderer.Add_Quad (bar_top_rect, bar_top_uvs);
 	renderer.Add_Quad (bar_bottom_rect, bar_bottom_uvs);
@@ -475,10 +475,10 @@ TabCtrlClass::Update_Client_Rect (void)
 	//
 	for (int index = 0; index < TabList.Count (); index ++) {
 		RectClass rect;
-		rect.Left	= (int)(ClientRect.Left + PAGE_AREA_OFFSET * ScaleX);
-		rect.Top		= (int)ClientRect.Top;
-		rect.Right	= (int)ClientRect.Right;
-		rect.Bottom	= (int)ClientRect.Bottom;
+		rect.Left	= WWMath::Trunc(ClientRect.Left + PAGE_AREA_OFFSET * ScaleX);
+		rect.Top		= WWMath::Trunc(ClientRect.Top);
+		rect.Right	= WWMath::Trunc(ClientRect.Right);
+		rect.Bottom	= WWMath::Trunc(ClientRect.Bottom);
 		TabList[index]->Set_Rect (rect);
 	}
 
@@ -754,7 +754,7 @@ TabCtrlClass::Update_Bubble (void)
 			//	Toggle the bubble light
 			//
 			IsBubbleDisplayed = !IsBubbleDisplayed;
-			NextBlinkTime		= curr_time + BLINK_DELAY;
+			NextBlinkTime		= int(curr_time + BLINK_DELAY);
 
 			//
 			//	Force a repaint
@@ -843,10 +843,10 @@ TabCtrlClass::Add_Tab (ChildDialogClass *dialog)
 	// page area.
 	//
 	RectClass rect;
-	rect.Left	= (int)(ClientRect.Left + PAGE_AREA_OFFSET * ScaleX);
-	rect.Top		= (int)ClientRect.Top;
-	rect.Right	= (int)ClientRect.Right;
-	rect.Bottom	= (int)ClientRect.Bottom;
+	rect.Left	= WWMath::Trunc(ClientRect.Left + PAGE_AREA_OFFSET * ScaleX);
+	rect.Top		= WWMath::Trunc(ClientRect.Top);
+	rect.Right	= WWMath::Trunc(ClientRect.Right);
+	rect.Bottom	= WWMath::Trunc(ClientRect.Bottom);
 	dialog->Set_Rect (rect);
 
 	//

--- a/Code/wwui/textmarqueectrl.cpp
+++ b/Code/wwui/textmarqueectrl.cpp
@@ -134,7 +134,7 @@ TextMarqueeCtrlClass::Create_Text_Renderer (void)
 	//
 	//	Calculate where to start rendering text
 	//
-	int ctrl_height		= ClientRect.Height ();
+	float ctrl_height		= WWMath::Trunc(ClientRect.Height ());
 	float start_height	= (ScrollPos - ctrl_height);
 
 	float curr_height		= 0;
@@ -177,7 +177,7 @@ TextMarqueeCtrlClass::Create_Text_Renderer (void)
 		//
 		//	Move down to the next row...
 		//
-		text_rect.Top = int(text_rect.Top + line.Height);
+		text_rect.Top = WWMath::Trunc(text_rect.Top + line.Height);
 	}
 
 	return ;
@@ -225,10 +225,10 @@ TextMarqueeCtrlClass::Update_Client_Rect (void)
 	//
 	ClientRect = Rect;
 	ClientRect.Inflate (Vector2 (-5.0F * StyleMgrClass::Get_X_Scale (), -3.75F * StyleMgrClass::Get_Y_Scale ()));
-	ClientRect.Left	= int(ClientRect.Left);
-	ClientRect.Top		= int(ClientRect.Top);
-	ClientRect.Right	= int(ClientRect.Right);
-	ClientRect.Bottom	= int(ClientRect.Bottom);
+	ClientRect.Left	= WWMath::Trunc(ClientRect.Left);
+	ClientRect.Top		= WWMath::Trunc(ClientRect.Top);
+	ClientRect.Right	= WWMath::Trunc(ClientRect.Right);
+	ClientRect.Bottom	= WWMath::Trunc(ClientRect.Bottom);
 
 	Set_Dirty ();
 	return ;
@@ -262,7 +262,7 @@ TextMarqueeCtrlClass::Set_Text (const unichar_t *title)
 	//
 	//	Add two blank pages
 	//
-	PixelHeight += ClientRect.Height () * 2;
+	PixelHeight += int(ClientRect.Height () * 2);
 	return ;
 }
 
@@ -338,7 +338,7 @@ TextMarqueeCtrlClass::Build_Credit_Lines (void)
 			//
 			CREDIT_LINE new_line (line);
 			new_line.Text		= text_str;
-			new_line.Height	= TextRenderers[new_line.FontIndex].Peek_Font ()->Get_Char_Height ();
+			new_line.Height	= float(TextRenderers[new_line.FontIndex].Peek_Font ()->Get_Char_Height ());
 			CreditLines.Add (new_line);
 
 			//
@@ -511,7 +511,7 @@ TextMarqueeCtrlClass::Read_Line (const unichar_t *text, CREDIT_LINE &line)
 void
 TextMarqueeCtrlClass::On_Frame_Update (void)
 {
-	float char_height = TextRenderers[0].Peek_Font ()->Get_Char_Height ();
+	float char_height = float(TextRenderers[0].Peek_Font ()->Get_Char_Height ());
 
 	//
 	//	Determine how many pixels to scroll

--- a/Code/wwui/tooltip.cpp
+++ b/Code/wwui/tooltip.cpp
@@ -91,8 +91,8 @@ ToolTipClass::Create_Text_Renderer (void)
 	//
 	Vector2 text_extent = renderer.Get_Text_Extents (Text);
 
-	int x_pos = int(Rect.Left + ((Rect.Width() - text_extent.X) / 2));
-	int y_pos = int(Rect.Top + ((Rect.Height() - text_extent.Y) / 2));
+	float x_pos = WWMath::Trunc(Rect.Left + ((Rect.Width() - text_extent.X) / 2));
+	float y_pos = WWMath::Trunc(Rect.Top + ((Rect.Height() - text_extent.Y) / 2));
 
 	//
 	//	Draw the text

--- a/Code/wwui/treectrl.cpp
+++ b/Code/wwui/treectrl.cpp
@@ -190,16 +190,16 @@ TreeCtrlClass::Render_Item (TreeItemClass *item, float x_pos, float &y_pos, int 
 	//	Build the display rectangles
 	//
 	RectClass rect;
-	rect.Left	= ClientRect.Left + LINE_START + int(level * LINE_SPACING);
+	rect.Left	= ClientRect.Left + LINE_START + WWMath::Trunc(level * LINE_SPACING);
 	rect.Top		= y_pos;
 	rect.Right	= ClientRect.Right;
 	rect.Bottom	= y_pos + RowHeight;
 
 	RectClass plus_rect;
-	plus_rect.Left		= int(rect.Left - LINE_SPACING);
-	plus_rect.Top		= int(rect.Center ().Y - (LINE_SPACING * 0.5F));
-	plus_rect.Right	= int((plus_rect.Left + LINE_SPACING));
-	plus_rect.Bottom	= int(rect.Center ().Y + (LINE_SPACING * 0.5F));
+	plus_rect.Left		= WWMath::Trunc(rect.Left - LINE_SPACING);
+	plus_rect.Top		= WWMath::Trunc(rect.Center ().Y - (LINE_SPACING * 0.5F));
+	plus_rect.Right	= WWMath::Trunc((plus_rect.Left + LINE_SPACING));
+	plus_rect.Bottom	= WWMath::Trunc(rect.Center ().Y + (LINE_SPACING * 0.5F));
 
 	RectClass icon_rect;
 	icon_rect.Left		= rect.Left;
@@ -502,9 +502,9 @@ TreeCtrlClass::Update_Client_Rect (void)
 	//
 	//	Determine how many rows we can fit on a page
 	//
-	RowsPerPage = ClientRect.Height () / RowHeight;
-	ClientRect.Top		= int(Rect.Center ().Y - (RowsPerPage * RowHeight * 0.5F));
-	ClientRect.Bottom	= int(Rect.Center ().Y + (RowsPerPage * RowHeight * 0.5F));
+	RowsPerPage = int(ClientRect.Height () / RowHeight);
+	ClientRect.Top		= WWMath::Trunc(Rect.Center ().Y - (RowsPerPage * RowHeight * 0.5F));
+	ClientRect.Bottom	= WWMath::Trunc(Rect.Center ().Y + (RowsPerPage * RowHeight * 0.5F));
 
 	//
 	//	Choose an arbitrary width, the scroll bar
@@ -750,7 +750,7 @@ TreeCtrlClass::Hit_Test (const Vector2 &mouse_pos, HITTYPE &type)
 		//
 		//	Determine on which row of the screen the user clicked
 		//
-		int row_index = (mouse_pos.Y - ClientRect.Top) / RowHeight;
+		int row_index = int((mouse_pos.Y - ClientRect.Top) / RowHeight);
 
 		//
 		//	Now move down that number of items...

--- a/Code/wwutil/ProcessManager.cpp
+++ b/Code/wwutil/ProcessManager.cpp
@@ -122,6 +122,6 @@ Process *ProcessManager::Create_Process(const char * const *args)
 	}
 	auto props = SDL_GetProcessProperties(sdl_process);
 	auto pid = SDL_GetNumberProperty(props, SDL_PROP_PROCESS_PID_NUMBER, -1);
-	return new Process(sdl_process, pid);
+	return new Process(sdl_process, int(pid)); // TODO OmniBlade: Investigate consquences of losing part of the pid?
 #endif
 }


### PR DESCRIPTION
Silences warnings about possible loss of data when converting between inbuilt types.
Most fixes accept current behaviour as desired. 
Some affect precision of floating point calculations but in theory should not affect behaviour. 
Some mask potential bugs and have comments added to highlight them for future work.
Some changes replace float>int>float casts with calls to a new truncf wrapper to perform same truncation operation while avoiding a type cast.