### PR TITLE
Initialize emitter keyframe headers

### DIFF
--- a/Code/ww3d2/CMakeLists.txt
+++ b/Code/ww3d2/CMakeLists.txt
@@ -272,4 +272,21 @@ if(BUILD_TESTING AND WIN32)
     )
 
     add_test(NAME ww3d2_screenshot_api_tests COMMAND ww3d2_screenshot_api_tests)
+
+    add_executable(ww3d2_emitter_serialization_tests
+        tests/EmitterSerializationTests.cpp
+    )
+
+    target_link_libraries(ww3d2_emitter_serialization_tests PRIVATE
+        wwcommon
+        wwdebug
+        wwlib
+        wwmath
+        wwsaveload
+        ww3d2
+        wwaudio
+    )
+
+    add_test(NAME ww3d2_emitter_serialization_tests
+        COMMAND ww3d2_emitter_serialization_tests)
 endif()

--- a/Code/ww3d2/part_ldr.cpp
+++ b/Code/ww3d2/part_ldr.cpp
@@ -1510,7 +1510,7 @@ ParticleEmitterDefClass::Save_Rotation_Keyframes (ChunkSaveClass & chunk_save)
 	if (chunk_save.Begin_Chunk (W3D_CHUNK_EMITTER_ROTATION_KEYFRAMES) == true) {
 
 		// Write the header
-		W3dEmitterRotationHeaderStruct header;
+		W3dEmitterRotationHeaderStruct header = {};
 		header.KeyframeCount = m_RotationKeyframes.NumKeyFrames;
 		header.Random = m_RotationKeyframes.Rand;
 		header.OrientationRandom = m_InitialOrientationRandom;
@@ -1559,7 +1559,7 @@ ParticleEmitterDefClass::Save_Frame_Keyframes (ChunkSaveClass & chunk_save)
 	if (chunk_save.Begin_Chunk (W3D_CHUNK_EMITTER_FRAME_KEYFRAMES) == true) {
 
 		// Write the header
-		W3dEmitterFrameHeaderStruct header;
+		W3dEmitterFrameHeaderStruct header = {};
 		header.KeyframeCount = m_FrameKeyframes.NumKeyFrames;
 		header.Random = m_FrameKeyframes.Rand;
 		chunk_save.Write (&header, sizeof (W3dEmitterFrameHeaderStruct));
@@ -1606,7 +1606,7 @@ ParticleEmitterDefClass::Save_Blur_Time_Keyframes (ChunkSaveClass & chunk_save)
 	if (chunk_save.Begin_Chunk (W3D_CHUNK_EMITTER_BLUR_TIME_KEYFRAMES) == true) {
 
 		// Write the header
-		W3dEmitterBlurTimeHeaderStruct header;
+		W3dEmitterBlurTimeHeaderStruct header = {};
 		header.KeyframeCount = m_BlurTimeKeyframes.NumKeyFrames;
 		header.Random = m_BlurTimeKeyframes.Rand;
 		chunk_save.Write (&header, sizeof (W3dEmitterBlurTimeHeaderStruct));

--- a/Code/ww3d2/tests/EmitterSerializationTests.cpp
+++ b/Code/ww3d2/tests/EmitterSerializationTests.cpp
@@ -1,0 +1,122 @@
+/*
+**	Command & Conquer Renegade(tm)
+**	Copyright 2026 OpenW3D Contributors.
+**
+**	This program is free software: you can redistribute it and/or modify
+**	it under the terms of the GNU General Public License as published by
+**	the Free Software Foundation, either version 3 of the License, or
+**	(at your option) any later version.
+**
+**	This program is distributed in the hope that it will be useful,
+**	but WITHOUT ANY WARRANTY; without even the implied warranty of
+**	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+**	GNU General Public License for more details.
+**
+**	You should have received a copy of the GNU General Public License
+**	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "part_ldr.h"
+
+#include "chunkio.h"
+#include "ramfile.h"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <iostream>
+
+namespace
+{
+class TestEmitterDef : public ParticleEmitterDefClass
+{
+public:
+	using ParticleEmitterDefClass::Save_Blur_Time_Keyframes;
+	using ParticleEmitterDefClass::Save_Frame_Keyframes;
+	using ParticleEmitterDefClass::Save_Rotation_Keyframes;
+};
+
+#if defined(_MSC_VER)
+#define W3D_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#define W3D_NOINLINE __attribute__((noinline))
+#else
+#define W3D_NOINLINE
+#endif
+
+W3D_NOINLINE void PoisonStack(unsigned char value)
+{
+	volatile unsigned char bytes[4096];
+	for (std::size_t index = 0; index < sizeof(bytes); ++index) {
+		bytes[index] = value;
+	}
+}
+
+#undef W3D_NOINLINE
+
+bool Expect(bool condition, const char *message)
+{
+	if (!condition) {
+		std::cerr << message << '\n';
+	}
+	return condition;
+}
+}
+
+int main()
+{
+	std::array<unsigned char, 128> storage{};
+	RAMFileClass file(storage.data(), static_cast<int>(storage.size()));
+	if (!Expect(file.Open(FileClass::WRITE), "Could not open the RAM file for writing")) {
+		return 1;
+	}
+
+	ChunkSaveClass chunkSave(&file);
+	TestEmitterDef emitter;
+
+	PoisonStack(0xa5);
+	bool passed = Expect(
+		emitter.Save_Rotation_Keyframes(chunkSave) == WW3D_ERROR_OK,
+		"Rotation keyframe serialization failed");
+	PoisonStack(0x5a);
+	passed &= Expect(
+		emitter.Save_Frame_Keyframes(chunkSave) == WW3D_ERROR_OK,
+		"Frame keyframe serialization failed");
+	PoisonStack(0x3c);
+	passed &= Expect(
+		emitter.Save_Blur_Time_Keyframes(chunkSave) == WW3D_ERROR_OK,
+		"Blur-time keyframe serialization failed");
+	passed &= Expect(chunkSave.Cur_Chunk_Depth() == 0,
+		"Emitter keyframe serializers left a chunk open");
+
+	constexpr std::size_t ExpectedSize = 92;
+	std::array<unsigned char, ExpectedSize> expected{};
+	expected[0] = 0x0a;
+	expected[1] = 0x05;
+	expected[4] = 0x18;
+	expected[32] = 0x0b;
+	expected[33] = 0x05;
+	expected[36] = 0x18;
+	expected[64] = 0x0c;
+	expected[65] = 0x05;
+	expected[68] = 0x14;
+
+	passed &= Expect(file.Size() == static_cast<int>(expected.size()),
+		"Emitter keyframe serialization wrote an unexpected byte count");
+	file.Close();
+
+	const auto mismatch = std::mismatch(
+		expected.begin(), expected.end(), storage.begin());
+	if (mismatch.first != expected.end()) {
+		const std::size_t offset =
+			static_cast<std::size_t>(mismatch.first - expected.begin());
+		std::cerr << "Emitter keyframe golden mismatch at offset " << offset
+			<< ": expected 0x" << std::hex
+			<< static_cast<unsigned int>(*mismatch.first)
+			<< ", got 0x" << static_cast<unsigned int>(*mismatch.second)
+			<< std::dec << '\n';
+		passed = false;
+	}
+
+	return passed ? 0 : 1;
+}


### PR DESCRIPTION
### Summary

This PR initializes particle-emitter keyframe header structures before serializing them.

The rotation, frame, and blur-time headers contain reserved fields that were previously left uninitialized and written directly into W3D files. This could produce nondeterministic output containing unrelated stack bytes.

### Changes

- Zero-initialize `W3dEmitterRotationHeaderStruct`.
- Zero-initialize `W3dEmitterFrameHeaderStruct`.
- Zero-initialize `W3dEmitterBlurTimeHeaderStruct`.
- Add a golden serialization regression test.
- Register the new test with CMake.

### Compatibility

This does not change the W3D chunk layout or any populated fields. It ensures reserved header fields are consistently written as zero.

### Testing

The regression test poisons the stack before each serializer runs, then verifies:

- Rotation, frame, and blur-time serialization succeeds.
- All chunks are properly closed.
- The output has the expected size.
- The complete serialized byte stream matches deterministic golden data.

MSVC x64 and strict MSVC x86 `/W4 /WX` builds and tests passed.