### PR TITLE
Fix modern MSVC test configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ endif()
 
 project(commando LANGUAGES C CXX)
 
+include(CTest)
+
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 # This file handles extra settings wanted/needed for different compilers.
@@ -77,14 +79,14 @@ endif()
 
 if(W3D_BUILD_OPTION_SDL3)
     include(sdl3)
-    add_compile_definitions(-DOPENW3D_SDL3=1)
+    add_compile_definitions(OPENW3D_SDL3=1)
 elseif(WIN32)
-    add_compile_definitions(-DOPENW3D_WIN32=1)
+    add_compile_definitions(OPENW3D_WIN32=1)
 else()
     message(FATAL_ERROR "Invalid backend")
 endif()
 
-add_compile_definitions(-DWEBBROWSER_ENABLED=$<BOOL:${W3D_BUILD_OPTION_WEBBROWSER}>)
+add_compile_definitions(WEBBROWSER_ENABLED=$<BOOL:${W3D_BUILD_OPTION_WEBBROWSER}>)
 
 if(W3D_BUILD_OPTION_OPENAL)
     include(openal)
@@ -106,7 +108,7 @@ endif()
 
 if(WIN32)
     # Do we want to build with bink for video decoding?
-    cmake_dependent_option(W3D_BUILD_OPTION_BINK "Build with bink." ON NOT W3D_BUILD_OPTION_FFMPEG OFF)
+    cmake_dependent_option(W3D_BUILD_OPTION_BINK "Build with bink." ON "NOT W3D_BUILD_OPTION_FFMPEG" OFF)
     add_feature_info(BinkBuild W3D_BUILD_OPTION_BINK "Build OpenW3D with Bink")
 
     if(W3D_BUILD_OPTION_BINK)
@@ -115,7 +117,7 @@ if(WIN32)
     endif()
 
     # Do we want to build with miles for audio playback?
-    cmake_dependent_option(W3D_BUILD_OPTION_MILES "Build with miles." ON NOT W3D_BUILD_OPTION_OPENAL OFF)
+    cmake_dependent_option(W3D_BUILD_OPTION_MILES "Build with miles." ON "NOT W3D_BUILD_OPTION_OPENAL" OFF)
     add_feature_info(MilesBuild W3D_BUILD_OPTION_MILES "Build OpenW3D with Miles Audio")
 
     if(W3D_BUILD_OPTION_MILES)

--- a/Code/wwlib/Except.cpp
+++ b/Code/wwlib/Except.cpp
@@ -172,40 +172,6 @@ static SymGetModuleBaseType				_SymGetModuleBase = nullptr;
 
 
 /***********************************************************************************************
- * _purecall -- This function overrides the C library Pure Virtual Function Call error         *
- *                                                                                             *
- *                                                                                             *
- *                                                                                             *
- * INPUT:    Nothing                                                                           *
- *                                                                                             *
- * OUTPUT:   0 = no error                                                                      *
- *                                                                                             *
- * WARNINGS: None                                                                              *
- *                                                                                             *
- * HISTORY:                                                                                    *
- *   8/22/00 11:42AM ST : Created                                                              *
- *=============================================================================================*/
-// MSVC 2015+ ships _purecall in vcruntime, so avoid a duplicate definition.
-#if !defined(_MSC_VER) || _MSC_VER < 1900
-int _purecall(void)
-{
-	int return_code = 0;
-
-#ifdef WWDEBUG
-	/*
-	** Use debugbreak to cause an exception.
-	*/
-	WWDEBUG_SAY(("Pure Virtual Function call. Oh No!\n"));
-	debugbreak();
-#endif	//_DEBUG_ASSERT
-
-	return(return_code);
-}
-#endif // _MSC_VER < 1900
-
-
-
-/***********************************************************************************************
  * Last_Error_Text -- Get the system error text for GetLastError                                *
  *                                                                                             *
  *                                                                                             *
@@ -1330,5 +1296,3 @@ bool Is_Trying_To_Exit(void)
 
 
 #endif	//_MSC_VER
-
-

--- a/Code/wwlib/Except.cpp
+++ b/Code/wwlib/Except.cpp
@@ -185,6 +185,8 @@ static SymGetModuleBaseType				_SymGetModuleBase = nullptr;
  * HISTORY:                                                                                    *
  *   8/22/00 11:42AM ST : Created                                                              *
  *=============================================================================================*/
+// MSVC 2015+ ships _purecall in vcruntime, so avoid a duplicate definition.
+#if !defined(_MSC_VER) || _MSC_VER < 1900
 int _purecall(void)
 {
 	int return_code = 0;
@@ -199,6 +201,7 @@ int _purecall(void)
 
 	return(return_code);
 }
+#endif // _MSC_VER < 1900
 
 
 
@@ -1327,7 +1330,5 @@ bool Is_Trying_To_Exit(void)
 
 
 #endif	//_MSC_VER
-
-
 
 

--- a/cmake/dx9.cmake
+++ b/cmake/dx9.cmake
@@ -7,6 +7,11 @@ if(WIN32)
         )
 
         FetchContent_MakeAvailable(dx9)
+        if(MSVC)
+            # The prebuilt legacy DxErr.lib still imports _vsnprintf, which
+            # moved to this compatibility library with the Universal CRT.
+            target_link_libraries(d3d9lib INTERFACE legacy_stdio_definitions)
+        endif()
     else()
         add_library(d3d9lib INTERFACE)
         target_link_libraries(d3d9lib INTERFACE d3d9 d3dx9)
@@ -23,4 +28,3 @@ else()
     target_include_directories(d3d9lib INTERFACE "${PROJECT_SOURCE_DIR}/Code/dxvk_wrapper")
     target_include_directories(d3d9lib INTERFACE "${DXVK_INCLUDE_PATH}/dxvk")
 endif()
-


### PR DESCRIPTION
## Summary

This is a small foundation PR for the upcoming independently tested W3DView and engine changes.

It:

- Enables CTest from the project root.
- Corrects modern CMake compile-definition and dependent-option syntax.
- Avoids defining `_purecall` when it is already supplied by modern MSVC.
- Links the legacy DirectX library against `legacy_stdio_definitions`.

## Motivation

These compatibility issues prevented reliable Visual Studio 2022 builds and registration of the focused regression tests being submitted in follow-up PRs.

Keeping these changes separate provides a clean base for the mempool, audio lifetime, chunk handling, capture API, and Qt W3D Viewer PRs.

## Testing

- Configured successfully with Visual Studio 2022 x64.
- Used as the common base for successful Debug and Release builds of the extracted regression-test targets.
- No engine runtime behavior is changed by this PR.

## Notes

- `include(CTest)` exposes the standard `BUILD_TESTING` option, which can still be disabled explicitly.
- The DirectX compatibility library is linked only for the applicable MSVC build.