### PR TITLE
Move byteswap compat to only file which calls the function.

### DIFF
--- a/Code/wwlib/always.h
+++ b/Code/wwlib/always.h
@@ -104,13 +104,6 @@ void operator delete(void *p, size_t size) noexcept;
 #if !defined(_WIN32)
 #include <alloca.h>
 
-#ifndef _byteswap_ulong
-inline unsigned int _byteswap_ulong(unsigned int value)
-{
-	return __builtin_bswap32(value);
-}
-#endif
-
 #ifndef _alloca
 #define _alloca(size) alloca(size)
 #endif

--- a/Code/wwnet/packetmgr.cpp
+++ b/Code/wwnet/packetmgr.cpp
@@ -52,6 +52,18 @@
 #include "socket_wrapper.h"
 #include <algorithm>
 
+#ifndef _MSC_VER
+#if defined __has_builtin && __has_builtin(__builtin_bswap32)
+#define _byteswap_ulong __builtin_bswap32
+#else
+unsigned int _byteswap_ulong(unsigned int value)
+{
+	return (((value & 0xff000000u) >> 24) | ((value & 0x00ff0000u) >> 8) | ((value & 0x0000ff00u) << 8)
+            | ((value & 0x000000ffu) << 24));
+}
+#endif
+#endif
+
 /*
 ** Single instance of PacketManagerClass.
 */


### PR DESCRIPTION
More cleaning out always.h with a view to removing it and replacing it with more targetted features.