### PR TITLE
Replace use of SetCurrentDirectoryA in engine.

### DIFF
--- a/Code/Commando/WINMAIN.CPP
+++ b/Code/Commando/WINMAIN.CPP
@@ -96,6 +96,7 @@
 #include "openw3d.h"
 #include "ini.h"
 #include "soutil.h"
+#include "pathutil.h"
 
 #ifdef _DEBUG
 #include	<crtdbg.h>
@@ -801,12 +802,12 @@ bool Set_Working_Directory(void)
 		_makepath(path_buffer, drive, dir, nullptr, nullptr);
 		gamedir = path_buffer;
 	}
-	return !!SetCurrentDirectoryA(gamedir);
+	return cPathUtil::SetWorkingDirectory(gamedir);
 #elif defined(OPENW3D_SDL3)
 	if (gamedir == nullptr || gamedir[0] == '\0') {
 		gamedir = SDL_GetBasePath();
 	}
-	return !chdir(gamedir);
+	return cPathUtil::SetWorkingDirectory(gamedir);
 #else
 	assert(0);
 #endif

--- a/Code/ww3d2/texturethumbnail.cpp
+++ b/Code/ww3d2/texturethumbnail.cpp
@@ -666,7 +666,7 @@ void ThumbnailManagerClass::Pre_Init(bool display_message_box)
 
 	StringClass cur_dir = cPathUtil::GetWorkingDirectory(true);
 	StringClass new_dir = cur_dir + "Data";
-	SetCurrentDirectoryA(new_dir);
+	cPathUtil::SetWorkingDirectory(new_dir);
 
 	WIN32_FIND_DATAA find_data;
 	HANDLE handle=FindFirstFileA("*.mix",&find_data);
@@ -681,7 +681,7 @@ void ThumbnailManagerClass::Pre_Init(bool display_message_box)
 			}
 		}
 	}
-	SetCurrentDirectoryA(cur_dir);
+	cPathUtil::SetWorkingDirectory(cur_dir);
 
 	// First generate thumbnails for always.dat
 	Update_Thumbnail_File("always.dat",display_message_box);

--- a/Code/wwutil/pathutil.cpp
+++ b/Code/wwutil/pathutil.cpp
@@ -15,6 +15,14 @@ StringClass cPathUtil::GetWorkingDirectory(bool trailing_separator)
 	return StringClass{path.generic_string().c_str()};
 }
 
+bool cPathUtil::SetWorkingDirectory(const StringClass &path)
+{
+	std::error_code ec;
+	std::filesystem::current_path(path.Peek_Buffer(), ec);
+
+	return !ec;
+}
+
 StringClass cPathUtil::ExtractFilename(const char *c_path)
 {
 	std::filesystem::path path = c_path;

--- a/Code/wwutil/pathutil.h
+++ b/Code/wwutil/pathutil.h
@@ -7,6 +7,8 @@ class cPathUtil
 public:
 	static StringClass GetWorkingDirectory(bool trailing_separator=true);
 
+	static bool SetWorkingDirectory(const StringClass &path);
+
 	static StringClass ExtractFilename(const char *path);
 
 	static bool PathExists(const char *path);


### PR DESCRIPTION
Adds a wrapper around filesystem::current_path for setting the working directory to mirror the functionality for getting it.