### PR TITLE
Track chunk writer errors

### DIFF
--- a/Code/wwlib/CMakeLists.txt
+++ b/Code/wwlib/CMakeLists.txt
@@ -195,4 +195,20 @@ if(BUILD_TESTING)
     )
 
     add_test(NAME wwlib_mempool_tests COMMAND wwlib_mempool_tests)
+
+    add_executable(wwlib_chunkio_tests
+        tests/ChunkIOTests.cpp
+    )
+
+    target_link_libraries(wwlib_chunkio_tests PRIVATE
+        wwlib
+        wwdebug
+        wwcommon
+    )
+
+    target_include_directories(wwlib_chunkio_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
+    add_test(NAME wwlib_chunkio_tests COMMAND wwlib_chunkio_tests)
 endif()

--- a/Code/wwlib/chunkio.cpp
+++ b/Code/wwlib/chunkio.cpp
@@ -87,7 +87,8 @@ ChunkSaveClass::ChunkSaveClass(FileClass * file) :
 	File(file),
 	StackIndex(0),
 	InMicroChunk(false),
-	MicroChunkPosition(0)
+	MicroChunkPosition(0),
+	WriteError(false)
 {
 	memset(PositionStack,0,sizeof(PositionStack));
 	memset(HeaderStack,0,sizeof(HeaderStack));
@@ -123,6 +124,9 @@ bool ChunkSaveClass::Begin_Chunk(uint32 id)
 	chunkh.Set_Type(id);
 	chunkh.Set_Size(0);
 	filepos = File->Seek(0);
+	if (filepos < 0) {
+		WriteError = true;
+	}
 
 	PositionStack[StackIndex] = filepos;
 	HeaderStack[StackIndex] = chunkh;
@@ -130,6 +134,7 @@ bool ChunkSaveClass::Begin_Chunk(uint32 id)
 
 	// write a temporary chunk header (size = 0)
 	if (File->Write(&chunkh,sizeof(chunkh)) != sizeof(chunkh)) {
+		WriteError = true;
 		return false;
 	}
 	return true;
@@ -155,6 +160,9 @@ bool ChunkSaveClass::End_Chunk(void)
 
 	// Save the current position
 	int curpos = File->Seek(0);
+	if (curpos < 0) {
+		WriteError = true;
+	}
 
 	// Pop the position and chunk header off the stacks
 	StackIndex--;
@@ -162,8 +170,11 @@ bool ChunkSaveClass::End_Chunk(void)
 	ChunkHeader chunkh = HeaderStack[StackIndex];
 
 	// write the completed header
-	File->Seek(chunkpos,SEEK_SET);
+	if (File->Seek(chunkpos,SEEK_SET) != chunkpos) {
+		WriteError = true;
+	}
 	if (File->Write(&chunkh,sizeof(chunkh)) != sizeof(chunkh)) {
+		WriteError = true;
 		return false;
 	}
 
@@ -173,7 +184,9 @@ bool ChunkSaveClass::End_Chunk(void)
 	}
 
 	// Go back to the end of the file
-	File->Seek(curpos,SEEK_SET);
+	if (File->Seek(curpos,SEEK_SET) != curpos) {
+		WriteError = true;
+	}
 
 	return true;
 }
@@ -207,6 +220,9 @@ bool ChunkSaveClass::Begin_Micro_Chunk(uint32 id)
 	MCHeader.Set_Type(uint8(id));
 	MCHeader.Set_Size(0);
 	MicroChunkPosition = File->Seek(0);
+	if (MicroChunkPosition < 0) {
+		WriteError = true;
+	}
 
 	// Write a temporary chunk header
 	// NOTE: I'm calling the ChunkSaveClass::Write method so that the bytes for
@@ -239,15 +255,23 @@ bool ChunkSaveClass::End_Micro_Chunk(void)
 
 	// Save the current position
 	int curpos = File->Seek(0);
+	if (curpos < 0) {
+		WriteError = true;
+	}
 
 	// Seek back and write the micro chunk header
-	File->Seek(MicroChunkPosition,SEEK_SET);
+	if (File->Seek(MicroChunkPosition,SEEK_SET) != MicroChunkPosition) {
+		WriteError = true;
+	}
 	if (File->Write(&MCHeader,sizeof(MCHeader)) != sizeof(MCHeader)) {
+		WriteError = true;
 		return false;
 	}
 
 	// Go back to the end of the file
-	File->Seek(curpos,SEEK_SET);
+	if (File->Seek(curpos,SEEK_SET) != curpos) {
+		WriteError = true;
+	}
 	InMicroChunk = false;
 	return true;
 }
@@ -281,7 +305,10 @@ uint32 ChunkSaveClass::Write(const void * buf, size_t nbytes)
 	const int nbytes_int = static_cast<int>(clamped_to_int);
 
 	// write the bytes into the file
