### PR TITLE
Add back-buffer screenshot API

### DIFF
--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -255,3 +255,21 @@ if (W3D_TOOLS)
 
     target_sources(ww3d2e PRIVATE ${WW3D2_SRC})
 endif()
+
+if(BUILD_TESTING AND WIN32)
+    add_executable(ww3d2_screenshot_api_tests
+        tests/ScreenshotApiTests.cpp
+    )
+
+    target_link_libraries(ww3d2_screenshot_api_tests PRIVATE
+        wwcommon
+        wwdebug
+        wwlib
+        wwmath
+        wwsaveload
+        ww3d2
+        wwaudio
+    )
+
+    add_test(NAME ww3d2_screenshot_api_tests COMMAND ww3d2_screenshot_api_tests)
+endif()

--- a/Code/ww3d2/tests/ScreenshotApiTests.cpp
+++ b/Code/ww3d2/tests/ScreenshotApiTests.cpp
@@ -1,0 +1,123 @@
+/*
+** Command & Conquer Renegade(tm)
+** Copyright 2026 OpenW3D Contributors.
+**
+** This program is free software: you can redistribute it and/or modify
+** it under the terms of the GNU General Public License as published by
+** the Free Software Foundation, either version 3 of the License, or
+** (at your option) any later version.
+**
+** This program is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+** GNU General Public License for more details.
+**
+** You should have received a copy of the GNU General Public License
+** along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ww3d.h"
+
+#include "ffactory.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace
+{
+class RecordingFileFactory final : public FileFactoryClass
+{
+public:
+    explicit RecordingFileFactory(FileFactoryClass *delegate) : Delegate(delegate)
+    {
+    }
+
+    FileClass *Get_File(const char *filename) override
+    {
+        RequestedNames.emplace_back(filename != nullptr ? filename : "");
+        return Delegate->Get_File(filename);
+    }
+
+    void Return_File(FileClass *file) override
+    {
+        ++ReturnedFiles;
+        Delegate->Return_File(file);
+    }
+
+    std::vector<std::string> RequestedNames;
+    int ReturnedFiles = 0;
+
+private:
+    FileFactoryClass *Delegate;
+};
+
+class ScopedFileFactoryOverride final
+{
+public:
+    explicit ScopedFileFactoryOverride(FileFactoryClass *replacement) : Previous(_TheFileFactory)
+    {
+        _TheFileFactory = replacement;
+    }
+
+    ~ScopedFileFactoryOverride()
+    {
+        _TheFileFactory = Previous;
+    }
+
+private:
+    FileFactoryClass *Previous;
+};
+}
+
+int main()
+{
+    if (_TheFileFactory == nullptr) {
+        return 1;
+    }
+
+    RecordingFileFactory file_factory(_TheFileFactory);
+    ScopedFileFactoryOverride override_file_factory(&file_factory);
+
+    if (WW3D::Make_Back_Buffer_Screen_Shot(nullptr) != 0 ||
+        WW3D::Make_Back_Buffer_Screen_Shot("") != 0 ||
+        !file_factory.RequestedNames.empty()) {
+        return 2;
+    }
+
+    const std::string filename_base =
+        (std::filesystem::temp_directory_path() /
+         ("OpenW3DScreenshotApiTest" +
+          std::to_string(reinterpret_cast<std::uintptr_t>(&file_factory)))).string();
+    const std::string first_filename = filename_base + "01.tga";
+    const std::string second_filename = filename_base + "02.tga";
+
+    std::error_code ignored_error;
+    std::filesystem::remove(first_filename, ignored_error);
+    std::filesystem::remove(second_filename, ignored_error);
+    {
+        std::ofstream existing_screenshot(first_filename, std::ios::binary);
+        if (!existing_screenshot) {
+            return 3;
+        }
+        existing_screenshot.put('\0');
+    }
+
+    // No D3D device is initialized in this test, so capture must fail cleanly after
+    // skipping the existing 01 file and choosing the available 02 filename.
+    const int capture_result = WW3D::Make_Back_Buffer_Screen_Shot(filename_base.c_str());
+    const bool filename_selection_passed =
+        capture_result == 0 &&
+        file_factory.RequestedNames.size() == 2 &&
+        file_factory.RequestedNames[0] == first_filename &&
+        file_factory.RequestedNames[1] == second_filename &&
+        file_factory.ReturnedFiles == 2;
+
+    std::filesystem::remove(first_filename, ignored_error);
+    std::filesystem::remove(second_filename, ignored_error);
+
+    return filename_selection_passed ? 0 : 4;
+}

--- a/Code/ww3d2/ww3d.cpp
+++ b/Code/ww3d2/ww3d.cpp
@@ -97,6 +97,7 @@
 #include "statistics.h"
 #include "pointgr.h"
 #include "ffactory.h"
+#include "wwstring.h"
 #include "ini.h"
 #include "dazzle.h"
 #include "meshmdl.h"
@@ -106,6 +107,9 @@
 #include "rddesc.h"
 #include "vector3i.h"
 #include <cstdio>
+#ifdef _WIN32
+#include <d3dx9tex.h>
+#endif
 #include "dx8wrapper.h"
 #include "TARGA.H"
 #include "sortingrenderer.h"
@@ -1238,6 +1242,35 @@ void WW3D::Normalize_Coordinates(int x, int y, float &fx, float &fy)
 }
 
 
+namespace
+{
+int Make_Back_Buffer_Screen_Shot_Filename(const char *filename_base, StringClass &filename)
+{
+	if (filename_base == nullptr || filename_base[0] == '\0' || _TheFileFactory == nullptr) {
+		return 0;
+	}
+
+	static int frame_number = 1;
+	int screenshot_number = 0;
+	bool done = false;
+	while (!done) {
+		screenshot_number = frame_number++;
+		filename.Format("%s%.2d.tga", filename_base, screenshot_number);
+		FileClass *file = _TheFileFactory->Get_File(filename.Peek_Buffer());
+		if (file != nullptr) {
+			file->Open();
+			done = !file->Is_Available();
+			_TheFileFactory->Return_File(file);
+		} else {
+			done = true;
+		}
+	}
+
+	return screenshot_number;
+}
+}
+
+
 /***********************************************************************************************
  * WW3D::Make_Screen_Shot -- saves a screenshot with the given base filename                   *
  *                                                                                             *
@@ -1333,6 +1366,44 @@ void WW3D::Make_Screen_Shot( const char * filename_base )
 
 	delete [] image;
 
+}
+
+
+/***********************************************************************************************
+ * WW3D::Make_Back_Buffer_Screen_Shot -- saves the current render-device back buffer            *
+ *=============================================================================================*/
+int WW3D::Make_Back_Buffer_Screen_Shot( const char * filename_base )
+{
+	WWASSERT(!IsRendering);
+
+#ifdef _WIN32
+	StringClass filename;
+	const int screenshot_number = Make_Back_Buffer_Screen_Shot_Filename(filename_base, filename);
+	if (screenshot_number == 0) {
+		return 0;
+	}
+
+	WWDEBUG_SAY(( "Creating Back Buffer Screen Shot %s\n", filename.Peek_Buffer() ));
+
+	IDirect3DDevice9 *device = DX8Wrapper::_Get_D3D_Device8();
+	if (device == nullptr) {
+		return 0;
+	}
+
+	IDirect3DSurface9 *back_buffer = nullptr;
+	if (FAILED(device->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &back_buffer)) ||
+		back_buffer == nullptr) {
+		return 0;
+	}
+
+	const HRESULT save_result = D3DXSaveSurfaceToFileA(
+		filename.Peek_Buffer(), D3DXIFF_TGA, back_buffer, nullptr, nullptr);
+	back_buffer->Release();
+	return SUCCEEDED(save_result) ? screenshot_number : 0;
+#else
+	(void)filename_base;
+	return 0;
+#endif
 }
 
 

