### PR TITLE
Replace OutputDebugStringA with printf.

### DIFF
--- a/Code/Combat/debug.cpp
+++ b/Code/Combat/debug.cpp
@@ -213,7 +213,7 @@ void	DebugManager::Display( char const *buffer )
 	}
 
 	if ( EnabledDevices & DEBUG_DEVICE_WINDOWS ) {
-		OutputDebugStringA( buffer );		// puts it in the MSVC debug window
+		fprintf(stderr, "%s",  buffer );		// puts it in the MSVC debug window
 	}
 }
 

--- a/Code/Commando/GameSpy_QnR.cpp
+++ b/Code/Commando/GameSpy_QnR.cpp
@@ -369,7 +369,7 @@ void CGameSpyQnR::basic_callback(char *outbuf, int maxlen)
 #ifdef WWDEBUG
 	StringClass tstr(true);
 	tstr.Format("GS_QnR -- Basic callback, sent: %s\n",outbuf);
-	OutputDebugStringA(tstr.Peek_Buffer());
+	fprintf(stderr, "%s", tstr.Peek_Buffer());
 #endif
 	WWDEBUG_SAY(("<--GS_QnR -- Basic callback\n"));
 
@@ -452,7 +452,7 @@ void CGameSpyQnR::info_callback(char *outbuf, int maxlen)
 #ifdef WWDEBUG
 	StringClass tstr(true);
 	tstr.Format("GS_QnR -- Info callback, sent: %s\n",outbuf);
-	OutputDebugStringA(tstr.Peek_Buffer());
+	fprintf(stderr, "%s", tstr.Peek_Buffer());
 #endif
 	WWDEBUG_SAY(("<--GS_QnR -- Info callback\n"));
 
@@ -555,7 +555,7 @@ void CGameSpyQnR::rules_callback(char *outbuf, int maxlen)
 #ifdef WWDEBUG
 	StringClass tstr(true);
 	tstr.Format("GS_QnR -- Rules callback, sent: %s\n",outbuf);
-	OutputDebugStringA(tstr.Peek_Buffer());
+	fprintf(stderr, "%s", tstr.Peek_Buffer());
 #endif
 	WWDEBUG_SAY(("<--GS_QnR -- Rules callback\n"));
 

--- a/Code/Commando/useroptions.cpp
+++ b/Code/Commando/useroptions.cpp
@@ -152,7 +152,7 @@ cUserOptions::ParseResult cUserOptions::Parse_Command_Line(int argc, char *argv[
 			}
 			strcpy(DefaultRegistryModifier, argval);
 			#ifdef WWDEBUG
-			OutputDebugStringA("Registry modifier on command line\n");
+			fprintf(stderr, "%s", "Registry modifier on command line\n");
 			#endif //WWDEBUG
 			Reread();
 			continue;

--- a/Code/Scripts/DPrint.cpp
+++ b/Code/Scripts/DPrint.cpp
@@ -87,7 +87,7 @@ void DebugPrint(const char* string, ...)
 		else
 			{
 			// Send string to debugger
-			OutputDebugStringA(_buffer);
+			fprintf(stderr, "%s", _buffer);
 			}
 
 #if 0

--- a/Code/ww3d2/intersec.cpp
+++ b/Code/ww3d2/intersec.cpp
@@ -299,9 +299,9 @@ void IntersectionClass::Append_Hierarchy_Objects(
 			obj->Release_Ref();	// you already own a reference to the object indirectly
 			if(obj->Intersect_Sphere_Quick(this, &result)) {
 				Append_Object_Array(MaxCount, CurrentCount, ObjectArray, obj);
-//				OutputDebugStringA("o"); // this shows one o per sphere intersection
+//				fprintf(stderr, "%s", "o"); // this shows one o per sphere intersection
 			} else {
-//				OutputDebugStringA("."); // this shows one . per sphere miss
+//				fprintf(stderr, "%s", "."); // this shows one . per sphere miss
 			}
 		}
 
@@ -317,7 +317,7 @@ void IntersectionClass::Append_Hierarchy_Objects(
 
 bool IntersectionClass::Intersect_Hierarchy(RenderObjClass *Hierarchy, IntersectionResultClass *FinalResult, bool Test_Bounding_Sphere, bool Convex ) {
 
-//	OutputDebugStringA("\n");
+//	fprintf(stderr, "%s", "\n");
 //	return FinalResult->Intersects = false;
 
 	RenderObjClass *candidate_objects[MAX_HIERARCHY_NODE_COUNT];
@@ -327,7 +327,7 @@ bool IntersectionClass::Intersect_Hierarchy(RenderObjClass *Hierarchy, Intersect
 
 	// make sure there's at least one sphere hit before continuing to more expensive tests below..
 	if(candidate_count == 0) {
-	//			OutputDebugStringA("/"); // no sphere intersections
+	//			fprintf(stderr, "%s", "/"); // no sphere intersections
 		return FinalResult->Intersects = false;
 	}
 
@@ -424,7 +424,7 @@ bool IntersectionClass::Intersect_Object_Array(
 	}
 	// test to see if anything actually hit a mesh
 	if( ! hit ) {
-//		OutputDebugStringA("!"); // no mesh intersections
+//		fprintf(stderr, "%s", "!"); // no mesh intersections
 		return FinalResult->Intersects = false;
 	}
 
@@ -440,7 +440,7 @@ bool IntersectionClass::Intersect_Object_Array(
 		}
 		Copy_Results(FinalResult, &TemporaryResults[nearest_index]);
 	}
-//	OutputDebugStringA("+");
+//	fprintf(stderr, "%s", "+");
 //	Debug.Print("Mesh ", Object_Array[nearest_index]);
 //	Intersection_Node = candidate_indices[nearest_index];
 	return true;

--- a/Code/wwlib/ini.cpp
+++ b/Code/wwlib/ini.cpp
@@ -1647,9 +1647,7 @@ bool INIClass::Put_String(char const * section, char const * entry, char const *
       if (strcmp(entryptr->Entry, entry)) {
          DuplicateCRCError("INIClass::Put_String", section, entry);
       } else {
-   		OutputDebugStringA("INIClass::Put_String - Duplicate Entry \"");
-	   	OutputDebugStringA(entry);
-		   OutputDebugStringA("\"\n");
+   	     fprintf(stderr, "INIClass::Put_String - Duplicate Entry \"%s\"\n", entry);
       }
    	secptr->EntryIndex.Remove_Index(entryptr->Index_ID());
 	   delete entryptr;
@@ -2360,7 +2358,7 @@ void INIClass::DuplicateCRCError(const char *message, const char *section, const
 	snprintf(buffer, sizeof(buffer), "%s - Duplicate Entry \"%s\" in section \"%s\" (%s)\n", message,
 		entry, section, Filename);
 
-	OutputDebugStringA(buffer);
+	fprintf(stderr, "%s", buffer);
 	assert(0);
 
 #ifdef NDEBUG


### PR DESCRIPTION
Replaces OutputDebugStringA with printf in otherwise cross platform code.
fixes #149
Not all instances are removed as some are in gated win32 code and some are in heavily win32 dependant code that will need to be removed or rewritten for cross platform builds.