-	if (File->Write(buf, nbytes_int) != nbytes_int) return 0;
+	if (File->Write(buf, nbytes_int) != nbytes_int) {
+		WriteError = true;
+		return 0;
+	}
 
 	// track them in the wrapping chunk
 	HeaderStack[StackIndex - 1].Add_Size(nbytes32);
@@ -864,4 +891,3 @@ uint32 ChunkLoadClass::Read(IOQuaternionStruct * q)
 	assert(q != nullptr);
 	return Read(q,sizeof(*q));
 }
-

--- a/Code/wwlib/chunkio.h
+++ b/Code/wwlib/chunkio.h
@@ -168,6 +168,7 @@ public:
 	uint32				Write(const IOVector3Struct & v);
 	uint32				Write(const IOVector4Struct & v);
 	uint32				Write(const IOQuaternionStruct & q);
+	bool					Has_Write_Error() const { return WriteError; }
 
 private:
 
@@ -184,6 +185,7 @@ private:
 	bool					InMicroChunk;
 	int					MicroChunkPosition;
 	MicroChunkHeader	MCHeader;
+	bool					WriteError;
 };
 
 

--- a/Code/wwlib/tests/ChunkIOTests.cpp
+++ b/Code/wwlib/tests/ChunkIOTests.cpp
@@ -1,0 +1,223 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2026 OpenW3D Contributors.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "chunkio.h"
+#include "ramfile.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <optional>
+#include <vector>
+
+namespace
+{
+class FaultInjectRAMFileClass final : public RAMFileClass
+{
+public:
+	FaultInjectRAMFileClass(void *buffer, int size) :
+		RAMFileClass(buffer, size)
+	{
+		Open(WRITE);
+	}
+
+	int Seek(int offset, int direction = SEEK_CUR) override
+	{
+		++SeekCallCount;
+		if (FailSeekCall && (*FailSeekCall == SeekCallCount)) {
+			FailSeekCall.reset();
+			++FailedSeekCount;
+			return -1;
+		}
+		return RAMFileClass::Seek(offset, direction);
+	}
+
+	int Write(void const *buffer, int size) override
+	{
+		++WriteCallCount;
+		if (FailWriteCall && (*FailWriteCall == WriteCallCount)) {
+			FailWriteCall.reset();
+			++ShortWriteCount;
+			return RAMFileClass::Write(buffer, (size > 0) ? size - 1 : 0);
+		}
+		return RAMFileClass::Write(buffer, size);
+	}
+
+	void Fail_Next_Write()
+	{
+		FailWriteCall = WriteCallCount + 1;
+	}
+
+	void Fail_Seek_On_Call(size_t call)
+	{
+		FailSeekCall = call;
+	}
+
+	size_t Get_Seek_Call_Count() const
+	{
+		return SeekCallCount;
+	}
+
+	size_t Get_Short_Write_Count() const
+	{
+		return ShortWriteCount;
+	}
+
+	size_t Get_Failed_Seek_Count() const
+	{
+		return FailedSeekCount;
+	}
+
+private:
+	size_t WriteCallCount = 0;
+	size_t SeekCallCount = 0;
+	size_t ShortWriteCount = 0;
+	size_t FailedSeekCount = 0;
+	std::optional<size_t> FailWriteCall;
+	std::optional<size_t> FailSeekCall;
+};
+
+#define CHECK(expression) if (!(expression)) { std::puts("check failed: " #expression); return false; }
+
+bool Test_Golden_Nested_And_Micro_Chunks()
+{
+	std::array<std::uint8_t, 256> buffer{};
+	FaultInjectRAMFileClass file(buffer.data(), static_cast<int>(buffer.size()));
+	ChunkSaveClass save(&file);
+
+	CHECK(!save.Has_Write_Error());
+	CHECK(save.Begin_Chunk(0x11223344));
+	CHECK(save.Begin_Chunk(0x55667788));
+
+	const uint16 micro_value = 0xBEEF;
+	WRITE_MICRO_CHUNK(save, 0xAB, micro_value);
+
+	CHECK(save.End_Chunk());
+	CHECK(save.End_Chunk());
+	CHECK(save.Cur_Chunk_Depth() == 0);
+	CHECK(!save.Has_Write_Error());
+
+	const std::vector<std::uint8_t> actual(buffer.begin(), buffer.begin() + file.Size());
+	const std::vector<std::uint8_t> expected = {
+		0x44, 0x33, 0x22, 0x11,
+		0x0C, 0x00, 0x00, 0x80,
+		0x88, 0x77, 0x66, 0x55,
+		0x04, 0x00, 0x00, 0x00,
+		0xAB, 0x02, 0xEF, 0xBE,
+	};
+	CHECK(actual == expected);
+	return true;
+}
+
+bool Test_Short_Payload_Write_Remains_Sticky_After_Close()
+{
+	std::array<std::uint8_t, 256> buffer{};
+	FaultInjectRAMFileClass file(buffer.data(), static_cast<int>(buffer.size()));
+	ChunkSaveClass save(&file);
+
+	CHECK(save.Begin_Chunk(0x01020304));
+	const uint32 payload = 0xAABBCCDD;
+	file.Fail_Next_Write();
+	CHECK(save.Write(&payload, sizeof(payload)) == 0);
+	CHECK(file.Get_Short_Write_Count() == 1);
+	CHECK(save.Has_Write_Error());
+
+	// The legacy local result stays true because this header rewrite succeeds.
+	CHECK(save.End_Chunk());
+	CHECK(save.Cur_Chunk_Depth() == 0);
+	CHECK(save.Has_Write_Error());
+	return true;
+}
+
+bool Test_Begin_Header_Failure_Is_Sticky()
+{
+	std::array<std::uint8_t, 256> buffer{};
+	FaultInjectRAMFileClass file(buffer.data(), static_cast<int>(buffer.size()));
+	ChunkSaveClass save(&file);
+
+	file.Fail_Next_Write();
+	CHECK(!save.Begin_Chunk(0x01020304));
+	CHECK(file.Get_Short_Write_Count() == 1);
+	CHECK(save.Has_Write_Error());
+
+	// Preserve upstream behavior: Begin pushes before the placeholder write.
+	CHECK(save.Cur_Chunk_Depth() == 1);
+	return true;
+}
+
+bool Test_End_Header_Rewrite_Failure_Is_Sticky()
+{
+	std::array<std::uint8_t, 256> buffer{};
+	FaultInjectRAMFileClass file(buffer.data(), static_cast<int>(buffer.size()));
+	ChunkSaveClass save(&file);
+
+	CHECK(save.Begin_Chunk(0x01020304));
+	file.Fail_Next_Write();
+	CHECK(!save.End_Chunk());
+	CHECK(file.Get_Short_Write_Count() == 1);
+	CHECK(save.Has_Write_Error());
+
+	// Preserve upstream behavior: End pops before rewriting the header.
+	CHECK(save.Cur_Chunk_Depth() == 0);
+	return true;
+}
+
+bool Test_Seek_Failure_Is_Sticky_Without_Changing_End_Result()
+{
+	std::array<std::uint8_t, 256> buffer{};
+	FaultInjectRAMFileClass file(buffer.data(), static_cast<int>(buffer.size()));
+	ChunkSaveClass save(&file);
+
+	CHECK(save.Begin_Chunk(0x01020304));
+
+	// End first queries the current position, then seeks to the header.
+	file.Fail_Seek_On_Call(file.Get_Seek_Call_Count() + 2);
+	CHECK(save.End_Chunk());
+	CHECK(file.Get_Failed_Seek_Count() == 1);
+	CHECK(save.Cur_Chunk_Depth() == 0);
+	CHECK(save.Has_Write_Error());
+	return true;
+}
+
+struct TestCase
+{
+	const char *Name;
+	bool (*Run)();
+};
+}
+
+int main()
+{
+	const TestCase tests[] = {
+		{"golden nested and micro chunks", Test_Golden_Nested_And_Micro_Chunks},
+		{"short payload remains sticky", Test_Short_Payload_Write_Remains_Sticky_After_Close},
+		{"begin header failure", Test_Begin_Header_Failure_Is_Sticky},
+		{"end header rewrite failure", Test_End_Header_Rewrite_Failure_Is_Sticky},
+		{"seek failure", Test_Seek_Failure_Is_Sticky_Without_Changing_End_Result},
+	};
+
+	for (const TestCase &test : tests) {
+		if (!test.Run()) {
+			std::puts("FAILED");
+			std::puts(test.Name);
+			return 1;
+		}
+		std::puts(test.Name);
+	}
+	return 0;
+}


### PR DESCRIPTION
### Summary

This PR adds persistent write-error tracking to `ChunkSaveClass`.

`Has_Write_Error()` lets callers determine whether any seek or write operation failed during the complete chunk-writing process. The status is sticky, so an earlier failure remains visible even if a later operation such as `End_Chunk()` succeeds.

### Changes

- Add `ChunkSaveClass::Has_Write_Error()`.
- Track failed seeks, short writes, and failed header writes.
- Cover regular chunks, micro-chunks, and payload writes.
- Preserve existing method return values and control flow.
- Add fault-injection tests for:
  - Valid nested and micro-chunk serialization.
  - Short payload writes.
  - Initial header-write failures.
  - Completed-header rewrite failures.
  - Seek failures.
  - Sticky error-state behavior.

### Compatibility

This does not change the W3D chunk format or the generated bytes for successful writes. It only exposes failures that the legacy API could otherwise lose after a later successful operation.

### Testing

- MSVC x64 build and tests passed.
- MSVC x86 build passed with `/W4 /WX`.
- All new Chunk I/O tests passed on both architectures.