--- a/Code/ww3d2/ww3d.h
+++ b/Code/ww3d2/ww3d.h
@@ -173,6 +173,7 @@ public:
 	** These functions allow you to create screenshots and movies.
 	*/
 	static void					Make_Screen_Shot( const char * filename = "ScreenShot");
+	static int					Make_Back_Buffer_Screen_Shot( const char * filename = "ScreenShot");
 	static void					Start_Movie_Capture( const char * filename_base = "Movie", float frame_rate = 15);
 	static void					Stop_Movie_Capture( void);
 	static void					Toggle_Movie_Capture( const char * filename_base = "Movie", float frame_rate = 15);


### PR DESCRIPTION

## Summary

Adds a new `WW3D::Make_Back_Buffer_Screen_Shot()` API for saving the current Direct3D back buffer as a TGA image.

The existing front-buffer screenshot API remains unchanged.

## Motivation

W3DViewQt needs to capture the frame it has just rendered before that frame is presented. The legacy screenshot function reads the front buffer and relies on window-screen coordinates, which is unsuitable for this workflow.

Capturing the back buffer directly provides the viewer with the rendered frame without desktop or window-position dependencies.

## Changes

- Adds `WW3D::Make_Back_Buffer_Screen_Shot()`.
- Saves the Direct3D back buffer through `D3DXSaveSurfaceToFileA`.
- Selects the first unused numbered filename, such as:
  - `ScreenShot01.tga`
  - `ScreenShot02.tga`
- Returns the selected positive sequence number on success.
- Returns `0` for invalid input, unavailable devices, capture failures, and unsupported platforms.
- Preserves the existing `WW3D::Make_Screen_Shot()` behavior.
- Adds focused behavioral coverage for:
  - Null and empty filename guards.
  - Avoiding file-factory access for invalid input.
  - Skipping an existing numbered screenshot.
  - Selecting the next available filename.
  - Returning borrowed file objects correctly.
  - Failing cleanly without an initialized D3D device.

## API and ABI impact

The change adds one static method and no data members or virtual functions. It does not alter object sizes, layouts, or vtables.

## Validation

- The focused test  passed with Visual Studio 2022 x64 in Debug and Release.

## Scope

This PR only adds the reusable back-buffer screenshot API and its focused guard/filename behavior test. W3DViewQt integration will follow separately.