### PR TITLE
Prevent duplicate completed audio releases

### DIFF
--- a/Code/WWAudio/CMakeLists.txt
+++ b/Code/WWAudio/CMakeLists.txt
@@ -109,3 +109,29 @@ if (W3D_TOOLS)
         target_link_libraries(wwaudioe PRIVATE milesstub)
     endif()
 endif()
+
+if(BUILD_TESTING)
+    add_executable(wwaudio_lifetime_tests
+        tests/WWAudioLifetimeTests.cpp
+    )
+
+    target_link_libraries(wwaudio_lifetime_tests PRIVATE
+        wwaudio
+        ww3d2
+        wwdebug
+        wwlib
+        wwmath
+        wwphys
+        wwsaveload
+        wwcommon
+    )
+
+    if(WIN32)
+        target_link_libraries(wwaudio_lifetime_tests PRIVATE
+            version
+            winmm
+        )
+    endif()
+
+    add_test(NAME wwaudio_lifetime_tests COMMAND wwaudio_lifetime_tests)
+endif()

--- a/Code/WWAudio/WWAudio.cpp
+++ b/Code/WWAudio/WWAudio.cpp
@@ -1261,7 +1261,12 @@ WWAudioClass::Remove_From_Playlist (AudibleSoundClass *sound_obj)
 					//
 					// Add this sound to the 'completed' list
 					//
-					m_CompletedSounds.Add (sound_obj);
+					// A sound can be stopped, replayed, and stopped again before
+					// the next frame drains this deferred-release queue. Keep only
+					// one entry so the playlist's single reference is released once.
+					if (m_CompletedSounds.ID (sound_obj) == -1) {
+						m_CompletedSounds.Add (sound_obj);
+					}
 					retval = true;
 				}
 			}

--- a/Code/WWAudio/tests/WWAudioLifetimeTests.cpp
+++ b/Code/WWAudio/tests/WWAudioLifetimeTests.cpp
@@ -1,0 +1,85 @@
+#include "AudibleSound.h"
+#include "WWAudio.h"
+
+#include <iostream>
+
+namespace {
+
+class TestAudioClass final : public WWAudioClass
+{
+public:
+    TestAudioClass()
+        : WWAudioClass(true), _driverName("Lifetime test")
+    {
+    }
+
+    void Initialize(bool = true, int = 16, int = 44100) override {}
+    void Initialize(const char *) override {}
+    void Shutdown() override {}
+    const StringClass &Get_3D_Driver_Name() const override { return _driverName; }
+    DRIVER_TYPE_2D Open_2D_Device(bool, int, int) override { return DRIVER2D_ERROR; }
+    int Get_3D_Device_Count() const override { return 0; }
+    bool Get_3D_Device(int, const char **info) override
+    {
+        if (info) {
+            *info = _driverName.Peek_Buffer();
+        }
+        return false;
+    }
+    bool Select_3D_Device(const char *) override { return false; }
+    void Set_Speaker_Type(int) override {}
+    int Get_Speaker_Type() const override { return W3D_3D_2_SPEAKER; }
+    float Get_Effects_Level() override { return 0.0F; }
+    void Flush_Cache() override {}
+    int Get_2D_Sample_Count() const override { return 0; }
+    int Get_3D_Sample_Count() const override { return 0; }
+    AudibleSoundClass *Peek_2D_Sample(int) override { return nullptr; }
+    AudibleSoundClass *Peek_3D_Sample(int) override { return nullptr; }
+
+    int Completed_Sound_Count() const { return m_CompletedSounds.Count(); }
+
+protected:
+    bool Validate_3D_Sound_Buffer(SoundBufferClass *) override { return false; }
+    SoundHandleClass *Get_2D_Handle(const AudibleSoundClass &, bool) override { return nullptr; }
+    SoundHandleClass *Get_3D_Handle(const Sound3DClass &) override { return nullptr; }
+    SoundBufferClass *Get_Sound_Buffer(const char *, bool) override { return nullptr; }
+
+private:
+    StringClass _driverName;
+};
+
+} // namespace
+
+int main()
+{
+    TestAudioClass audio;
+    AudibleSoundClass *sound = new AudibleSoundClass;
+
+    audio.Add_To_Playlist(sound);
+    if (audio.Get_Playlist_Count() != 1) {
+        std::cerr << "Sound was not added to the playlist exactly once.\n";
+        return 1;
+    }
+
+    if (!audio.Remove_From_Playlist(sound) || !audio.Remove_From_Playlist(sound)) {
+        std::cerr << "Repeated removal did not find the queued sound.\n";
+        return 1;
+    }
+
+    if (audio.Completed_Sound_Count() != 1) {
+        std::cerr << "A sound was queued for deferred release more than once.\n";
+        return 1;
+    }
+
+    // Leave the playlist as the final owner, then drain its single deferred
+    // release. Duplicate completed entries would dereference a freed object.
+    sound->Release_Ref();
+    audio.Free_Completed_Sounds();
+
+    if (audio.Get_Playlist_Count() != 0 || audio.Completed_Sound_Count() != 0) {
+        std::cerr << "Completed-sound cleanup left stale ownership state.\n";
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Title

Prevent duplicate completed audio releases

### Description

## Summary

- Prevents the same sound from being queued more than once in `WWAudioClass::m_CompletedSounds`.
- Adds a backend-independent regression test for deferred sound cleanup.
- Registers the new test with CTest.

## Motivation

A sound can be stopped, replayed, and stopped again before the deferred-release queue is drained. Previously, this could queue the same playlist reference twice. Cleanup would release the sound for the first entry and then potentially dereference the freed object for the duplicate entry.

## Validation

- MSVC x64 Debug: 1/1 passed
- MSVC x64 Release: 1/1 passed
- MSVC x86 Release: 1/1 passed

The test uses a lightweight audio implementation and requires no audio device, OpenAL context, or external assets.

## Scope

This PR only changes WWAudio deferred-release handling and its focused test. It does not modify the OpenAL backend, sound serialization, or W3DViewQt.