### PR TITLE
Fix x64 object pool alignment

### DIFF
--- a/Code/wwlib/CMakeLists.txt
+++ b/Code/wwlib/CMakeLists.txt
@@ -178,3 +178,21 @@ if(WIN32)
 endif()
 
 target_sources(wwlib PRIVATE ${WWLIB_SRC})
+
+if(BUILD_TESTING)
+    add_executable(wwlib_mempool_tests
+        tests/MempoolTests.cpp
+    )
+
+    target_link_libraries(wwlib_mempool_tests PRIVATE
+        wwlib
+        wwdebug
+        wwcommon
+    )
+
+    target_include_directories(wwlib_mempool_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+    add_test(NAME wwlib_mempool_tests COMMAND wwlib_mempool_tests)
+endif()

--- a/Code/wwlib/mempool.h
+++ b/Code/wwlib/mempool.h
@@ -91,7 +91,7 @@ public:
 protected:
 
 	T	*		FreeListHead;
-	uint32 *	BlockListHead;
+	void *		BlockListHead;
 	int		FreeObjectCount;
 	int		TotalObjectCount;
 	FastCriticalSectionClass ObjectPoolCS;
@@ -211,8 +211,10 @@ ObjectPoolClass<T,BLOCK_SIZE>::~ObjectPoolClass(void)
 	// delete all of the blocks we allocated
 	int block_count = 0;
 	while (BlockListHead != nullptr) {
-		uint32 * next_block = *(uint32 **)BlockListHead;
-		::operator delete(BlockListHead);
+		void * next_block = *(void **)BlockListHead;
+		constexpr size_t block_alignment =
+			alignof(T) > alignof(void *) ? alignof(T) : alignof(void *);
+		::operator delete(BlockListHead, std::align_val_t(block_alignment));
 		BlockListHead = next_block;
 		block_count++;
 	}
@@ -282,18 +284,29 @@ void ObjectPoolClass<T,BLOCK_SIZE>::Free_Object(T * obj)
 template<class T,int BLOCK_SIZE>
 T * ObjectPoolClass<T,BLOCK_SIZE>::Allocate_Object_Memory(void)
 {
+	static_assert(BLOCK_SIZE > 0, "Object pools require a positive block size");
+	static_assert(sizeof(T) >= sizeof(T *),
+		"Object pool slots must be large enough to store a free-list pointer");
+
 	FastCriticalSectionClass::LockClass lock(ObjectPoolCS);
 
 	if ( FreeListHead == 0 ) {
 
 		// No free objects, allocate another block
-		uint32 * tmp_block_head = BlockListHead;
-		BlockListHead = (uint32*)::operator new( sizeof(T) * BLOCK_SIZE + sizeof(uint32 *));
+		void * tmp_block_head = BlockListHead;
+		constexpr size_t block_header_size =
+			(sizeof(void *) + alignof(T) - 1) & ~(alignof(T) - 1);
+		constexpr size_t block_alignment =
+			alignof(T) > alignof(void *) ? alignof(T) : alignof(void *);
+		BlockListHead = ::operator new(
+			sizeof(T) * BLOCK_SIZE + block_header_size,
+			std::align_val_t(block_alignment));
 		// Link this block into the block list
 		*(void **)BlockListHead = tmp_block_head;
 
 		// Link the objects in the block into the free object list
-		FreeListHead = (T*)((uint32**)BlockListHead + 1);
+		FreeListHead = reinterpret_cast<T *>(
+			reinterpret_cast<unsigned char *>(BlockListHead) + block_header_size);
 		for ( int i = 0; i < BLOCK_SIZE; i++ ) {
 			*(T**)(&(FreeListHead[i])) = &(FreeListHead[i+1]);	// link up the elements
 		}

--- a/Code/wwlib/tests/MempoolTests.cpp
+++ b/Code/wwlib/tests/MempoolTests.cpp
@@ -1,0 +1,74 @@
+#include "mempool.h"
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+struct alignas(32) PooledValue
+{
+    std::uintptr_t first = 0;
+    std::uintptr_t second = 0;
+};
+
+struct alignas(32) AutoPooledValue : public AutoPoolClass<AutoPooledValue, 3>
+{
+    std::uintptr_t value = 0;
+};
+
+} // namespace
+
+int main()
+{
+    {
+        ObjectPoolClass<PooledValue, 3> pool;
+        std::vector<PooledValue *> values;
+
+        for (std::uintptr_t index = 0; index < 10; ++index) {
+            PooledValue *value = pool.Allocate_Object();
+            if ((reinterpret_cast<std::uintptr_t>(value) % alignof(PooledValue)) != 0) {
+                std::cerr << "Object pool returned a misaligned value.\n";
+                return 1;
+            }
+            value->first = index;
+            value->second = index + 100;
+            values.push_back(value);
+        }
+
+        for (std::uintptr_t index = 0; index < values.size(); ++index) {
+            if (values[index]->first != index || values[index]->second != index + 100) {
+                std::cerr << "Object pool values overlapped or were corrupted.\n";
+                return 1;
+            }
+        }
+
+        for (PooledValue *value : values) {
+            pool.Free_Object(value);
+        }
+    }
+
+    std::vector<AutoPooledValue *> automatic_values;
+    for (std::uintptr_t index = 0; index < 10; ++index) {
+        AutoPooledValue *value = new AutoPooledValue;
+        if ((reinterpret_cast<std::uintptr_t>(value) % alignof(AutoPooledValue)) != 0) {
+            std::cerr << "Automatic object pool returned a misaligned value.\n";
+            return 1;
+        }
+        value->value = index;
+        automatic_values.push_back(value);
+    }
+
+    for (std::uintptr_t index = 0; index < automatic_values.size(); ++index) {
+        if (automatic_values[index]->value != index) {
+            std::cerr << "Automatic object pool values were corrupted.\n";
+            return 1;
+        }
+    }
+
+    for (AutoPooledValue *value : automatic_values) {
+        delete value;
+    }
+
+    return 0;
+}

--- a/Code/wwlib/tests/MempoolTests.cpp
+++ b/Code/wwlib/tests/MempoolTests.cpp
@@ -1,21 +1,29 @@
 #include "mempool.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <iostream>
 #include <vector>
 
 namespace {
 
-struct alignas(32) PooledValue
+constexpr std::size_t PoolAlignment = 32;
+
+struct alignas(PoolAlignment) PooledValue
 {
     std::uintptr_t first = 0;
     std::uintptr_t second = 0;
+    std::byte padding[PoolAlignment - (2 * sizeof(std::uintptr_t))] = {};
 };
 
-struct alignas(32) AutoPooledValue : public AutoPoolClass<AutoPooledValue, 3>
+struct alignas(PoolAlignment) AutoPooledValue : public AutoPoolClass<AutoPooledValue, 3>
 {
     std::uintptr_t value = 0;
+    std::byte padding[PoolAlignment - sizeof(std::uintptr_t)] = {};
 };
+
+static_assert(sizeof(PooledValue) == PoolAlignment);
+static_assert(sizeof(AutoPooledValue) == PoolAlignment);
 
 } // namespace
 


### PR DESCRIPTION
## Summary

Fixes pointer-size and alignment assumptions in `ObjectPoolClass` for 64-bit builds.

## Problem

The pool’s block layout was based on a 32-bit header calculation. On x64, this could place pooled objects at an incorrectly aligned address, particularly for over-aligned types, resulting in undefined behavior or memory corruption.

The free-list implementation also stores a pointer inside each unused object slot, so pooled types must be large enough to hold a pointer.

## Changes

- Uses pointer-sized block bookkeeping.
- Aligns block allocations for both the bookkeeping header and pooled object type.
- Aligns the first object after the block header.
- Uses matching aligned allocation and deallocation.
- Adds compile-time checks that:
  - The block size is greater than zero.
  - A pooled object is large enough to hold a free-list pointer.
- Adds a focused `wwlib_mempool_tests` target.

## Testing

The new tests exercise both `ObjectPoolClass` and `AutoPoolClass` using a 32-byte-aligned object type.

Coverage includes:

- Address alignment checks.
- Allocation across multiple blocks.
- Stored-value integrity.
- Object reuse and destruction.
- Matching allocation and deallocation paths.

Results with Visual Studio 2022 x64:

- Debug: 1/1 passed.
- Release: 1/1 passed.

## Scope and risk

This changes allocation layout for all `ObjectPoolClass` users, but does not change its public API.

Previously invalid pool configurations, such as an object smaller than a pointer, now fail at compile time instead of potentially corrupting memory at runtime.